### PR TITLE
Test: verify CI catches type errors

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -99,3 +99,11 @@ export function loadConfig(dir: string): WmdevConfig {
 export function expandTemplate(template: string, env: Record<string, string>): string {
   return template.replace(/\$\{(\w+)\}/g, (_, key: string) => env[key] ?? "");
 }
+
+// deliberate type error for CI testing
+const brokenConfig: WmdevConfig = {
+  services: "not an array",
+  profiles: { default: { name: "default" } },
+  autoName: false,
+  linkedRepos: [],
+};


### PR DESCRIPTION
## Summary
- Adds a deliberate type error (`string` assigned to `ServiceConfig[]`) in `backend/src/config.ts`
- This PR exists solely to verify the type check CI workflow catches failures

## Expected result
CI should **fail** on the "Backend type check" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)