### PR TITLE
Fix agent status not showing from backend

### DIFF
--- a/backend/src/workmux.ts
+++ b/backend/src/workmux.ts
@@ -45,8 +45,16 @@ function parseTable<T>(output: string, mapper: (cols: string[]) => T): T[] {
   });
 }
 
+/** Build env with TMUX set so workmux can resolve agent states outside tmux. */
+function workmuxEnv(): Record<string, string | undefined> {
+  if (process.env.TMUX) return process.env;
+  const tmpdir = process.env.TMUX_TMPDIR || "/tmp";
+  const uid = process.getuid?.() ?? 1000;
+  return { ...process.env, TMUX: `${tmpdir}/tmux-${uid}/default,0,0` };
+}
+
 export async function listWorktrees(): Promise<Worktree[]> {
-  const result = await $`workmux list`.text();
+  const result = await $`workmux list`.env(workmuxEnv()).text();
   return parseTable(result, (cols) => ({
     branch: cols[0] ?? "",
     agent: cols[1] ?? "",
@@ -57,7 +65,7 @@ export async function listWorktrees(): Promise<Worktree[]> {
 }
 
 export async function getStatus(): Promise<WorktreeStatus[]> {
-  const result = await $`workmux status`.text();
+  const result = await $`workmux status`.env(workmuxEnv()).text();
   return parseTable(result, (cols) => ({
     worktree: cols[0] ?? "",
     status: cols[1] ?? "",


### PR DESCRIPTION
## Summary
- Backend runs outside tmux so `$TMUX` is unset, causing `workmux list`/`status` to resolve the instance ID as `"default"` instead of the actual socket path (e.g. `/tmp/tmux-1000/default`)
- This mismatches stored agent state files, so agents are filtered out during reconciliation — AGENT column shows `-` in the dashboard
- Added `workmuxEnv()` helper that synthesizes the correct `TMUX` env var when running outside tmux, mirroring tmux's own socket resolution

## Test plan
- [ ] Set agent status from inside a worktree tmux pane: `workmux set-window-status working`
- [ ] Call API from outside tmux: `curl http://localhost:5111/api/worktrees | jq '.[].agent'`
- [ ] Confirm agent field shows `working` instead of `-` or empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)