### PR TITLE
Test CI failure detection

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -54,3 +54,6 @@ export interface AppConfig {
   };
   autoName: boolean;
 }
+
+// Deliberate type error to test CI failure detection
+const _testCiFail: string = 42;


### PR DESCRIPTION
## Summary
- Adds a deliberate type error (`const _testCiFail: string = 42`) to test CI failure detection in the dashboard

## Test plan
- [ ] Verify the Type Check CI workflow fails on this PR
- [ ] Confirm the dashboard correctly surfaces the failure status

🤖 Generated with [Claude Code](https://claude.com/claude-code)