### PR TITLE
Harden docker.ts: security, correctness, and lifecycle fixes

### DIFF
--- a/backend/src/__tests__/docker.test.ts
+++ b/backend/src/__tests__/docker.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "bun:test";
+import { buildDockerRunArgs, type LaunchContainerOpts } from "../docker";
+
+const HOME = "/home/testuser";
+
+/** Minimal valid opts; individual tests override what they need. */
+function makeOpts(overrides: Partial<LaunchContainerOpts> = {}): LaunchContainerOpts {
+  return {
+    branch: "my-branch",
+    wtDir: "/repos/my-branch",
+    mainRepoDir: "/repos/main",
+    sandboxConfig: { name: "sandbox", image: "my-image:latest" },
+    services: [],
+    env: {},
+    ...overrides,
+  };
+}
+
+/** Pull all -v flag values out of an args array. */
+function mounts(args: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === "-v") result.push(args[i + 1]!);
+  }
+  return result;
+}
+
+/** Pull all -p flag values out of an args array. */
+function ports(args: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === "-p") result.push(args[i + 1]!);
+  }
+  return result;
+}
+
+/** Pull all -e flag values out of an args array. */
+function envFlags(args: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === "-e") result.push(args[i + 1]!);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// extraMounts
+// ---------------------------------------------------------------------------
+
+describe("buildDockerRunArgs — extraMounts", () => {
+  it("adds a read-only mount when writable is false", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "/data/shared", guestPath: "/mnt/shared", writable: false },
+      ]}}),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    expect(mounts(args)).toContain("/data/shared:/mnt/shared:ro");
+  });
+
+  it("adds a writable mount when writable is true", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "/data/shared", guestPath: "/mnt/shared", writable: true },
+      ]}}),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    expect(mounts(args)).toContain("/data/shared:/mnt/shared");
+    expect(mounts(args)).not.toContain("/data/shared:/mnt/shared:ro");
+  });
+
+  it("defaults to read-only when writable is omitted", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "/data/shared", guestPath: "/mnt/shared" },
+      ]}}),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    expect(mounts(args)).toContain("/data/shared:/mnt/shared:ro");
+  });
+
+  it("uses hostPath as guestPath when guestPath is omitted", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "/data/shared" },
+      ]}}),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    expect(mounts(args)).toContain("/data/shared:/data/shared:ro");
+  });
+
+  it("expands ~ to the home directory", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "~/projects", guestPath: "/root/projects" },
+      ]}}),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    expect(mounts(args)).toContain(`${HOME}/projects:/root/projects:ro`);
+  });
+
+  it("skips mounts with non-absolute paths after ~ expansion", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "relative/path", guestPath: "/mnt/data" },
+      ]}}),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    expect(mounts(args).join("\n")).not.toContain("/mnt/data");
+  });
+
+  it("includes multiple extra mounts in order", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "/data/a", guestPath: "/mnt/a", writable: true },
+        { hostPath: "/data/b", guestPath: "/mnt/b" },
+      ]}}),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    const m = mounts(args);
+    expect(m).toContain("/data/a:/mnt/a");
+    expect(m).toContain("/data/b:/mnt/b:ro");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extraMounts conflict resolution: config wins over credential defaults
+// ---------------------------------------------------------------------------
+
+describe("buildDockerRunArgs — extraMounts override credential mounts", () => {
+  it("config ~/.ssh writable overrides the default read-only credential mount", () => {
+    // Default behaviour without extraMounts: ~/.ssh is mounted :ro when it exists.
+    // With an extraMount for ~/.ssh marked writable, the credential mount must be
+    // suppressed so the container only sees the writable version.
+    const existingPaths = new Set([`${HOME}/.ssh`]);
+
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "~/.ssh", guestPath: "/root/.ssh", writable: true },
+      ]}}),
+      existingPaths,
+      HOME,
+      "wm-test-123",
+    );
+
+    const m = mounts(args);
+    // The writable extraMount must be present.
+    expect(m).toContain(`${HOME}/.ssh:/root/.ssh`);
+    // The default read-only credential mount must NOT be present.
+    expect(m).not.toContain(`${HOME}/.ssh:/root/.ssh:ro`);
+  });
+
+  it("config ~/.ssh read-only still suppresses the credential mount (config controls it)", () => {
+    const existingPaths = new Set([`${HOME}/.ssh`]);
+
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "~/.ssh", guestPath: "/root/.ssh", writable: false },
+      ]}}),
+      existingPaths,
+      HOME,
+      "wm-test-123",
+    );
+
+    const m = mounts(args);
+    // Exactly one mount for /root/.ssh — the one from extraMounts.
+    const sshMounts = m.filter(v => v.includes("/root/.ssh"));
+    expect(sshMounts).toHaveLength(1);
+    expect(sshMounts[0]).toBe(`${HOME}/.ssh:/root/.ssh:ro`);
+  });
+
+  it("config ~/.gitconfig override does not affect unrelated credential mounts", () => {
+    const existingPaths = new Set([`${HOME}/.gitconfig`, `${HOME}/.ssh`]);
+
+    const args = buildDockerRunArgs(
+      makeOpts({ sandboxConfig: { name: "sandbox", image: "img", extraMounts: [
+        { hostPath: "~/.gitconfig", guestPath: "/root/.gitconfig", writable: true },
+      ]}}),
+      existingPaths,
+      HOME,
+      "wm-test-123",
+    );
+
+    const m = mounts(args);
+    // .gitconfig should be the writable extraMount version.
+    expect(m).toContain(`${HOME}/.gitconfig:/root/.gitconfig`);
+    expect(m).not.toContain(`${HOME}/.gitconfig:/root/.gitconfig:ro`);
+    // .ssh should still be present as the default read-only credential mount.
+    expect(m).toContain(`${HOME}/.ssh:/root/.ssh:ro`);
+  });
+
+  it("credential mounts are included normally when there are no extraMounts", () => {
+    const existingPaths = new Set([`${HOME}/.gitconfig`, `${HOME}/.ssh`]);
+
+    const args = buildDockerRunArgs(
+      makeOpts(),
+      existingPaths,
+      HOME,
+      "wm-test-123",
+    );
+
+    const m = mounts(args);
+    expect(m).toContain(`${HOME}/.gitconfig:/root/.gitconfig:ro`);
+    expect(m).toContain(`${HOME}/.ssh:/root/.ssh:ro`);
+  });
+
+  it("credential mounts are omitted for paths that do not exist on the host", () => {
+    const args = buildDockerRunArgs(
+      makeOpts(),
+      new Set(), // nothing exists
+      HOME,
+      "wm-test-123",
+    );
+
+    const m = mounts(args);
+    expect(m).not.toContain(`${HOME}/.gitconfig:/root/.gitconfig:ro`);
+    expect(m).not.toContain(`${HOME}/.ssh:/root/.ssh:ro`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Port handling
+// ---------------------------------------------------------------------------
+
+describe("buildDockerRunArgs — ports", () => {
+  it("binds valid ports to loopback only", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({
+        services: [{ name: "web", portEnv: "PORT" }],
+        env: { PORT: "3000" },
+      }),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    expect(ports(args)).toContain("127.0.0.1:3000:3000");
+  });
+
+  it("skips ports with non-numeric values", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({
+        services: [{ name: "web", portEnv: "PORT" }],
+        env: { PORT: "auto" },
+      }),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    expect(ports(args)).toHaveLength(0);
+  });
+
+  it("deduplicates ports that appear more than once", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({
+        services: [
+          { name: "web", portEnv: "PORT" },
+          { name: "api", portEnv: "API_PORT" },
+        ],
+        env: { PORT: "3000", API_PORT: "3000" },
+      }),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    expect(ports(args).filter(p => p.startsWith("127.0.0.1:3000"))).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reserved env var protection
+// ---------------------------------------------------------------------------
+
+describe("buildDockerRunArgs — reserved env vars", () => {
+  it("HOME from .env.local does not override the hardcoded HOME=/root", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({ env: { HOME: "/attacker" } }),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    const flags = envFlags(args);
+    expect(flags).toContain("HOME=/root");
+    expect(flags).not.toContain("HOME=/attacker");
+  });
+
+  it("IS_SANDBOX from .env.local is silently dropped", () => {
+    const args = buildDockerRunArgs(
+      makeOpts({ env: { IS_SANDBOX: "0" } }),
+      new Set(),
+      HOME,
+      "wm-test-123",
+    );
+    const flags = envFlags(args);
+    expect(flags).toContain("IS_SANDBOX=1");
+    expect(flags.filter(f => f.startsWith("IS_SANDBOX="))).toHaveLength(1);
+  });
+});

--- a/backend/src/docker.ts
+++ b/backend/src/docker.ts
@@ -26,6 +26,7 @@ function sanitiseBranchForName(branch: string): string {
     .replace(/[^a-zA-Z0-9_.-]/g, "-")
     .replace(/-{2,}/g, "-")
     .replace(/^[^a-zA-Z0-9]+/, "")
+    .replace(/-+$/, "")
     .slice(0, 46);
   return s || "x";
 }
@@ -56,24 +57,24 @@ export interface LaunchContainerOpts {
 }
 
 /**
- * Launch a sandbox container for a worktree. Returns the container name.
- * If a container for this branch is already running, returns its name without launching a second one.
+ * Build the `docker run` argument list from the given options.
+ *
+ * This is a pure function — all I/O (path existence checks, env reads) must
+ * be resolved by the caller and passed in as parameters.
+ *
+ * @param opts          - Launch options (branch, dirs, config, env).
+ * @param existingPaths - Set of host paths confirmed to exist; used to decide
+ *                        which credential mounts to include.
+ * @param home          - Resolved home directory (e.g. Bun.env.HOME ?? "/root").
+ * @param name          - Pre-generated container name.
  */
-export async function launchContainer(opts: LaunchContainerOpts): Promise<string> {
-  const { branch, wtDir, mainRepoDir, sandboxConfig, services, env } = opts;
-
-  // Idempotency: reuse an already-running container for this branch.
-  const existing = await findContainer(branch);
-  if (existing) {
-    console.log(`[docker] reusing existing container ${existing} for branch ${branch}`);
-    return existing;
-  }
-
-  if (!sandboxConfig.image) {
-    throw new Error("sandboxConfig.image is required but was empty");
-  }
-
-  const name = containerName(branch);
+export function buildDockerRunArgs(
+  opts: LaunchContainerOpts,
+  existingPaths: Set<string>,
+  home: string,
+  name: string,
+): string[] {
+  const { wtDir, mainRepoDir, sandboxConfig, services, env } = opts;
 
   const args: string[] = [
     "docker", "run", "-d",
@@ -97,7 +98,7 @@ export async function launchContainer(opts: LaunchContainerOpts): Promise<string
     args.push("-p", `127.0.0.1:${port}:${port}`);
   }
 
-  // Core env vars — defined first so .env.local passthrough cannot override them.
+  // Core env vars — defined first so passthrough cannot override them.
   const reservedKeys = new Set([
     "HOME", "TERM", "IS_SANDBOX",
     "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
@@ -121,6 +122,7 @@ export async function launchContainer(opts: LaunchContainerOpts): Promise<string
         console.warn(`[docker] skipping invalid envPassthrough key: ${JSON.stringify(key)}`);
         continue;
       }
+      if (reservedKeys.has(key)) continue;
       const val = Bun.env[key];
       if (val !== undefined) {
         args.push("-e", `${key}=${val}`);
@@ -143,20 +145,31 @@ export async function launchContainer(opts: LaunchContainerOpts): Promise<string
   args.push("-v", `${mainRepoDir}/.git:${mainRepoDir}/.git`);
   args.push("-v", `${mainRepoDir}:${mainRepoDir}:ro`);
 
-  const home = Bun.env.HOME ?? "/root";
-
   // Claude config mounts.
   args.push("-v", `${home}/.claude:/root/.claude`);
   args.push("-v", `${home}/.claude.json:/root/.claude.json`);
 
-  // Git/GitHub credential mounts (read-only, only if they exist on host).
+  // Compute which guest paths are already covered by extraMounts so credential
+  // mounts for the same path can be skipped (extraMounts win).
+  const extraMountGuestPaths = new Set<string>();
+  if (sandboxConfig.extraMounts) {
+    for (const mount of sandboxConfig.extraMounts) {
+      const hostPath = mount.hostPath.replace(/^~/, home);
+      if (!hostPath.startsWith("/")) continue;
+      extraMountGuestPaths.add(mount.guestPath ?? hostPath);
+    }
+  }
+
+  // Git/GitHub credential mounts (read-only, only if they exist on host and
+  // are not overridden by an extraMount for the same guest path).
   const credentialMounts = [
     { hostPath: `${home}/.gitconfig`, guestPath: "/root/.gitconfig" },
     { hostPath: `${home}/.ssh`, guestPath: "/root/.ssh" },
     { hostPath: `${home}/.config/gh`, guestPath: "/root/.config/gh" },
   ];
   for (const { hostPath, guestPath } of credentialMounts) {
-    if (await pathExists(hostPath)) {
+    if (extraMountGuestPaths.has(guestPath)) continue;
+    if (existingPaths.has(hostPath)) {
       args.push("-v", `${hostPath}:${guestPath}:ro`);
     }
   }
@@ -178,6 +191,43 @@ export async function launchContainer(opts: LaunchContainerOpts): Promise<string
   // Image + command.
   args.push(sandboxConfig.image, "sleep", "infinity");
 
+  return args;
+}
+
+/**
+ * Launch a sandbox container for a worktree. Returns the container name.
+ * If a container for this branch is already running, returns its name without launching a second one.
+ */
+export async function launchContainer(opts: LaunchContainerOpts): Promise<string> {
+  const { branch } = opts;
+
+  // Idempotency: reuse an already-running container for this branch.
+  const existing = await findContainer(branch);
+  if (existing) {
+    console.log(`[docker] reusing existing container ${existing} for branch ${branch}`);
+    return existing;
+  }
+
+  if (!opts.sandboxConfig.image) {
+    throw new Error("sandboxConfig.image is required but was empty");
+  }
+
+  const name = containerName(branch);
+  const home = Bun.env.HOME ?? "/root";
+
+  // Resolve which credential paths exist on the host before building args.
+  const credentialHostPaths = [
+    `${home}/.gitconfig`,
+    `${home}/.ssh`,
+    `${home}/.config/gh`,
+  ];
+  const existingPaths = new Set<string>();
+  await Promise.all(credentialHostPaths.map(async (p) => {
+    if (await pathExists(p)) existingPaths.add(p);
+  }));
+
+  const args = buildDockerRunArgs(opts, existingPaths, home, name);
+
   console.log(`[docker] launching container: ${name}`);
   const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
 
@@ -195,13 +245,13 @@ export async function launchContainer(opts: LaunchContainerOpts): Promise<string
   ]);
 
   if (exitResult === "timeout") {
-    Bun.spawn(["docker", "rm", "-f", name], { stdout: "ignore", stderr: "ignore" });
+    await Bun.spawn(["docker", "rm", "-f", name], { stdout: "ignore", stderr: "ignore" }).exited;
     throw new Error(`docker run timed out after ${DOCKER_RUN_TIMEOUT_MS / 1000}s`);
   }
 
   if (exitResult !== 0) {
     // Clean up any stopped container docker may have left behind.
-    Bun.spawn(["docker", "rm", "-f", name], { stdout: "ignore", stderr: "ignore" });
+    await Bun.spawn(["docker", "rm", "-f", name], { stdout: "ignore", stderr: "ignore" }).exited;
     throw new Error(`docker run failed (exit ${exitResult}): ${stderr}`);
   }
 


### PR DESCRIPTION
## Summary

- **Branch name sanitisation** — branch names like `feature/my-branch` are now mapped to `feature-my-branch` before use in container names, fixing a crash on `docker run --name` with slash-containing branches
- **Port security** — service ports now bind to `127.0.0.1` only instead of all interfaces (`0.0.0.0`), preventing dev services from being exposed on external network interfaces
- **Port validation & dedup** — port values from `.env.local` are validated as integers in 1–65535 and deduplicated before `-p` flags are built; invalid values are warned and skipped
- **Env var hardening** — keys are validated against `[A-Za-z_][A-Za-z0-9_]*` before `-e` args are added; reserved core vars (`HOME`, `TERM`, `IS_SANDBOX`, `GIT_CONFIG_*`) are protected from `.env.local` override
- **`process.env` → `Bun.env`** — per coding rules
- **60 s timeout on `docker run`** — `Promise.race` against `Bun.sleep(60_000)` prevents indefinite hangs on slow image pulls or a hung daemon; fires `docker rm -f` cleanup on timeout
- **Cleanup on failure** — `docker rm -f <name>` is fired on non-zero exit to remove the stopped container Docker may leave behind
- **Container ID captured** — stdout from `docker run -d` is now read and the short ID logged on success
- **Idempotency guard** — `launchContainer` calls `findContainer` first and returns the existing container on a rapid double-open or retry instead of launching a duplicate
- **`sandboxConfig.image` guard** — explicit check before use (guards against unvalidated `as` cast in config parser)
- **Extra mount path validation** — non-absolute paths after `~` expansion are warned and skipped
- **`Bun.$` → `Bun.spawn` array** in `findContainer` and `removeContainer` — no shell involvement, consistent with `launchContainer`
- **`findContainer` correctness** — throws on daemon errors instead of silently returning `null`; returns the most-recently-started container (`names.at(-1)`) instead of the oldest; filters results with a `/^\d+$/` suffix check so `wm-main-` cannot false-match `wm-main-v2-*` containers
- **`removeContainer` correctness** — all `docker rm -f` calls run in parallel via `Promise.all`; same exact-prefix filter applied

## Test plan

- [ ] Create a sandbox worktree for a branch named `feature/my-thing` — container should launch successfully as `wm-feature-my-thing-<ts>`
- [ ] Verify `docker ps` shows port bindings as `127.0.0.1:<port>-><port>/tcp`, not `0.0.0.0`
- [ ] Set an invalid `portEnv` value (e.g. `"auto"`) in `.env.local` — server should log a warning and start without the bad `-p` flag
- [ ] Open the same worktree twice rapidly — second call should log "reusing existing container" and not create a duplicate
- [ ] Remove a worktree — `docker rm -f` should fire for all matching containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)