### PR TITLE
Add guest-to-host RPC for workmux CLI in sandbox containers

### DIFF
--- a/backend/src/__tests__/docker.test.ts
+++ b/backend/src/__tests__/docker.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { buildDockerRunArgs, type LaunchContainerOpts } from "../docker";
 
 const HOME = "/home/testuser";
+const RPC_SECRET = "test-rpc-secret";
+const RPC_PORT = "5111";
 
 /** Minimal valid opts; individual tests override what they need. */
 function makeOpts(overrides: Partial<LaunchContainerOpts> = {}): LaunchContainerOpts {
@@ -56,6 +58,8 @@ describe("buildDockerRunArgs — extraMounts", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     expect(mounts(args)).toContain("/data/shared:/mnt/shared:ro");
   });
@@ -68,6 +72,8 @@ describe("buildDockerRunArgs — extraMounts", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     expect(mounts(args)).toContain("/data/shared:/mnt/shared");
     expect(mounts(args)).not.toContain("/data/shared:/mnt/shared:ro");
@@ -81,6 +87,8 @@ describe("buildDockerRunArgs — extraMounts", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     expect(mounts(args)).toContain("/data/shared:/mnt/shared:ro");
   });
@@ -93,6 +101,8 @@ describe("buildDockerRunArgs — extraMounts", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     expect(mounts(args)).toContain("/data/shared:/data/shared:ro");
   });
@@ -105,6 +115,8 @@ describe("buildDockerRunArgs — extraMounts", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     expect(mounts(args)).toContain(`${HOME}/projects:/root/projects:ro`);
   });
@@ -117,6 +129,8 @@ describe("buildDockerRunArgs — extraMounts", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     expect(mounts(args).join("\n")).not.toContain("/mnt/data");
   });
@@ -130,6 +144,8 @@ describe("buildDockerRunArgs — extraMounts", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     const m = mounts(args);
     expect(m).toContain("/data/a:/mnt/a");
@@ -155,6 +171,8 @@ describe("buildDockerRunArgs — extraMounts override credential mounts", () => 
       existingPaths,
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
 
     const m = mounts(args);
@@ -174,6 +192,8 @@ describe("buildDockerRunArgs — extraMounts override credential mounts", () => 
       existingPaths,
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
 
     const m = mounts(args);
@@ -193,6 +213,8 @@ describe("buildDockerRunArgs — extraMounts override credential mounts", () => 
       existingPaths,
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
 
     const m = mounts(args);
@@ -211,6 +233,8 @@ describe("buildDockerRunArgs — extraMounts override credential mounts", () => 
       existingPaths,
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
 
     const m = mounts(args);
@@ -224,6 +248,8 @@ describe("buildDockerRunArgs — extraMounts override credential mounts", () => 
       new Set(), // nothing exists
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
 
     const m = mounts(args);
@@ -246,6 +272,8 @@ describe("buildDockerRunArgs — ports", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     expect(ports(args)).toContain("127.0.0.1:3000:3000");
   });
@@ -259,6 +287,8 @@ describe("buildDockerRunArgs — ports", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     expect(ports(args)).toHaveLength(0);
   });
@@ -275,6 +305,8 @@ describe("buildDockerRunArgs — ports", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     expect(ports(args).filter(p => p.startsWith("127.0.0.1:3000"))).toHaveLength(1);
   });
@@ -291,6 +323,8 @@ describe("buildDockerRunArgs — reserved env vars", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     const flags = envFlags(args);
     expect(flags).toContain("HOME=/root");
@@ -303,6 +337,8 @@ describe("buildDockerRunArgs — reserved env vars", () => {
       new Set(),
       HOME,
       "wm-test-123",
+      RPC_SECRET,
+      RPC_PORT,
     );
     const flags = envFlags(args);
     expect(flags).toContain("IS_SANDBOX=1");

--- a/backend/src/docker.ts
+++ b/backend/src/docker.ts
@@ -7,6 +7,7 @@
 
 import { stat } from "node:fs/promises";
 import { type SandboxProfileConfig, type ServiceConfig } from "./config";
+import { loadRpcSecret } from "./rpc-secret";
 
 const DOCKER_RUN_TIMEOUT_MS = 60_000;
 
@@ -56,6 +57,39 @@ export interface LaunchContainerOpts {
   env: Record<string, string>;
 }
 
+function buildWorkmuxStub(): string {
+  return `#!/usr/bin/env python3
+import sys, json, os, urllib.request
+
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+args = sys.argv[2:]
+host = os.environ.get("WORKMUX_RPC_HOST", "host.docker.internal")
+port = os.environ.get("WORKMUX_RPC_PORT", "5111")
+token = os.environ.get("WORKMUX_RPC_TOKEN", "")
+
+payload = {"command": cmd}
+if args:
+    payload["name"] = args[0]
+data = json.dumps(payload).encode()
+req = urllib.request.Request(
+    f"http://{host}:{port}/rpc/workmux",
+    data=data,
+    headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"}
+)
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        result = json.loads(resp.read())
+        if result.get("ok"):
+            print(result.get("output", ""))
+        else:
+            print(result.get("error", "RPC failed"), file=sys.stderr)
+            sys.exit(1)
+except Exception as e:
+    print(f"workmux rpc error: {e}", file=sys.stderr)
+    sys.exit(1)
+`;
+}
+
 /**
  * Build the `docker run` argument list from the given options.
  *
@@ -73,6 +107,8 @@ export function buildDockerRunArgs(
   existingPaths: Set<string>,
   home: string,
   name: string,
+  rpcSecret: string,
+  rpcPort: string,
 ): string[] {
   const { wtDir, mainRepoDir, sandboxConfig, services, env } = opts;
 
@@ -188,6 +224,11 @@ export function buildDockerRunArgs(
     }
   }
 
+  // RPC env vars so workmux stub inside the container can reach the host.
+  args.push("-e", `WORKMUX_RPC_HOST=host.docker.internal`);
+  args.push("-e", `WORKMUX_RPC_PORT=${rpcPort}`);
+  args.push("-e", `WORKMUX_RPC_TOKEN=${rpcSecret}`);
+
   // Image + command.
   args.push(sandboxConfig.image, "sleep", "infinity");
 
@@ -214,6 +255,8 @@ export async function launchContainer(opts: LaunchContainerOpts): Promise<string
 
   const name = containerName(branch);
   const home = Bun.env.HOME ?? "/root";
+  const rpcSecret = await loadRpcSecret();
+  const rpcPort = Bun.env.DASHBOARD_PORT ?? "5111";
 
   // Resolve which credential paths exist on the host before building args.
   const credentialHostPaths = [
@@ -226,7 +269,7 @@ export async function launchContainer(opts: LaunchContainerOpts): Promise<string
     if (await pathExists(p)) existingPaths.add(p);
   }));
 
-  const args = buildDockerRunArgs(opts, existingPaths, home, name);
+  const args = buildDockerRunArgs(opts, existingPaths, home, name, rpcSecret, rpcPort);
 
   console.log(`[docker] launching container: ${name}`);
   const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
@@ -256,6 +299,27 @@ export async function launchContainer(opts: LaunchContainerOpts): Promise<string
   }
 
   console.log(`[docker] container ${name} ready (id=${containerId.trim().slice(0, 12)})`);
+
+  // Inject workmux stub so agents inside the container can call host-side workmux.
+  const stub = buildWorkmuxStub();
+  const injectProc = Bun.spawn(
+    ["docker", "exec", "-i", name, "sh", "-c",
+     "cat > /usr/local/bin/workmux && chmod +x /usr/local/bin/workmux"],
+    { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
+  );
+  const { stdin } = injectProc;
+  if (stdin) {
+    stdin.write(stub);
+    stdin.end();
+  }
+  const injectExit = await injectProc.exited;
+  if (injectExit !== 0) {
+    const injectStderr = await new Response(injectProc.stderr).text();
+    console.warn(`[docker] workmux stub injection failed for ${name}: ${injectStderr}`);
+  } else {
+    console.log(`[docker] workmux stub injected into ${name}`);
+  }
+
   return name;
 }
 

--- a/backend/src/http.ts
+++ b/backend/src/http.ts
@@ -1,0 +1,10 @@
+export function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function errorResponse(message: string, status = 500): Response {
+  return jsonResponse({ error: message }, status);
+}

--- a/backend/src/rpc-secret.ts
+++ b/backend/src/rpc-secret.ts
@@ -1,0 +1,21 @@
+import { chmod, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const SECRET_PATH = `${Bun.env.HOME ?? "/root"}/.config/workmux/rpc-secret`;
+
+let cached: string | null = null;
+
+export async function loadRpcSecret(): Promise<string> {
+  if (cached) return cached;
+  const file = Bun.file(SECRET_PATH);
+  if (await file.exists()) {
+    cached = (await file.text()).trim();
+    return cached;
+  }
+  const secret = crypto.randomUUID();
+  await mkdir(dirname(SECRET_PATH), { recursive: true });
+  await Bun.write(SECRET_PATH, secret);
+  await chmod(SECRET_PATH, 0o600);
+  cached = secret;
+  return secret;
+}

--- a/backend/src/rpc.ts
+++ b/backend/src/rpc.ts
@@ -1,0 +1,67 @@
+import { listWorktrees, getStatus, mergeWorktree, removeWorktree } from "./workmux";
+import { loadRpcSecret } from "./rpc-secret";
+import { jsonResponse } from "./http";
+
+type RpcRequest =
+  | { command: "list" }
+  | { command: "status" }
+  | { command: "merge"; name: string }
+  | { command: "rm"; name: string }
+
+type RpcResponse = { ok: true; output: string } | { ok: false; error: string }
+
+const VALID_NAME_RE = /^[a-zA-Z0-9._\/-]+$/;
+
+export async function handleWorkmuxRpc(req: Request): Promise<Response> {
+  const secret = await loadRpcSecret();
+  const authHeader = req.headers.get("Authorization");
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+  if (token !== secret) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  let raw: { command?: string; name?: string };
+  try {
+    raw = await req.json() as { command?: string; name?: string };
+  } catch {
+    return jsonResponse({ ok: false, error: "Invalid JSON" } satisfies RpcResponse, 400);
+  }
+
+  const { command, name } = raw;
+
+  if (name && !VALID_NAME_RE.test(name)) {
+    return jsonResponse({ ok: false, error: "Invalid name" } satisfies RpcResponse, 400);
+  }
+
+  try {
+    switch (command) {
+      case "list": {
+        const result = await listWorktrees();
+        return jsonResponse({ ok: true, output: JSON.stringify(result) } satisfies RpcResponse);
+      }
+      case "status": {
+        const result = await getStatus();
+        return jsonResponse({ ok: true, output: JSON.stringify(result) } satisfies RpcResponse);
+      }
+      case "merge": {
+        if (!name) return jsonResponse({ ok: false, error: "Missing name" } satisfies RpcResponse, 400);
+        const result = await mergeWorktree(name);
+        if (!result.ok) return jsonResponse({ ok: false, error: result.error } satisfies RpcResponse, 422);
+        return jsonResponse({ ok: true, output: result.output } satisfies RpcResponse);
+      }
+      case "rm": {
+        if (!name) return jsonResponse({ ok: false, error: "Missing name" } satisfies RpcResponse, 400);
+        const result = await removeWorktree(name);
+        if (!result.ok) return jsonResponse({ ok: false, error: result.error } satisfies RpcResponse, 422);
+        return jsonResponse({ ok: true, output: result.output } satisfies RpcResponse);
+      }
+      default:
+        return jsonResponse({ ok: false, error: `Unknown command: ${command ?? ""}` } satisfies RpcResponse, 400);
+    }
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : String(err);
+    return jsonResponse({ ok: false, error } satisfies RpcResponse, 500);
+  }
+}
+
+export type { RpcRequest, RpcResponse };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,6 +24,8 @@ import {
 } from "./terminal";
 import { loadConfig, type WmdevConfig } from "./config";
 import { startPrMonitor, type PrEntry } from "./pr";
+import { handleWorkmuxRpc } from "./rpc";
+import { jsonResponse, errorResponse } from "./http";
 
 const PORT = parseInt(Bun.env.DASHBOARD_PORT || "5111", 10);
 const STATIC_DIR = Bun.env.WMDEV_STATIC_DIR || "";
@@ -77,17 +79,6 @@ function parseWsMessage(raw: string | Buffer): WsInboundMessage | null {
 }
 
 // --- HTTP helpers ---
-
-function jsonResponse(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
-function errorResponse(message: string, status = 500): Response {
-  return jsonResponse({ error: message }, status);
-}
 
 function sendWs(ws: { send: (data: string) => void }, msg: WsOutboundMessage): void {
   ws.send(JSON.stringify(msg));
@@ -312,6 +303,10 @@ Bun.serve({
       return server.upgrade(req, { data: { worktree, attached: false } })
         ? undefined
         : new Response("WebSocket upgrade failed", { status: 400 });
+    },
+
+    "/rpc/workmux": {
+      POST: (req) => handleWorkmuxRpc(req),
     },
 
     "/api/config": {


### PR DESCRIPTION
## Summary

- Adds `POST /rpc/workmux` endpoint on the host, authenticated with a persistent Bearer token stored at `~/.config/workmux/rpc-secret`
- Injects a Python3 `workmux` stub into each sandbox container at launch via `docker exec`, forwarding `list`, `status`, `merge`, and `rm` to the host over `host.docker.internal`
- Shared `rpc-secret.ts` module ensures the secret survives server restarts and is consistent between the launcher and validator

## Test plan

- [ ] Start `wmdev` with a sandbox-enabled `.wmdev.yaml`
- [ ] `workmux add` to create a sandbox worktree
- [ ] In the agent pane, run `workmux list` — should return JSON list of worktrees
- [ ] Run `workmux status` — should show agent status
- [ ] Run `workmux merge <branch>` / `workmux rm <branch>` from inside the container — should affect the host
- [ ] Confirm a missing/wrong token returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)