### PR TITLE
Add PR comments badge and plan prompt in TopBar

### DIFF
--- a/backend/src/pr.ts
+++ b/backend/src/pr.ts
@@ -1,6 +1,12 @@
 import { upsertEnvLocal } from "./env";
 import type { LinkedRepoConfig } from "./config";
 
+export interface PrComment {
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
 export interface CiCheck {
   name: string;
   status: string;
@@ -15,6 +21,13 @@ export interface PrEntry {
   url: string;
   ciStatus: string;
   ciChecks: CiCheck[];
+  comments: PrComment[];
+}
+
+interface GhComment {
+  author: { login: string };
+  body: string;
+  createdAt: string;
 }
 
 interface GhCheckEntry {
@@ -30,6 +43,7 @@ interface GhPrEntry {
   state: string;
   statusCheckRollup: GhCheckEntry[];
   url: string;
+  comments: GhComment[];
 }
 
 /** Summarize CI check status from statusCheckRollup array. */
@@ -69,7 +83,7 @@ function mapChecks(checks: GhCheckEntry[]): CiCheck[] {
 
 /** Fetch all PRs from a repo via gh CLI. Returns a map of branch name → PrEntry. */
 export async function fetchAllPrs(repoSlug?: string, repoLabel?: string): Promise<Map<string, PrEntry>> {
-  const args = ["gh", "pr", "list", "--state", "open", "--json", "number,headRefName,state,statusCheckRollup,url", "--limit", "50"];
+  const args = ["gh", "pr", "list", "--state", "open", "--json", "number,headRefName,state,statusCheckRollup,url,comments", "--limit", "50"];
   if (repoSlug) args.push("--repo", repoSlug);
 
   const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
@@ -95,6 +109,11 @@ export async function fetchAllPrs(repoSlug?: string, repoLabel?: string): Promis
         url: entry.url,
         ciStatus: summarizeChecks(entry.statusCheckRollup),
         ciChecks: mapChecks(entry.statusCheckRollup),
+        comments: (entry.comments ?? []).map((c) => ({
+          author: c.author?.login ?? "unknown",
+          body: c.body ?? "",
+          createdAt: c.createdAt ?? "",
+        })),
       });
     }
   } catch (err) {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -245,7 +245,7 @@ async function handleApi(req: Request, url: URL): Promise<Response> {
           agentName: env.AGENT || null,
           services,
           paneCount: wt.mux === "✓" ? getTmuxPaneCount(wt.branch) : 0,
-          prs: env.PR_DATA ? (JSON.parse(env.PR_DATA) as PrEntry[]) : [],
+          prs: env.PR_DATA ? (JSON.parse(env.PR_DATA) as PrEntry[]).map(pr => ({ ...pr, comments: pr.comments ?? [] })) : [],
         };
       }));
       return jsonResponse(merged);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import PaneBar from "./lib/PaneBar.svelte";
   import type { WorktreeInfo, AppConfig, PrEntry } from "./lib/types";
   import * as api from "./lib/api";
+  import { normalizeTextForPrompt } from "./lib/promptUtils";
 
   let config = $state<AppConfig>({
     services: [],
@@ -303,6 +304,24 @@
       }}
       onsettings={() => (showSettingsDialog = true)}
       onciclick={(pr) => (ciDetailsPr = pr)}
+      onreviewsclick={async (pr) => {
+        if (!selectedBranch) return;
+        const label = pr.repo ? `${pr.repo} #${pr.number}` : `PR #${pr.number}`;
+        const preamble = [
+          "Review the PR comments and elaborate a plan to address them.",
+          `PR: ${label}`,
+          "",
+          "Comments:",
+        ].join("\n") + "\n";
+        const content = pr.comments
+          .map((c, i) => `[${i + 1}] @${c.author} (${c.createdAt.slice(0, 10)}):\n${c.body}`)
+          .join("\n\n");
+        try {
+          await api.sendWorktreePrompt(selectedBranch, normalizeTextForPrompt(content, 20000), preamble);
+        } catch (err) {
+          console.error("Failed to send reviews prompt:", err);
+        }
+      }}
     />
 
     {#if canConnect}

--- a/frontend/src/lib/CiDetailsDialog.svelte
+++ b/frontend/src/lib/CiDetailsDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { PrEntry } from "./types";
   import { fetchCiLogs, sendWorktreePrompt } from "./api";
+  import { normalizeTextForPrompt } from "./promptUtils";
 
   let {
     pr,
@@ -22,24 +23,6 @@
   let copied = $state(false);
   let fixLoading = $state<number | null>(null);
   let fixError = $state("");
-
-  function stripAnsi(input: string): string {
-    return input
-      .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "")
-      .replace(/\x1B[@-_]/g, "");
-  }
-
-  const MAX_LOG_CHARS = 30000;
-
-  function normalizeLogsForPrompt(input: string): string {
-    const noAnsi = stripAnsi(input).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-    // Keep tabs/newlines and printable ASCII only to avoid terminal control issues.
-    const cleaned = noAnsi.replace(/[^\x09\x0A\x20-\x7E]/g, "");
-    if (cleaned.length > MAX_LOG_CHARS) {
-      return "[... truncated]\n" + cleaned.slice(-MAX_LOG_CHARS);
-    }
-    return cleaned;
-  }
 
   $effect(() => {
     dialogEl?.showModal();
@@ -81,7 +64,7 @@
         "",
         "Logs:",
       ].join("\n") + "\n";
-    const sanitizedLogs = normalizeLogsForPrompt(logs);
+    const sanitizedLogs = normalizeTextForPrompt(logs);
     try {
       await sendWorktreePrompt(branch, sanitizedLogs, preamble);
       onfixsuccess();

--- a/frontend/src/lib/ReviewsBadge.svelte
+++ b/frontend/src/lib/ReviewsBadge.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { PrEntry } from "./types";
+
+  let { pr, onclick }: {
+    pr: PrEntry;
+    onclick: (pr: PrEntry) => void;
+  } = $props();
+</script>
+
+<button
+  type="button"
+  class="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded-full flex items-center gap-1 cursor-pointer border-none hover:opacity-80 bg-accent/20 text-accent"
+  onclick={(e) => { e.stopPropagation(); onclick(pr); }}
+  title="Send PR comments to Claude for review"
+>
+  <span class="inline-block w-1.5 h-1.5 rounded-full bg-accent"></span>
+  {pr.comments.length} {pr.comments.length === 1 ? 'comment' : 'comments'}
+</button>

--- a/frontend/src/lib/TopBar.svelte
+++ b/frontend/src/lib/TopBar.svelte
@@ -2,6 +2,7 @@
   import type { WorktreeInfo, PrEntry } from "./types";
   import PrBadge from "./PrBadge.svelte";
   import CiBadge from "./CiBadge.svelte";
+  import ReviewsBadge from "./ReviewsBadge.svelte";
 
   let {
     name,
@@ -13,6 +14,7 @@
     onremove,
     onsettings,
     onciclick,
+    onreviewsclick,
   }: {
     name: string | null;
     worktree: WorktreeInfo | undefined;
@@ -23,6 +25,7 @@
     onremove: () => void;
     onsettings: () => void;
     onciclick: (pr: PrEntry) => void;
+    onreviewsclick: (pr: PrEntry) => void;
   } = $props();
 
   let cursorUrl = $derived.by(() => {
@@ -75,6 +78,9 @@
       <PrBadge {pr} clickable />
       {#if pr.ciChecks && pr.ciChecks.length > 0}
         <CiBadge {pr} onclick={onciclick} />
+      {/if}
+      {#if pr.comments.length > 0}
+        <ReviewsBadge {pr} onclick={onreviewsclick} />
       {/if}
     {/each}
     {#if !isMobile}

--- a/frontend/src/lib/promptUtils.ts
+++ b/frontend/src/lib/promptUtils.ts
@@ -1,0 +1,15 @@
+function stripAnsi(input: string): string {
+  return input
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\x1B[@-_]/g, "");
+}
+
+export function normalizeTextForPrompt(input: string, maxChars = 30000): string {
+  const noAnsi = stripAnsi(input).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  // Keep tabs, newlines, and printable ASCII only to avoid terminal control issues.
+  const cleaned = noAnsi.replace(/[^\x09\x0A\x20-\x7E]/g, "");
+  if (cleaned.length > maxChars) {
+    return "[... truncated]\n" + cleaned.slice(-maxChars);
+  }
+  return cleaned;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -4,6 +4,12 @@ export interface ServiceStatus {
   running: boolean;
 }
 
+export interface PrComment {
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
 export interface CiCheck {
   name: string;
   status: string;
@@ -18,6 +24,7 @@ export interface PrEntry {
   url: string;
   ciStatus: string;
   ciChecks: CiCheck[];
+  comments: PrComment[];
 }
 
 export interface WorktreeInfo {


### PR DESCRIPTION
## Summary

- Fetches PR comment content (author, body, date) alongside existing CI status in the same `gh pr list` call — no extra network cost
- Shows a comment count badge in the TopBar next to the CI badge when a PR has comments
- Clicking the badge pastes a structured prompt into Claude with the full comment thread (preamble + formatted comments) so it can evaluate and plan without re-fetching; Enter is intentionally **not** auto-sent so you can review before submitting
- Extracted `normalizeTextForPrompt` into a shared `promptUtils.ts`, removing the duplicate from `CiDetailsDialog`
- Normalizes legacy `PR_DATA` in `server.ts` to backfill `comments: []` on cached entries that predate this change

## Test plan

- [ ] Open a worktree whose branch has an open PR with comments — badge should appear in TopBar
- [ ] Click the badge — verify the comment thread is pasted into Claude's input with preamble, cursor waiting for Enter
- [ ] Worktree with no PR comments — badge should not appear
- [ ] CI fix flow still works (regression check on shared `normalizeTextForPrompt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)