### PR TITLE
Assign unique ports per worktree via post_create hook

### DIFF
--- a/.wmdev.yaml
+++ b/.wmdev.yaml
@@ -1,6 +1,27 @@
+services:
+  - name: BE
+    portEnv: DASHBOARD_PORT
+  - name: FE
+    portEnv: FRONTEND_PORT
+
 profiles:
   default:
     name: default
+    systemPrompt: >
+      You are running inside a git worktree managed by workmux.
+      To create a new worktree for a parallel subtask, run:
+      workmux add -b -p "PROMPT" BRANCH
+      You must supply an explicit BRANCH name. Good branch names: kebab-case, 1-3 words, describe the change not the process.
+      When creating multiple worktrees, create them one at a time — run the command, wait for it to complete, then create the next.
+      Example: workmux add -b -p 'Add CSV export to reports table, download visible rows as report.csv' export-csv
+
+      This worktree has dedicated ports:
+
+      - Backend: port ${DASHBOARD_PORT}.
+        Start with: cd backend && DASHBOARD_PORT=${DASHBOARD_PORT} bun run dev
+
+      - Frontend: port ${FRONTEND_PORT}.
+        Start with: cd frontend && DASHBOARD_PORT=${DASHBOARD_PORT} bun run dev
 
 linkedRepos:
   - repo: centdix/workmux-test-linked

--- a/.workmux.yaml
+++ b/.workmux.yaml
@@ -31,16 +31,30 @@ auto_name:
     Output ONLY the branch name, nothing else.
   background: true
 
+post_create:
+  - ./scripts/worktree-env
+
 panes:
   - command: >-
+      source .env.local 2>/dev/null || true;
       claude --dangerously-skip-permissions --append-system-prompt
       "You are running inside a git worktree managed by workmux.
       To create a new worktree for a parallel subtask, run:
       workmux add -b -p \"PROMPT\" BRANCH
       You must supply an explicit BRANCH name. Good branch names: kebab-case, 1-3 words, describe the change not the process.
       When creating multiple worktrees, create them one at a time — run the command, wait for it to complete, then create the next.
-      Example: workmux add -b -p 'Add CSV export to reports table, download visible rows as report.csv' export-csv"
+      Example: workmux add -b -p 'Add CSV export to reports table, download visible rows as report.csv' export-csv
+
+      This worktree has dedicated ports (from .env.local):
+      - Backend (bun): DASHBOARD_PORT — start with: cd backend && DASHBOARD_PORT=\$DASHBOARD_PORT bun run dev
+      - Frontend (vite): FRONTEND_PORT — start with: cd frontend && DASHBOARD_PORT=\$DASHBOARD_PORT bun run dev"
     focus: true
+  - command: >-
+      source .env.local 2>/dev/null || true;
+      cd backend && DASHBOARD_PORT=${DASHBOARD_PORT:-5111} bun run dev
+  - command: >-
+      source .env.local 2>/dev/null || true;
+      cd frontend && DASHBOARD_PORT=${DASHBOARD_PORT:-5111} bun run dev
 
 sandbox:
   enabled: false

--- a/dev.sh
+++ b/dev.sh
@@ -7,6 +7,11 @@ if [ -f .env ]; then
   set -a; source .env; set +a
 fi
 
+# Load worktree-specific port assignments (DASHBOARD_PORT, FRONTEND_PORT)
+if [ -f .env.local ]; then
+  set -a; source .env.local; set +a
+fi
+
 cleanup() {
   kill $BE_PID $FE_PID 2>/dev/null || true
 }

--- a/scripts/worktree-env
+++ b/scripts/worktree-env
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Assigns unique DASHBOARD_PORT and FRONTEND_PORT to a new worktree.
+# Called by workmux as a post_create hook; receives the worktree dir as $1
+# (falls back to $PWD if not provided).
+#
+# Port layout (slots of 10):
+#   slot 0 → 5111/5112  (main branch default, never assigned by this script)
+#   slot 1 → 5121/5122
+#   slot 2 → 5131/5132
+#   ...
+set -euo pipefail
+
+WORKTREE_DIR="${1:-$PWD}"
+ENV_FILE="$WORKTREE_DIR/.env.local"
+
+BASE=5111
+STEP=10
+
+# Collect occupied slots from every worktree's .env.local
+occupied=""
+while IFS= read -r wt_path; do
+  wt_env="$wt_path/.env.local"
+  [ -f "$wt_env" ] || continue
+  [ "$wt_env" = "$ENV_FILE" ] && continue
+  port=$(grep -E "^DASHBOARD_PORT=" "$wt_env" 2>/dev/null | cut -d= -f2 || true)
+  if [ -n "$port" ] && [ "$port" -ge "$BASE" ]; then
+    slot=$(( (port - BASE) / STEP ))
+    occupied="$occupied $slot "
+  fi
+done < <(git -C "$WORKTREE_DIR" worktree list | awk '{print $1}')
+
+# Pick the first free slot starting from 1 (slot 0 is reserved for main)
+slot=1
+while echo "$occupied" | grep -qF " $slot "; do
+  slot=$(( slot + 1 ))
+done
+
+DASHBOARD_PORT=$(( BASE + slot * STEP ))
+FRONTEND_PORT=$(( DASHBOARD_PORT + 1 ))
+
+# Upsert keys into .env.local (create the file if it doesn't exist)
+touch "$ENV_FILE"
+upsert() {
+  local key="$1" val="$2"
+  if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+    sed -i "s|^${key}=.*|${key}=${val}|" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$val" >> "$ENV_FILE"
+  fi
+}
+
+upsert DASHBOARD_PORT "$DASHBOARD_PORT"
+upsert FRONTEND_PORT  "$FRONTEND_PORT"
+
+echo "worktree-env: DASHBOARD_PORT=$DASHBOARD_PORT FRONTEND_PORT=$FRONTEND_PORT"


### PR DESCRIPTION
## Summary

- Add `scripts/worktree-env`: slot-based port allocator (increments of 10 starting at 5121/5122) that scans existing worktrees and upserts `DASHBOARD_PORT`/`FRONTEND_PORT` into each worktree's `.env.local`
- Add `post_create` hook in `.workmux.yaml` to run `worktree-env` automatically; also add BE/FE dev-server panes that source `.env.local` before starting
- Add `services` config in `.wmdev.yaml` (`BE→DASHBOARD_PORT`, `FE→FRONTEND_PORT`) so the dashboard shows per-worktree service status indicators
- Add `systemPrompt` to the default profile in `.wmdev.yaml` with `${DASHBOARD_PORT}`/`${FRONTEND_PORT}` template vars so Claude is told which ports to use
- Update `dev.sh` to source `.env.local` so `DASHBOARD_PORT` is inherited by both the bun backend and vite frontend

## Test plan

- [ ] Create a new worktree via the dashboard — verify `.env.local` gets `DASHBOARD_PORT` and `FRONTEND_PORT` written
- [ ] Create a second worktree — verify it gets different ports (next slot)
- [ ] Run `./dev.sh` in a worktree — verify backend starts on `DASHBOARD_PORT` and frontend on `DASHBOARD_PORT+1`
- [ ] Dashboard service indicators show BE/FE as running once dev servers are up

🤖 Generated with [Claude Code](https://claude.com/claude-code)