### PR TITLE
Add comment review dialog for selective PR comment sending

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -7,10 +7,10 @@
   import CreateWorktreeDialog from "./lib/CreateWorktreeDialog.svelte";
   import SettingsDialog from "./lib/SettingsDialog.svelte";
   import CiDetailsDialog from "./lib/CiDetailsDialog.svelte";
+  import CommentReviewDialog from "./lib/CommentReviewDialog.svelte";
   import PaneBar from "./lib/PaneBar.svelte";
   import type { WorktreeInfo, AppConfig, PrEntry } from "./lib/types";
   import * as api from "./lib/api";
-  import { normalizeTextForPrompt } from "./lib/promptUtils";
 
   let config = $state<AppConfig>({
     services: [],
@@ -28,6 +28,7 @@
   let showCreateDialog = $state(false);
   let showSettingsDialog = $state(false);
   let ciDetailsPr = $state<PrEntry | null>(null);
+  let commentReviewPr = $state<PrEntry | null>(null);
   let creating = $state(false);
   let sshHost = $state(localStorage.getItem(SSH_STORAGE_KEY) ?? "");
 
@@ -304,24 +305,7 @@
       }}
       onsettings={() => (showSettingsDialog = true)}
       onciclick={(pr) => (ciDetailsPr = pr)}
-      onreviewsclick={async (pr) => {
-        if (!selectedBranch) return;
-        const label = pr.repo ? `${pr.repo} #${pr.number}` : `PR #${pr.number}`;
-        const preamble = [
-          "Review the PR comments and elaborate a plan to address them.",
-          `PR: ${label}`,
-          "",
-          "Comments:",
-        ].join("\n") + "\n";
-        const content = pr.comments
-          .map((c, i) => `[${i + 1}] @${c.author} (${c.createdAt.slice(0, 10)}):\n${c.body}`)
-          .join("\n\n");
-        try {
-          await api.sendWorktreePrompt(selectedBranch, normalizeTextForPrompt(content, 20000), preamble);
-        } catch (err) {
-          console.error("Failed to send reviews prompt:", err);
-        }
-      }}
+      onreviewsclick={(pr) => (commentReviewPr = pr)}
     />
 
     {#if canConnect}
@@ -397,6 +381,18 @@
     onclose={() => (ciDetailsPr = null)}
     onfixsuccess={() => {
       ciDetailsPr = null;
+      setTimeout(() => terminalRef?.sendInput("\r"), ENTER_DELAY_MS);
+    }}
+  />
+{/if}
+
+{#if commentReviewPr}
+  <CommentReviewDialog
+    pr={commentReviewPr}
+    branch={selectedWorktree?.branch ?? ""}
+    onclose={() => (commentReviewPr = null)}
+    onsendsuccess={() => {
+      commentReviewPr = null;
       setTimeout(() => terminalRef?.sendInput("\r"), ENTER_DELAY_MS);
     }}
   />

--- a/frontend/src/lib/CommentReviewDialog.svelte
+++ b/frontend/src/lib/CommentReviewDialog.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import { SvelteSet } from "svelte/reactivity";
+  import type { PrEntry } from "./types";
+  import { sendWorktreePrompt } from "./api";
+  import { normalizeTextForPrompt } from "./promptUtils";
+
+  let {
+    pr,
+    branch,
+    onclose,
+    onsendsuccess,
+  }: {
+    pr: PrEntry;
+    branch: string;
+    onclose: () => void;
+    onsendsuccess: () => void;
+  } = $props();
+
+  let dialogEl: HTMLDialogElement;
+  let selected = new SvelteSet(pr.comments.map((_, i) => i));
+  let sending = $state(false);
+  let sendError = $state("");
+
+  $effect(() => {
+    dialogEl?.showModal();
+  });
+
+  let label = $derived(
+    pr.repo ? `${pr.repo} #${pr.number}` : `PR #${pr.number}`,
+  );
+  let allSelected = $derived(selected.size === pr.comments.length);
+  let noneSelected = $derived(selected.size === 0);
+
+  function toggleAll(): void {
+    if (allSelected) {
+      selected.clear();
+    } else {
+      for (let i = 0; i < pr.comments.length; i++) selected.add(i);
+    }
+  }
+
+  function toggleOne(index: number): void {
+    if (selected.has(index)) {
+      selected.delete(index);
+    } else {
+      selected.add(index);
+    }
+  }
+
+  async function handleSend(): Promise<void> {
+    if (!branch || noneSelected) return;
+    sending = true;
+    sendError = "";
+    const preamble =
+      [
+        "Review the PR comments and elaborate a plan to address them.",
+        `PR: ${label}`,
+        "",
+        "Comments:",
+      ].join("\n") + "\n";
+    const content = pr.comments
+      .filter((_, i) => selected.has(i))
+      .map(
+        (c, i) =>
+          `[${i + 1}] @${c.author} (${c.createdAt.slice(0, 10)}):\n${c.body}`,
+      )
+      .join("\n\n");
+    try {
+      await sendWorktreePrompt(
+        branch,
+        normalizeTextForPrompt(content, 20000),
+        preamble,
+      );
+      onsendsuccess();
+    } catch (err) {
+      sendError = err instanceof Error ? err.message : String(err);
+    } finally {
+      sending = false;
+    }
+  }
+
+  const btn =
+    "px-3 py-1.5 rounded-md border border-edge bg-surface text-primary text-xs cursor-pointer hover:bg-hover";
+  const linkBtn =
+    "text-[11px] text-accent cursor-pointer bg-transparent border-none p-0 hover:underline disabled:opacity-50 disabled:cursor-not-allowed";
+  const ctaBtn =
+    "text-[11px] font-semibold text-white bg-accent border border-accent px-2.5 py-1 rounded-md cursor-pointer hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed";
+</script>
+
+<dialog
+  bind:this={dialogEl}
+  {onclose}
+  class="bg-sidebar text-primary border border-edge rounded-xl p-6 max-w-[560px] w-[90%]"
+>
+  <h2 class="text-base mb-4">PR Comments &mdash; {label}</h2>
+
+  <div class="flex items-center justify-between mb-3">
+    <button type="button" class={linkBtn} onclick={toggleAll}>
+      {allSelected ? "Deselect all" : "Select all"}
+    </button>
+    <span class="text-[11px] text-muted">
+      {selected.size} of {pr.comments.length} selected
+    </span>
+  </div>
+
+  <ul class="list-none p-0 m-0 flex flex-col gap-2 mb-4 max-h-[400px] overflow-y-auto">
+    {#each pr.comments as comment, i (i)}
+      <li class="rounded-md border border-edge bg-surface p-3">
+        <label class="flex items-start gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={selected.has(i)}
+            onchange={() => toggleOne(i)}
+            class="mt-0.5 accent-accent"
+          />
+          <div class="flex-1 min-w-0">
+            <div class="text-[12px] text-muted mb-1">
+              <span class="font-medium text-primary">@{comment.author}</span>
+              &middot; {comment.createdAt.slice(0, 10)}
+            </div>
+            <pre class="text-[11px] font-mono whitespace-pre-wrap m-0 text-primary/80">{comment.body}</pre>
+          </div>
+        </label>
+      </li>
+    {/each}
+  </ul>
+
+  {#if sendError}
+    <div class="text-[12px] text-danger mb-3">{sendError}</div>
+  {/if}
+
+  <div class="flex justify-end gap-2">
+    <button type="button" class={btn} onclick={onclose}>Cancel</button>
+    <button
+      type="button"
+      class={ctaBtn}
+      disabled={noneSelected || sending}
+      onclick={handleSend}
+    >
+      {sending ? "Sending..." : `Send ${selected.size} to agent`}
+    </button>
+  </div>
+</dialog>


### PR DESCRIPTION
## Summary
- New `CommentReviewDialog` component that opens when clicking the ReviewsBadge, showing all PR comments with checkboxes
- Users can select/deselect individual comments or toggle all, then send only chosen comments to the agent
- Replaces the previous inline handler that sent all comments immediately without user review

## Test plan
- [ ] Click the comments badge → dialog opens with all comments listed and pre-selected
- [ ] Toggle individual checkboxes → selection count updates, Send button text updates
- [ ] Click "Select all" / "Deselect all" → toggles all checkboxes
- [ ] With none selected → Send button is disabled
- [ ] Click Send → only selected comments sent to agent, dialog closes, terminal receives Enter
- [ ] Click Cancel or backdrop → dialog closes without sending

🤖 Generated with [Claude Code](https://claude.com/claude-code)