### PR TITLE
Cap worktree name width at 90%

### DIFF
--- a/frontend/src/lib/WorktreeList.svelte
+++ b/frontend/src/lib/WorktreeList.svelte
@@ -35,9 +35,9 @@
         onclick={() => onselect(wt.branch)}
       >
         <span class="flex items-center gap-1.5 pr-5 flex-wrap">
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 max-w-[90%] min-w-0">
             <span class="font-medium truncate">{wt.branch}</span>
-            <AgentStatusIcon status={wt.agent} size={14} />
+            <span class="shrink-0"><AgentStatusIcon status={wt.agent} size={14} /></span>
           </div>
           {#each wt.prs as pr (pr.repo)}
             <PrBadge {pr} />


### PR DESCRIPTION
## Summary
- Limits the worktree name + status icon container to 90% of the row width
- Long branch names now truncate with ellipsis instead of overflowing

## Test plan
- [ ] Verify long worktree names show "..." truncation
- [ ] Verify status icon remains visible next to truncated names
- [ ] Verify PR badges still render correctly beside the name container

🤖 Generated with [Claude Code](https://claude.com/claude-code)