### PR TITLE
Fix terminal sessions killed when running multiple dashboards

### DIFF
--- a/backend/src/__tests__/terminal.test.ts
+++ b/backend/src/__tests__/terminal.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { parseTmuxSessionForWorktree } from "../terminal";
+
+describe("parseTmuxSessionForWorktree", () => {
+  it("finds the exact worktree window in its session", () => {
+    const output = [
+      "main-session:bash",
+      "workmux:wm-my-branch",
+      "workmux:wm-other-branch",
+    ].join("\n");
+    expect(parseTmuxSessionForWorktree(output, "my-branch")).toBe("workmux");
+  });
+
+  it("skips wm-dash-* viewer sessions even if they have the window", () => {
+    const output = [
+      "wm-dash-5111-1:wm-my-branch",
+      "wm-dash-5222-2:wm-my-branch",
+      "real-session:wm-my-branch",
+    ].join("\n");
+    expect(parseTmuxSessionForWorktree(output, "my-branch")).toBe("real-session");
+  });
+
+  it("falls back to any non-viewer session with a wm-* window", () => {
+    const output = [
+      "wm-dash-5111-1:wm-other",
+      "workmux:wm-other",
+    ].join("\n");
+    expect(parseTmuxSessionForWorktree(output, "missing-branch")).toBe("workmux");
+  });
+
+  it("returns null when only viewer sessions have wm-* windows", () => {
+    const output = [
+      "wm-dash-5111-1:wm-my-branch",
+      "wm-dash-5222-2:wm-other",
+    ].join("\n");
+    expect(parseTmuxSessionForWorktree(output, "my-branch")).toBeNull();
+  });
+
+  it("returns null when no wm-* windows exist", () => {
+    const output = [
+      "main:bash",
+      "other:vim",
+    ].join("\n");
+    expect(parseTmuxSessionForWorktree(output, "my-branch")).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseTmuxSessionForWorktree("", "my-branch")).toBeNull();
+  });
+
+  it("prefers exact match over fallback", () => {
+    const output = [
+      "session-a:wm-other-branch",
+      "session-b:wm-my-branch",
+    ].join("\n");
+    expect(parseTmuxSessionForWorktree(output, "my-branch")).toBe("session-b");
+  });
+});

--- a/backend/src/terminal.ts
+++ b/backend/src/terminal.ts
@@ -86,37 +86,51 @@ function killTmuxSession(name: string): void {
   }
 }
 
+/**
+ * Pure: parse `tmux list-windows -a` output to find the session owning
+ * a worktree window.  Skips wm-dash-* viewer sessions.
+ * Returns the session name, or null if not found.
+ */
+export function parseTmuxSessionForWorktree(
+  tmuxOutput: string,
+  worktreeName: string,
+): string | null {
+  const windowName = `wm-${worktreeName}`;
+  const lines = tmuxOutput.trim().split("\n").filter(Boolean);
+  // First pass: exact window match, skip viewer sessions
+  for (const line of lines) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const session = line.slice(0, colonIdx);
+    const name = line.slice(colonIdx + 1);
+    if (name === windowName && !session.startsWith("wm-dash-")) {
+      return session;
+    }
+  }
+  // Fallback: any non-viewer session with a wm-* window
+  for (const line of lines) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const session = line.slice(0, colonIdx);
+    const name = line.slice(colonIdx + 1);
+    if (name.startsWith("wm-") && !session.startsWith("wm-dash-")) {
+      return session;
+    }
+  }
+  return null;
+}
+
 /** Find the tmux session that owns the window for a given worktree.
  *  Skips wm-dash-* grouped/viewer sessions to find the real workmux session. */
 async function findTmuxSessionForWorktree(worktreeName: string): Promise<string> {
-  const windowName = `wm-${worktreeName}`;
   try {
     const proc = Bun.spawn(
       ["tmux", "list-windows", "-a", "-F", "#{session_name}:#{window_name}"],
       { stdout: "pipe", stderr: "pipe" },
     );
     if (await proc.exited !== 0) return "0";
-    const output = (await new Response(proc.stdout).text()).trim();
-    // First pass: look for the exact window, skipping viewer sessions
-    for (const line of output.split("\n")) {
-      const colonIdx = line.indexOf(":");
-      if (colonIdx === -1) continue;
-      const session = line.slice(0, colonIdx);
-      const name = line.slice(colonIdx + 1);
-      if (name === windowName && !session.startsWith("wm-dash-")) {
-        return session;
-      }
-    }
-    // Fallback: any non-viewer session with a wm-* window
-    for (const line of output.split("\n")) {
-      const colonIdx = line.indexOf(":");
-      if (colonIdx === -1) continue;
-      const session = line.slice(0, colonIdx);
-      const name = line.slice(colonIdx + 1);
-      if (name.startsWith("wm-") && !session.startsWith("wm-dash-")) {
-        return session;
-      }
-    }
+    const output = await new Response(proc.stdout).text();
+    return parseTmuxSessionForWorktree(output, worktreeName) ?? "0";
   } catch {
     // No tmux server running
   }

--- a/backend/src/workmux.ts
+++ b/backend/src/workmux.ts
@@ -471,17 +471,3 @@ export async function mergeWorktree(name: string): Promise<{ ok: true; output: s
   return { ok: true, output: result.stdout };
 }
 
-export async function getTmuxSession(): Promise<string> {
-  try {
-    const result = await $`tmux list-windows -a -F "#{session_name}:#{window_name}"`.text();
-    for (const line of result.trim().split("\n")) {
-      const [session, window] = line.split(":");
-      if (window?.startsWith("wm-")) {
-        return session!;
-      }
-    }
-  } catch {
-    // No tmux server running
-  }
-  return "0";
-}


### PR DESCRIPTION
## Summary

- **Scope tmux session names by `DASHBOARD_PORT`** (`wm-dash-5111-1` vs `wm-dash-5222-1`) so `cleanupStaleSessions()` and counter-based naming don't collide across dashboard instances
- **Replace `getTmuxSession()` with `findTmuxSessionForWorktree()`** which finds the exact `wm-{worktreeName}` window and skips `wm-dash-*` viewer sessions, preventing cross-repo session targeting

## Test plan

- [ ] Start dashboards for two repos on different ports
- [ ] Verify `tmux list-sessions` shows port-scoped names (e.g. `wm-dash-5111-1`, `wm-dash-5222-1`)
- [ ] Restart one backend — the other dashboard's terminal should stay alive
- [ ] Switch between dashboards — both should keep their terminal sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)