### PR TITLE
Fix tmux panes not filling dashboard on larger screens

### DIFF
--- a/backend/src/terminal.ts
+++ b/backend/src/terminal.ts
@@ -34,6 +34,7 @@ function buildAttachCmd(opts: AttachCmdOptions): string {
   const paneTarget = `${opts.gName}:${windowTarget}.${opts.initialPane ?? 0}`;
   return [
     `tmux new-session -d -s "${opts.gName}" -t "${opts.tmuxSession}"`,
+    `tmux set-option -t "${opts.tmuxSession}" window-size latest`,
     `tmux set-option -t "${opts.gName}" mouse on`,
     `tmux set-option -t "${opts.gName}" set-clipboard on`,
     `tmux select-window -t "${opts.gName}:${windowTarget}"`,


### PR DESCRIPTION
## Summary

- Set `window-size latest` on the main tmux session in `buildAttachCmd` so tmux sizes shared windows to the most recently active client instead of the smallest one
- Fixes the tmux dot-fill pattern that appeared when the dashboard was opened on a larger screen than the one used to create the worktree

## Test plan

- [ ] Create a worktree while the terminal is on a small window/screen
- [ ] Open the dashboard in a larger browser window
- [ ] Confirm terminal panes fill the entire xterm.js viewport with no dot-fill
- [ ] Resize the browser — confirm panes resize accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)