### PR TITLE
Make sandbox RPC forward any workmux command

### DIFF
--- a/backend/src/docker.ts
+++ b/backend/src/docker.ts
@@ -67,9 +67,7 @@ host = os.environ.get("WORKMUX_RPC_HOST", "host.docker.internal")
 port = os.environ.get("WORKMUX_RPC_PORT", "5111")
 token = os.environ.get("WORKMUX_RPC_TOKEN", "")
 
-payload = {"command": cmd}
-if args:
-    payload["name"] = args[0]
+payload = {"command": cmd, "args": args}
 data = json.dumps(payload).encode()
 req = urllib.request.Request(
     f"http://{host}:{port}/rpc/workmux",

--- a/backend/src/rpc.ts
+++ b/backend/src/rpc.ts
@@ -1,16 +1,12 @@
-import { listWorktrees, getStatus, mergeWorktree, removeWorktree } from "./workmux";
 import { loadRpcSecret } from "./rpc-secret";
 import { jsonResponse } from "./http";
 
-type RpcRequest =
-  | { command: "list" }
-  | { command: "status" }
-  | { command: "merge"; name: string }
-  | { command: "rm"; name: string }
+interface RpcRequest {
+  command: string;
+  args?: string[];
+}
 
 type RpcResponse = { ok: true; output: string } | { ok: false; error: string }
-
-const VALID_NAME_RE = /^[a-zA-Z0-9._\/-]+$/;
 
 export async function handleWorkmuxRpc(req: Request): Promise<Response> {
   const secret = await loadRpcSecret();
@@ -20,44 +16,33 @@ export async function handleWorkmuxRpc(req: Request): Promise<Response> {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  let raw: { command?: string; name?: string };
+  let raw: RpcRequest;
   try {
-    raw = await req.json() as { command?: string; name?: string };
+    raw = await req.json() as RpcRequest;
   } catch {
     return jsonResponse({ ok: false, error: "Invalid JSON" } satisfies RpcResponse, 400);
   }
 
-  const { command, name } = raw;
-
-  if (name && !VALID_NAME_RE.test(name)) {
-    return jsonResponse({ ok: false, error: "Invalid name" } satisfies RpcResponse, 400);
+  const { command, args = [] } = raw;
+  if (!command) {
+    return jsonResponse({ ok: false, error: "Missing command" } satisfies RpcResponse, 400);
   }
 
   try {
-    switch (command) {
-      case "list": {
-        const result = await listWorktrees();
-        return jsonResponse({ ok: true, output: JSON.stringify(result) } satisfies RpcResponse);
-      }
-      case "status": {
-        const result = await getStatus();
-        return jsonResponse({ ok: true, output: JSON.stringify(result) } satisfies RpcResponse);
-      }
-      case "merge": {
-        if (!name) return jsonResponse({ ok: false, error: "Missing name" } satisfies RpcResponse, 400);
-        const result = await mergeWorktree(name);
-        if (!result.ok) return jsonResponse({ ok: false, error: result.error } satisfies RpcResponse, 422);
-        return jsonResponse({ ok: true, output: result.output } satisfies RpcResponse);
-      }
-      case "rm": {
-        if (!name) return jsonResponse({ ok: false, error: "Missing name" } satisfies RpcResponse, 400);
-        const result = await removeWorktree(name);
-        if (!result.ok) return jsonResponse({ ok: false, error: result.error } satisfies RpcResponse, 422);
-        return jsonResponse({ ok: true, output: result.output } satisfies RpcResponse);
-      }
-      default:
-        return jsonResponse({ ok: false, error: `Unknown command: ${command ?? ""}` } satisfies RpcResponse, 400);
+    const proc = Bun.spawn(["workmux", command, ...args], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    if (exitCode !== 0) {
+      return jsonResponse({ ok: false, error: stderr.trim() || `exit code ${exitCode}` } satisfies RpcResponse, 422);
     }
+    return jsonResponse({ ok: true, output: stdout.trim() } satisfies RpcResponse);
   } catch (err: unknown) {
     const error = err instanceof Error ? err.message : String(err);
     return jsonResponse({ ok: false, error } satisfies RpcResponse, 500);


### PR DESCRIPTION
## Summary
- Replace hardcoded 4-command RPC switch (`list`, `status`, `merge`, `rm`) with generic `Bun.spawn(["workmux", command, ...args])` passthrough
- Update in-container Python stub to send all CLI args as an array instead of just `name`
- Array-form spawn (no shell) prevents command injection without needing regex validation

## Test plan
- [ ] Launch a sandbox container and run `workmux list` from inside — verify it returns worktree list
- [ ] Run `workmux status` from inside container — verify it returns status
- [ ] Run `workmux merge <name>` / `workmux rm <name>` — verify they still work
- [ ] Run a previously unsupported command like `workmux send` — verify it now works via RPC
- [ ] Verify invalid commands return a proper error

🤖 Generated with [Claude Code](https://claude.com/claude-code)