### PR TITLE
Fix tmux resize targeting wrong window due to race condition

### DIFF
--- a/backend/src/terminal.ts
+++ b/backend/src/terminal.ts
@@ -267,7 +267,8 @@ export function write(worktreeName: string, data: string): void {
 export async function resize(worktreeName: string, cols: number, rows: number): Promise<void> {
   const session = sessions.get(worktreeName);
   if (!session) return;
-  const result = await asyncTmux(["tmux", "resize-window", "-t", session.groupedSessionName, "-x", String(cols), "-y", String(rows)]);
+  const windowTarget = `${session.groupedSessionName}:wm-${worktreeName}`;
+  const result = await asyncTmux(["tmux", "resize-window", "-t", windowTarget, "-x", String(cols), "-y", String(rows)]);
   if (result.exitCode !== 0) console.warn(`[term:${ts()}] resize failed: ${result.stderr}`);
 }
 


### PR DESCRIPTION
## Summary
- `resize()` in `terminal.ts` targeted the grouped session's **active window** (`-t sessionName`), but the subprocess that selects the correct window (`tmux select-window`) may not have finished yet due to a race condition
- This caused the wrong window (e.g. `zsh`) to be resized, and as a side effect set `window-size manual` on the session, preventing auto-resize when the client eventually attached
- Fix: target the specific window directly (`-t sessionName:wm-worktreeName`) so the resize is correct regardless of subprocess timing

## Test plan
- [ ] Open a dashboard with multiple worktrees
- [ ] Switch between worktrees and verify panes fill the full terminal area without tmux dots
- [ ] Resize the browser window and verify panes resize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)