### PR TITLE
Remove arrow key navigation from new worktree dialog

### DIFF
--- a/frontend/src/lib/CreateWorktreeDialog.svelte
+++ b/frontend/src/lib/CreateWorktreeDialog.svelte
@@ -43,17 +43,6 @@
     }
   });
 
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
-      e.preventDefault();
-      const idx = profiles.findIndex((p) => p.name === profile);
-      const next = e.key === "ArrowDown"
-        ? (idx + 1) % profiles.length
-        : (idx - 1 + profiles.length) % profiles.length;
-      profile = profiles[next].name;
-    }
-  }
-
   const btn =
     "px-3 py-1.5 rounded-md border border-edge bg-surface text-primary text-xs cursor-pointer hover:bg-hover";
 </script>
@@ -61,7 +50,6 @@
 <dialog
   bind:this={dialogEl}
   onclose={oncancel}
-  onkeydown={handleKeydown}
   class="bg-sidebar text-primary border border-edge rounded-xl p-6 max-w-[380px] w-[90%]"
 >
   <form


### PR DESCRIPTION
## Summary
- Remove the `handleKeydown` function and `onkeydown` handler from `CreateWorktreeDialog` that allowed cycling through profiles with arrow up/down keys

## Test plan
- [ ] Open the new worktree dialog and verify arrow keys no longer cycle through profiles
- [ ] Confirm the dialog still functions normally (profile selection via click, form submission, cancel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)