### PR TITLE
refactor: remove backend pane from default workmux profile

### DIFF
--- a/.workmux.yaml
+++ b/.workmux.yaml
@@ -40,19 +40,17 @@ panes:
       "You are running inside a git worktree managed by workmux.\n
       Pane layout (current window):\n
       - Pane 0: this pane (claude agent)\n
-      - Pane 1: backend (bun run dev)\n
-      - Pane 2: frontend (bun run dev)\n\n
-      To check logs: tmux capture-pane -t .1 -p -S -50 (backend) or tmux capture-pane -t .2 -p -S -50 (frontend).\n
-      Ports are in .env.local: DASHBOARD_PORT (backend), FRONTEND_PORT (frontend).\n\n
+      - Pane 1: frontend (bun run dev)\n\n
+      To check logs: tmux capture-pane -t .1 -p -S -50 (frontend).\n
+      The backend runs on the main worktree at port 5111.\n
+      Ports are in .env.local: FRONTEND_PORT (frontend).\n\n
       To create a worktree for a parallel subtask:\n
       workmux add -b -p PROMPT BRANCH\n
       Supply an explicit BRANCH name (kebab-case, 1-3 words, describe the change).\n
       Create one at a time — run the command, wait for completion, then create the next."
     focus: true
-  - command: 'ROOT="$(git rev-parse --show-toplevel)"; [ -f "$ROOT/.env.local" ] && source "$ROOT/.env.local"; cd "$ROOT/backend" && bun install && DASHBOARD_PORT=${DASHBOARD_PORT:-5111} bun run dev'
+  - command: 'ROOT="$(git rev-parse --show-toplevel)"; [ -f "$ROOT/.env.local" ] && source "$ROOT/.env.local"; cd "$ROOT/frontend" && bun install && DASHBOARD_PORT=5111 bun run dev'
     split: horizontal
-  - command: 'ROOT="$(git rev-parse --show-toplevel)"; [ -f "$ROOT/.env.local" ] && source "$ROOT/.env.local"; cd "$ROOT/frontend" && bun install && DASHBOARD_PORT=${DASHBOARD_PORT:-5111} bun run dev'
-    split: vertical
 
 sandbox:
   enabled: false


### PR DESCRIPTION
## Summary
Worktree sessions no longer spawn their own backend. Instead, the frontend connects to the main backend running on port 5111.

## Changes
- Removed the backend pane from `.workmux.yaml` default profile
- Frontend pane now hardcodes `DASHBOARD_PORT=5111` to connect to the main backend
- Updated Claude system prompt to reflect the new 2-pane layout (claude + frontend only)

## Test plan
- [ ] Create a new worktree with `workmux add` and verify only 2 panes are created (claude agent + frontend)
- [ ] Verify the frontend connects to the main backend at port 5111

---
Generated with [Claude Code](https://claude.com/claude-code)