### PR TITLE
fix: add passwd entry for UID 1000 in sandbox image

### DIFF
--- a/sandbox-image/Dockerfile.sandbox
+++ b/sandbox-image/Dockerfile.sandbox
@@ -58,7 +58,8 @@ RUN PUPPETEER_SKIP_DOWNLOAD=true npm i -g @mermaid-js/mermaid-cli \
        > /root/.puppeteerrc.json
 
 # ── Allow non-root UID (--user) to access tools installed in /root ───────────
-RUN chmod -R 777 /root
+RUN chmod -R 777 /root \
+    && echo "agent:x:1000:100::/root:/bin/bash" >> /etc/passwd
 
 # ── Entrypoint (run explicitly via docker exec, not on container start) ──────
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
## Summary
- Adds an `/etc/passwd` entry (`agent:x:1000:100::/root:/bin/bash`) for UID 1000 in the sandbox Dockerfile
- Fixes the `I have no name!` shell prompt and SSH failures (`No user exists for uid 1000`) when the container runs as UID 1000

## Test plan
- [ ] Rebuild the sandbox image and run a container with `--user 1000:100`
- [ ] Verify `whoami` returns `agent`
- [ ] Verify `git push` over SSH works

🤖 Generated with [Claude Code](https://claude.com/claude-code)