### PR TITLE
test: add deliberate type error to verify CI

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -4,6 +4,9 @@ export interface ServiceStatus {
   running: boolean;
 }
 
+// Deliberate type error to test CI
+const willFail: string = 42;
+
 export interface PrComment {
   author: string;
   body: string;


### PR DESCRIPTION
## Summary
Adds a deliberate type error (`const willFail: string = 42`) to `frontend/src/lib/types.ts` to verify that the CI type-check workflow correctly catches and reports type failures.

## Changes
- Added a `string = 42` type mismatch in `frontend/src/lib/types.ts` to trigger a TypeScript error

## Test plan
- [ ] Verify the "Type Check" CI workflow fails on this PR
- [ ] Confirm the error message points to the deliberate type mismatch

---
Generated with [Claude Code](https://claude.com/claude-code)