### PR TITLE
fix: bundle backend at publish time to resolve missing deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ backend/node_modules/
 backend/bun.lock
 frontend/node_modules/
 frontend/bun.lock
+backend/dist/
 frontend/dist/
 frontend/.vite/
 public/

--- a/bin/wmdev.js
+++ b/bin/wmdev.js
@@ -126,7 +126,7 @@ process.on("SIGTERM", cleanup);
 
 // ── Start ────────────────────────────────────────────────────────────────────
 
-const backendEntry = join(PKG_ROOT, "backend", "src", "server.ts");
+const backendEntry = join(PKG_ROOT, "backend", "dist", "server.js");
 const staticDir = join(PKG_ROOT, "frontend", "dist");
 
 if (!existsSync(staticDir)) {

--- a/package.json
+++ b/package.json
@@ -27,15 +27,14 @@
     "dev": "bash dev.sh",
     "start": "bun bin/wmdev.js",
     "build": "cd frontend && bun run build",
-    "prepublishOnly": "bun run build",
+    "build:backend": "bun build backend/src/server.ts --target=bun --outfile=backend/dist/server.js",
+    "prepublishOnly": "bun run build && bun run build:backend",
     "test": "bun run --cwd backend test && bun run --cwd frontend test",
     "test:coverage": "bun run --cwd backend test --coverage && bun run --cwd frontend test:coverage"
   },
   "files": [
     "bin/",
-    "backend/src/*.ts",
-    "backend/src/lib/",
-    "backend/tsconfig.json",
+    "backend/dist/",
     "frontend/dist/"
   ],
   "devDependencies": {


### PR DESCRIPTION
## Summary
- **Problem**: `wmdev` failed on global install with `Cannot find package 'yaml'` because the published package shipped raw `.ts` source — backend workspace dependencies were never installed.
- **Fix**: Bundle `backend/src/server.ts` into a single `backend/dist/server.js` via `bun build --target=bun` during `prepublishOnly`. All dependencies (currently just `yaml`) are inlined, eliminating the need to mirror them in root `package.json`.
- Local dev (`dev.sh`) is unaffected — it still runs from raw source with `bun --watch`.

## Test plan
- [ ] `bun run build:backend` produces `backend/dist/server.js`
- [ ] `bun backend/dist/server.js` starts the server correctly
- [ ] `npm pack` and inspect tarball — contains `backend/dist/server.js`, no `backend/src/`
- [ ] `bun install -g .` then `wmdev` starts without missing package errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)