### PR TITLE
fix: persist notification dot until worktree is focused

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -38,10 +38,11 @@
   const AUTO_DISMISS_MS = 4000;
   const MAX_HISTORY = 10;
 
-  let notifiedBranches = $derived(new Set(notifications.map((n) => n.branch)));
+  let notifiedBranches = $state<Set<string>>(new Set());
 
   function handleNotification(n: AppNotification): void {
     notifications = [...notifications, n];
+    notifiedBranches = new Set([...notifiedBranches, n.branch]);
     notificationHistory = [n, ...notificationHistory].slice(0, MAX_HISTORY);
     unreadCount++;
     // Auto-dismiss after timeout
@@ -313,6 +314,7 @@
         {notifiedBranches}
         onselect={(b) => {
           selectedBranch = b;
+          notifiedBranches = new Set([...notifiedBranches].filter((x) => x !== b));
           if (isMobile) sidebarOpen = false;
         }}
         onremove={(b) => (removeBranch = b)}
@@ -359,6 +361,7 @@
       onbellopen={handleBellOpen}
       onnotificationselect={(branch) => {
         selectedBranch = branch;
+        notifiedBranches = new Set([...notifiedBranches].filter((x) => x !== branch));
         if (isMobile) sidebarOpen = false;
       }}
     />
@@ -453,6 +456,7 @@
   ondismiss={handleDismissNotification}
   onselect={(branch) => {
     selectedBranch = branch;
+    notifiedBranches = new Set([...notifiedBranches].filter((x) => x !== branch));
     if (isMobile) sidebarOpen = false;
   }}
 />


### PR DESCRIPTION
## Summary
Notification dots on the worktree list now persist until the user focuses that worktree, instead of disappearing when the toast auto-dismisses.

## Changes
- Changed `notifiedBranches` from `$derived` (tied to toast array) to independent `$state<Set<string>>`
- Add branch to `notifiedBranches` when a notification arrives
- Clear branch from `notifiedBranches` when user selects it (sidebar click, toast click, or bell notification click)

## Test plan
- [ ] Trigger a notification (e.g. agent stop) — toast appears and dot shows on worktree list
- [ ] Wait for toast to auto-dismiss (4s) — dot remains on the worktree list
- [ ] Click the notified worktree — dot disappears
- [ ] Click a notification in the bell dropdown — dot disappears for that branch
- [ ] Click a toast notification — dot disappears for that branch

---
Generated with [Claude Code](https://claude.com/claude-code)