### PR TITLE
fix: defer .env.local sourcing to avoid backend port race condition

### DIFF
--- a/.workmux.yaml
+++ b/.workmux.yaml
@@ -49,9 +49,9 @@ panes:
       Create one at a time — run the command, wait for completion, then create the next.\n\n
       IMPORTANT: Read docs/autonomous-mode.md before starting any work."
     focus: true
-  - command: 'ROOT="$(git rev-parse --show-toplevel)"; [ -f "$ROOT/.env.local" ] && source "$ROOT/.env.local"; cd "$ROOT/backend" && bun install && BACKEND_PORT=$BACKEND_PORT bun run dev'
+  - command: 'ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT/backend" && bun install && { until [ -f "$ROOT/.env.local" ]; do sleep 0.2; done; source "$ROOT/.env.local"; BACKEND_PORT=$BACKEND_PORT bun run dev; }'
     split: horizontal
-  - command: 'ROOT="$(git rev-parse --show-toplevel)"; [ -f "$ROOT/.env.local" ] && source "$ROOT/.env.local"; cd "$ROOT/frontend" && bun install && BACKEND_PORT=$BACKEND_PORT PORT=$FRONTEND_PORT bun run dev'
+  - command: 'ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT/frontend" && bun install && { until [ -f "$ROOT/.env.local" ]; do sleep 0.2; done; source "$ROOT/.env.local"; BACKEND_PORT=$BACKEND_PORT PORT=$FRONTEND_PORT bun run dev; }'
     split: horizontal
 
 sandbox:


### PR DESCRIPTION
## Summary
- **Root cause**: `workmux add` creates the git worktree and starts tmux panes in one call. The pane commands immediately tried to `source .env.local`, but the backend writes that file (with port allocations) only *after* `workmux add` returns — so the file didn't exist yet, `BACKEND_PORT` stayed empty, and the server fell back to default port 5111.
- **Fix**: Moved `source .env.local` to after `bun install` and added an `until` wait loop, so panes block until the file exists before sourcing it.

## Test plan
- [ ] Create a new worktree via the dashboard and verify the backend starts on the assigned port (not 5111)
- [ ] Verify the frontend also picks up the correct `BACKEND_PORT` and `FRONTEND_PORT`
- [ ] Confirm manually restarting backend/frontend in a pane still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)