### PR TITLE
feat: show externally-created worktrees in UI

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -232,7 +232,11 @@ async function apiGetWorktrees(req: Request): Promise<Response> {
   activeBranches.add("main");
   cleanupStaleWindows(activeBranches, `${PROJECT_DIR}__worktrees/`);
 
-  const merged = await Promise.all(worktrees.map(async (wt) => {
+  // Filter out the main working tree — it has no entry in wtPaths
+  // (getWorktreePaths skips the first porcelain entry).
+  const nonMainWorktrees = worktrees.filter(wt => wtPaths.has(wt.branch));
+
+  const merged = await Promise.all(nonMainWorktrees.map(async (wt) => {
     const st = status.find(s =>
       s.worktree.includes(wt.branch) || s.worktree.startsWith(wt.branch)
     );

--- a/backend/src/workmux.ts
+++ b/backend/src/workmux.ts
@@ -252,7 +252,7 @@ export async function initWorktreeEnv(
   const allPaths = [...worktreeMap.values()];
   const existingEnvs = await readAllWorktreeEnvs(allPaths, wtDir);
   const portAssignments = opts?.services ? allocatePorts(existingEnvs, opts.services) : {};
-  const defaults: Record<string, string> = { ...portAssignments, ...opts?.envOverrides, PROFILE: profile, AGENT: agent };
+  const defaults: Record<string, string> = { ...portAssignments, PROFILE: profile, AGENT: agent, ...opts?.envOverrides };
   // Only write keys that don't already exist
   const toWrite: Record<string, string> = {};
   for (const [key, value] of Object.entries(defaults)) {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -98,8 +98,8 @@
   // may not be fully flushed yet — this small delay lets it settle.
   const ENTER_DELAY_MS = 200;
 
-  let openingBranch = $state<string | null>(null);
-  let visibleWorktrees = $derived(worktrees.filter((w) => w.branch !== "main"));
+  let openingBranches = $state<Set<string>>(new Set());
+  let visibleWorktrees = $derived(worktrees);
   let selectedWorktree = $derived(
     visibleWorktrees.find((w) => w.branch === selectedBranch),
   );
@@ -346,7 +346,7 @@
         worktrees={visibleWorktrees}
         selected={selectedBranch}
         removing={removingBranches}
-        initializing={openingBranch}
+        initializing={openingBranches}
         {notifiedBranches}
         onselect={async (b) => {
           selectedBranch = b;
@@ -355,14 +355,14 @@
           // Open closed worktrees on click
           const wt = worktrees.find((w) => w.branch === b);
           if (wt && wt.mux !== "✓") {
-            openingBranch = b;
+            openingBranches = new Set([...openingBranches, b]);
             try {
               await api.openWorktree(b);
               await refresh();
             } catch (err) {
-              console.error("Failed to open worktree:", err);
+              alert(`Failed to open worktree: ${errorMessage(err)}`);
             } finally {
-              openingBranch = null;
+              openingBranches = new Set([...openingBranches].filter((x) => x !== b));
             }
           }
         }}

--- a/frontend/src/lib/WorktreeList.svelte
+++ b/frontend/src/lib/WorktreeList.svelte
@@ -16,7 +16,7 @@
     worktrees: WorktreeInfo[];
     selected: string | null;
     removing: Set<string>;
-    initializing: string | null;
+    initializing: Set<string>;
     notifiedBranches: Set<string>;
     onselect: (branch: string) => void;
     onremove: (branch: string) => void;
@@ -28,7 +28,7 @@
     {@const isActive = wt.branch === selected}
     {@const isRemoving = removing.has(wt.branch)}
     {@const isClosed = wt.mux !== "✓"}
-    {@const isInitializing = initializing === wt.branch}
+    {@const isInitializing = initializing.has(wt.branch)}
     <li
       class="mb-0.5 group relative {isRemoving || isInitializing
         ? 'opacity-40 pointer-events-none'


### PR DESCRIPTION
## Summary
- **Extract `initWorktreeEnv()`** from `addWorktree()` so env/hooks initialization can be reused when opening externally-created worktrees
- **Lazy-init on open**: `apiOpenWorktree()` now checks for `.env.local` and initializes ports, profile, agent, and Claude hooks if missing
- **Show all worktrees in sidebar**: removed the `mux === "✓"` filter so CLI-created worktrees appear (dimmed with "closed" label); clicking one opens it and transitions to active

## Test plan
- [ ] Create a worktree via CLI (`workmux add -b test-branch`) — confirm it appears dimmed with "closed" label in the sidebar
- [ ] Click the closed worktree — should show "opening..." then become active with terminal
- [ ] Create a worktree via the web UI "+" button — should work as before
- [ ] Keyboard navigation (Cmd+Up/Down) works across both open and closed worktrees
- [ ] Verify backend type-checks (`npx tsc --noEmit`) and frontend type-checks (`npx svelte-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)