### PR TITLE
feat: support Shift+Enter for newline in terminal

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -19,6 +19,7 @@ import {
   write,
   resize,
   selectPane,
+  sendKeys,
   getScrollback,
   setCallbacks,
   clearCallbacks,
@@ -49,6 +50,7 @@ interface WsData {
 
 type WsInboundMessage =
   | { type: "input"; data: string }
+  | { type: "sendKeys"; hexBytes: string[] }
   | { type: "selectPane"; pane: number }
   | { type: "resize"; cols: number; rows: number; initialPane?: number };
 
@@ -67,6 +69,10 @@ function parseWsMessage(raw: string | Buffer): WsInboundMessage | null {
     switch (m.type) {
       case "input":
         return typeof m.data === "string" ? { type: "input", data: m.data } : null;
+      case "sendKeys":
+        return Array.isArray(m.hexBytes) && m.hexBytes.every((b: unknown) => typeof b === "string")
+          ? { type: "sendKeys", hexBytes: m.hexBytes as string[] }
+          : null;
       case "selectPane":
         return typeof m.pane === "number" ? { type: "selectPane", pane: m.pane } : null;
       case "resize":
@@ -503,6 +509,9 @@ Bun.serve({
       switch (msg.type) {
         case "input":
           write(worktree, msg.data);
+          break;
+        case "sendKeys":
+          await sendKeys(worktree, msg.hexBytes);
           break;
         case "selectPane":
           if (ws.data.attached) {

--- a/backend/src/terminal.ts
+++ b/backend/src/terminal.ts
@@ -263,6 +263,15 @@ export function write(worktreeName: string, data: string): void {
   }
 }
 
+/** Send raw hex bytes to the active tmux pane via `tmux send-keys -H`,
+ *  bypassing tmux's input parser (needed for CSI u sequences). */
+export async function sendKeys(worktreeName: string, hexBytes: string[]): Promise<void> {
+  const session = sessions.get(worktreeName);
+  if (!session) return;
+  const windowTarget = `${session.groupedSessionName}:wm-${worktreeName}`;
+  await asyncTmux(["tmux", "send-keys", "-t", windowTarget, "-H", ...hexBytes]);
+}
+
 export async function resize(worktreeName: string, cols: number, rows: number): Promise<void> {
   const session = sessions.get(worktreeName);
   if (!session) return;

--- a/frontend/src/lib/Terminal.svelte
+++ b/frontend/src/lib/Terminal.svelte
@@ -91,7 +91,21 @@
     // Let app-level shortcuts (Cmd+Arrow, Cmd+K, Cmd+M, Cmd+D) bubble up
     // instead of being consumed by xterm.  Return false → xterm ignores the event.
     term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+      // Shift+Enter: send CSI u escape sequence so apps like Claude Code
+      // can distinguish it from plain Enter (xterm.js sends \r for both).
+      // Block all event types (keydown, keypress, keyup) to prevent xterm
+      // from also emitting \r on the keypress phase.
+      if (e.key === "Enter" && e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (e.type === "keydown" && ws.readyState === WebSocket.OPEN) {
+          // CSI u for Shift+Enter: \x1b[13;2u = hex 1b 5b 31 33 3b 32 75
+          // Use sendKeys (tmux send-keys -H) to bypass tmux's input parser
+          ws.send(JSON.stringify({ type: "sendKeys", hexBytes: ["1b", "5b", "31", "33", "3b", "32", "75"] }));
+        }
+        return false;
+      }
+
       if (e.type !== "keydown") return true;
+
       const mod = e.metaKey || e.ctrlKey;
       if (mod && (e.key === "c" || e.key === "C")) {
         if (term.hasSelection()) {


### PR DESCRIPTION
## Summary
Shift+Enter now inserts a newline in terminal apps like Claude Code from the web UI. Previously, xterm.js sent the same `\r` for both Enter and Shift+Enter, so the modifier was lost. The fix intercepts Shift+Enter on the frontend and uses `tmux send-keys -H` to inject the CSI u escape sequence (`\x1b[13;2u`) directly to the active pane, bypassing tmux's input parser.

## Changes
- **Frontend** (`Terminal.svelte`): Intercept Shift+Enter in the custom key event handler, send a `sendKeys` WebSocket message with the CSI u hex bytes, and block all event phases (keydown/keypress/keyup) to prevent xterm's default `\r`
- **Backend** (`terminal.ts`): Add `sendKeys()` function that runs `tmux send-keys -H` to inject raw bytes directly to the tmux pane
- **Backend** (`server.ts`): Add `sendKeys` WebSocket message type and handler

## Test plan
- [ ] Open a worktree with Claude Code running, press Shift+Enter — should insert a newline
- [ ] Press Enter — should still submit as before
- [ ] Verify no double newlines on Shift+Enter

---
Generated with [Claude Code](https://claude.com/claude-code)