### PR TITLE
fix: escape single quotes in .env.local values for bash sourcing

### DIFF
--- a/backend/src/__tests__/env.test.ts
+++ b/backend/src/__tests__/env.test.ts
@@ -132,6 +132,28 @@ describe("writeEnvLocal / readEnvLocal round-trip", () => {
     expect(stdout.trim()).toBe(json);
   });
 
+  it("escapes single quotes in values so bash can source them", async () => {
+    const json = JSON.stringify([{ body: "centdix's task (done)" }]);
+    await writeEnvLocal(dir, { PR_DATA: json });
+
+    // Verify round-trip through readEnvLocal
+    const env = await readEnvLocal(dir);
+    expect(env.PR_DATA).toBe(json);
+
+    // Verify bash can source the file without error
+    const proc = Bun.spawn(["bash", "-c", `source "${dir}/.env.local" && echo "$PR_DATA"`], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    await proc.exited;
+
+    expect(proc.exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(json);
+  });
+
   it("upserts existing keys preserving quoting", async () => {
     await writeEnvLocal(dir, { PORT: "3000", PR_DATA: '{"old":true}' });
     await writeEnvLocal(dir, { PR_DATA: '{"new":true}' });

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -11,7 +11,7 @@ export async function readEnvLocal(wtDir: string): Promise<Record<string, string
         let val = match[2];
         // Strip surrounding single quotes (written by writeEnvLocal for complex values)
         if (val.length >= 2 && val.startsWith("'") && val.endsWith("'")) {
-          val = val.slice(1, -1);
+          val = val.slice(1, -1).replaceAll("'\\''", "'");
         }
         env[match[1]] = val;
       }
@@ -35,8 +35,11 @@ export async function writeEnvLocal(wtDir: string, entries: Record<string, strin
 
   for (const [key, value] of Object.entries(entries)) {
     // Single-quote values that contain characters unsafe for bare shell assignment
-    const needsQuoting = /[{}"\s$`\\!#|;&()<>]/.test(value);
-    const safe = needsQuoting ? `'${value}'` : value;
+    const needsQuoting = /[{}"\s$`\\!#|;&()<>']/.test(value);
+    // In bash, single quotes cannot contain single quotes, so we use the
+    // '\'' idiom: end the current single-quoted string, insert an escaped
+    // single quote, and start a new single-quoted string.
+    const safe = needsQuoting ? `'${value.replaceAll("'", "'\\''")}'` : value;
     const pattern = new RegExp(`^${key}=`);
     const idx = lines.findIndex((l) => pattern.test(l));
     if (idx >= 0) {


### PR DESCRIPTION
## Summary
Fix `workmux remove` failing with a bash syntax error when `.env.local` contains values with single quotes (e.g., PR_DATA JSON with apostrophes like `centdix's task`).

## Changes
- `writeEnvLocal`: added `'` to the quoting-detection regex and escape single quotes within values using the bash `'\''` idiom before wrapping in single quotes
- `readEnvLocal`: reverse the `'\''` escape when stripping surrounding quotes
- Added test verifying round-trip and bash-sourcing of values containing single quotes

## Test plan
- [ ] `bun test src/__tests__/env.test.ts` — all 14 tests pass
- [ ] Create a worktree with PR_DATA containing an apostrophe, then `workmux remove` it successfully

---
Generated with [Claude Code](https://claude.com/claude-code)