### PR TITLE
fix: probe both IPv4 and IPv6 in service port health check

### DIFF
--- a/backend/src/adapters/port-probe.ts
+++ b/backend/src/adapters/port-probe.ts
@@ -5,36 +5,53 @@ export interface PortProbe {
 export class BunPortProbe implements PortProbe {
   constructor(
     private readonly timeoutMs = 300,
-    private readonly hostname = "127.0.0.1",
+    private readonly hostnames: readonly string[] = ["127.0.0.1", "::1"],
   ) {}
 
   isListening(port: number): Promise<boolean> {
     return new Promise((resolve) => {
       let settled = false;
+      let pending = this.hostnames.length;
 
       const settle = (result: boolean): void => {
         if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve(result);
+        if (result) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(true);
+          return;
+        }
+        pending--;
+        if (pending === 0) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(false);
+        }
       };
 
-      const timer = setTimeout(() => settle(false), this.timeoutMs);
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          resolve(false);
+        }
+      }, this.timeoutMs);
 
-      Bun.connect({
-        hostname: this.hostname,
-        port,
-        socket: {
-          open(socket) {
-            socket.end();
-            settle(true);
+      for (const hostname of this.hostnames) {
+        Bun.connect({
+          hostname,
+          port,
+          socket: {
+            open(socket) {
+              socket.end();
+              settle(true);
+            },
+            error() {
+              settle(false);
+            },
+            data() {},
           },
-          error() {
-            settle(false);
-          },
-          data() {},
-        },
-      }).catch(() => settle(false));
+        }).catch(() => settle(false));
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
Service badge in the UI stayed gray for servers binding to IPv6 (`::1`) because the port probe only checked IPv4 (`127.0.0.1`). This is common with Docusaurus and other Node.js-based dev servers on modern systems.

## Changes
- `BunPortProbe` now probes both `127.0.0.1` (IPv4) and `::1` (IPv6) in parallel
- First successful connection resolves `true` immediately; only resolves `false` if both fail or timeout
- No increase in timeout budget since both probes run concurrently within the same 300ms window

## Test plan
- [ ] Start a dev server that binds to IPv6 only (e.g. Docusaurus) and verify the service badge turns green
- [ ] Start a dev server that binds to IPv4 only and verify it still works
- [ ] Verify no regression for servers binding to `0.0.0.0`

---
Generated with [Claude Code](https://claude.com/claude-code)