### PR TITLE
fix: handle missing direnv binary in lifecycle hook runner

### DIFF
--- a/backend/src/adapters/hooks.ts
+++ b/backend/src/adapters/hooks.ts
@@ -25,7 +25,11 @@ function buildErrorMessage(
 }
 
 function hasDirenv(): boolean {
-  return Bun.spawnSync(["direnv", "version"], { stdout: "pipe", stderr: "pipe" }).exitCode === 0;
+  try {
+    return Bun.spawnSync(["direnv", "version"], { stdout: "pipe", stderr: "pipe" }).exitCode === 0;
+  } catch {
+    return false;
+  }
 }
 
 export class BunLifecycleHookRunner implements LifecycleHookRunner {


### PR DESCRIPTION
## Summary
- `Bun.spawnSync()` throws when the binary doesn't exist in `$PATH`, unlike Node's `spawnSync` which returns a non-zero exit code
- The `hasDirenv()` check in the lifecycle hook runner was not catching this exception, causing worktree creation to fail for users without direnv installed
- Wrapped the spawn call in a try-catch so missing direnv correctly returns `false`

## Test plan
- [ ] Create a worktree on a machine without direnv installed — should succeed without errors
- [ ] Create a worktree on a machine with direnv installed — direnv integration should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)