### PR TITLE
feat: use claude/codex CLI for auto-name generation

### DIFF
--- a/.webmux.yaml
+++ b/.webmux.yaml
@@ -6,7 +6,7 @@ workspace:
   defaultAgent: claude
 
 auto_name:
-  model: gemini-2.5-flash-lite
+  provider: claude
 
 startupEnvs:
   NODE_ENV: development

--- a/backend/src/__tests__/auto-name-service.test.ts
+++ b/backend/src/__tests__/auto-name-service.test.ts
@@ -1,190 +1,166 @@
 import { describe, expect, it } from "bun:test";
 import { AutoNameService } from "../services/auto-name-service";
 
+function fakeSpawn(stdout: string, exitCode = 0, stderr = "") {
+  const calls: string[][] = [];
+  const spawnImpl = async (args: string[]) => {
+    calls.push(args);
+    return { exitCode, stdout, stderr };
+  };
+  return { calls, spawnImpl };
+}
+
 describe("AutoNameService", () => {
-  it("calls Anthropic's messages API for claude models", async () => {
-    let calledUrl = "";
-    let calledInit: RequestInit | undefined;
-    const service = new AutoNameService({
-      anthropicApiKey: "anthropic-key",
-      fetchImpl: async (url, init) => {
-        calledUrl = String(url);
-        calledInit = init;
-        return new Response(JSON.stringify({
-          content: [{ type: "text", text: "{\"branch_name\":\"fix-login-flow\"}" }],
-        }));
-      },
-    });
+  it("spawns claude -p with correct args", async () => {
+    const { calls, spawnImpl } = fakeSpawn("fix-login-flow");
+    const service = new AutoNameService({ spawnImpl });
 
     const branch = await service.generateBranchName(
-      {
-        model: "claude-3-5-haiku-latest",
-        systemPrompt: "Generate a branch name",
-      },
+      { provider: "claude", systemPrompt: "Generate a branch name" },
       "Fix the login flow",
     );
 
     expect(branch).toBe("fix-login-flow");
-    expect(calledUrl).toBe("https://api.anthropic.com/v1/messages");
-    expect(calledInit?.headers).toEqual({
-      "content-type": "application/json",
-      "x-api-key": "anthropic-key",
-      "anthropic-version": "2023-06-01",
-    });
-    expect(JSON.parse(String(calledInit?.body))).toEqual({
-      model: "claude-3-5-haiku-latest",
-      system: "Generate a branch name",
-      max_tokens: 64,
-      messages: [{ role: "user", content: "Task description:\nFix the login flow" }],
-      output_config: {
-        format: {
-          type: "json_schema",
-          schema: {
-            type: "object",
-            properties: {
-              branch_name: {
-                type: "string",
-                description: "A lowercase kebab-case git branch name with no prefix",
-              },
-            },
-            required: ["branch_name"],
-            additionalProperties: false,
-          },
-        },
-      },
-    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([
+      "claude", "-p",
+      "--system-prompt", "Generate a branch name",
+      "--output-format", "text",
+      "--no-session-persistence",
+      "Task description:\nFix the login flow",
+    ]);
   });
 
-  it("calls Google's generateContent API for gemini models", async () => {
-    let calledUrl = "";
-    let calledInit: RequestInit | undefined;
-    const service = new AutoNameService({
-      geminiApiKey: "gemini-key",
-      fetchImpl: async (url, init) => {
-        calledUrl = String(url);
-        calledInit = init;
-        return new Response(JSON.stringify({
-          candidates: [
-            {
-              content: {
-                parts: [{ text: "{\"branch_name\":\"improve-search-ranking\"}" }],
-              },
-            },
-          ],
-        }));
-      },
-    });
+  it("passes --model to claude when model is specified", async () => {
+    const { calls, spawnImpl } = fakeSpawn("add-search");
+    const service = new AutoNameService({ spawnImpl });
+
+    await service.generateBranchName(
+      { provider: "claude", model: "haiku" },
+      "Add search",
+    );
+
+    expect(calls[0]).toContain("--model");
+    expect(calls[0]).toContain("haiku");
+  });
+
+  it("omits --model from claude when model is not specified", async () => {
+    const { calls, spawnImpl } = fakeSpawn("add-search");
+    const service = new AutoNameService({ spawnImpl });
+
+    await service.generateBranchName(
+      { provider: "claude" },
+      "Add search",
+    );
+
+    expect(calls[0]).not.toContain("--model");
+  });
+
+  it("spawns codex exec with correct args", async () => {
+    const { calls, spawnImpl } = fakeSpawn("improve-search-ranking");
+    const service = new AutoNameService({ spawnImpl });
 
     const branch = await service.generateBranchName(
-      {
-        model: "gemini-2.5-flash",
-        systemPrompt: "Generate a branch name",
-      },
+      { provider: "codex", systemPrompt: "Generate a branch name" },
       "Improve search ranking",
     );
 
     expect(branch).toBe("improve-search-ranking");
-    expect(calledUrl).toBe("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent");
-    expect(calledInit?.headers).toEqual({
-      "content-type": "application/json",
-      "x-goog-api-key": "gemini-key",
-    });
-    expect(JSON.parse(String(calledInit?.body))).toEqual({
-      systemInstruction: {
-        parts: [{ text: "Generate a branch name" }],
-      },
-      contents: [
-        {
-          role: "user",
-          parts: [{ text: "Task description:\nImprove search ranking" }],
-        },
-      ],
-      generationConfig: {
-        responseMimeType: "application/json",
-        responseJsonSchema: {
-          type: "object",
-          properties: {
-            branch_name: {
-              type: "string",
-              description: "A lowercase kebab-case git branch name with no prefix",
-            },
-          },
-          required: ["branch_name"],
-          additionalProperties: false,
-          propertyOrdering: ["branch_name"],
-        },
-      },
-    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([
+      "codex",
+      "-c", 'developer_instructions="Generate a branch name"',
+      "exec",
+      "--ephemeral",
+      "Task description:\nImprove search ranking",
+    ]);
   });
 
-  it("calls OpenAI's responses API for OpenAI models", async () => {
-    let calledUrl = "";
-    let calledInit: RequestInit | undefined;
-    const service = new AutoNameService({
-      openaiApiKey: "openai-key",
-      fetchImpl: async (url, init) => {
-        calledUrl = String(url);
-        calledInit = init;
-        return new Response(JSON.stringify({
-          output: [
-            {
-              content: [{ type: "output_text", text: "{\"branch_name\":\"add-bulk-actions\"}" }],
-            },
-          ],
-        }));
-      },
-    });
+  it("passes -m to codex when model is specified", async () => {
+    const { calls, spawnImpl } = fakeSpawn("add-bulk-actions");
+    const service = new AutoNameService({ spawnImpl });
 
-    const branch = await service.generateBranchName(
-      {
-        model: "openai/gpt-5-mini",
-        systemPrompt: "Generate a branch name",
-      },
-      "Add bulk actions to the list view",
+    await service.generateBranchName(
+      { provider: "codex", model: "gpt-4.1" },
+      "Add bulk actions",
     );
 
-    expect(branch).toBe("add-bulk-actions");
-    expect(calledUrl).toBe("https://api.openai.com/v1/responses");
-    expect(calledInit?.headers).toEqual({
-      "content-type": "application/json",
-      authorization: "Bearer openai-key",
-    });
-    expect(JSON.parse(String(calledInit?.body))).toEqual({
-      model: "gpt-5-mini",
-      input: [
-        { role: "system", content: "Generate a branch name" },
-        { role: "user", content: "Task description:\nAdd bulk actions to the list view" },
-      ],
-      max_output_tokens: 64,
-      text: {
-        format: {
-          type: "json_schema",
-          name: "branch_name_response",
-          strict: true,
-          schema: {
-            type: "object",
-            properties: {
-              branch_name: {
-                type: "string",
-                description: "A lowercase kebab-case git branch name with no prefix",
-              },
-            },
-            required: ["branch_name"],
-            additionalProperties: false,
-          },
-        },
-      },
-    });
+    expect(calls[0]).toContain("-m");
+    expect(calls[0]).toContain("gpt-4.1");
   });
 
-  it("fails clearly when the matching provider key is missing", async () => {
+  it("omits -m from codex when model is not specified", async () => {
+    const { calls, spawnImpl } = fakeSpawn("add-bulk-actions");
+    const service = new AutoNameService({ spawnImpl });
+
+    await service.generateBranchName(
+      { provider: "codex" },
+      "Add bulk actions",
+    );
+
+    expect(calls[0]).not.toContain("-m");
+  });
+
+  it("uses default system prompt when none provided", async () => {
+    const { calls, spawnImpl } = fakeSpawn("fix-bug");
+    const service = new AutoNameService({ spawnImpl });
+
+    await service.generateBranchName({ provider: "claude" }, "Fix bug");
+
+    const systemPromptIdx = calls[0].indexOf("--system-prompt");
+    expect(calls[0][systemPromptIdx + 1]).toContain("Generate a concise git branch name");
+  });
+
+  it("normalizes messy output into a valid branch name", async () => {
+    const { spawnImpl } = fakeSpawn('```\n"Fix-Login-Flow"\n```');
+    const service = new AutoNameService({ spawnImpl });
+
+    const branch = await service.generateBranchName(
+      { provider: "claude" },
+      "Fix login",
+    );
+
+    expect(branch).toBe("fix-login-flow");
+  });
+
+  it("throws when CLI is not found", async () => {
     const service = new AutoNameService({
-      fetchImpl: async () => new Response("{}"),
+      spawnImpl: async () => { throw new Error("ENOENT"); },
     });
 
-    await expect(service.generateBranchName(
-      { model: "gemini-2.5-flash" },
-      "Improve search ranking",
-    )).rejects.toThrow("GEMINI_API_KEY is required");
+    await expect(
+      service.generateBranchName({ provider: "claude" }, "Fix bug"),
+    ).rejects.toThrow("'claude' CLI not found");
+  });
+
+  it("throws on non-zero exit code", async () => {
+    const { spawnImpl } = fakeSpawn("", 1, "authentication required");
+    const service = new AutoNameService({ spawnImpl });
+
+    await expect(
+      service.generateBranchName({ provider: "codex" }, "Fix bug"),
+    ).rejects.toThrow("codex failed: authentication required");
+  });
+
+  it("throws on empty output", async () => {
+    const { spawnImpl } = fakeSpawn("");
+    const service = new AutoNameService({ spawnImpl });
+
+    await expect(
+      service.generateBranchName({ provider: "claude" }, "Fix bug"),
+    ).rejects.toThrow("claude returned empty output");
+  });
+
+  it("escapes special characters in system prompt for codex TOML config", async () => {
+    const { calls, spawnImpl } = fakeSpawn("fix-bug");
+    const service = new AutoNameService({ spawnImpl });
+
+    await service.generateBranchName(
+      { provider: "codex", systemPrompt: 'Use "kebab-case"\nNo prefixes' },
+      "Fix bug",
+    );
+
+    const cIdx = calls[0].indexOf("-c");
+    expect(calls[0][cIdx + 1]).toBe('developer_instructions="Use \\"kebab-case\\"\\nNo prefixes"');
   });
 });

--- a/backend/src/__tests__/lifecycle-service.test.ts
+++ b/backend/src/__tests__/lifecycle-service.test.ts
@@ -455,7 +455,7 @@ describe("LifecycleService", () => {
       {
         ...TEST_CONFIG,
         autoName: {
-          model: "claude-3-5-haiku-latest",
+          provider: "claude" as const,
           systemPrompt: "Generate a branch name",
         },
       },
@@ -471,7 +471,7 @@ describe("LifecycleService", () => {
     expect(autoName.calls).toEqual([
       {
         config: {
-          model: "claude-3-5-haiku-latest",
+          provider: "claude",
           systemPrompt: "Generate a branch name",
         },
         task: "Fix the login flow for OAuth redirects",

--- a/backend/src/__tests__/setup.test.ts
+++ b/backend/src/__tests__/setup.test.ts
@@ -70,7 +70,7 @@ describe("loadConfig", () => {
         "  postCreate: scripts/post-create.sh",
         "  preRemove: scripts/pre-remove.sh",
         "auto_name:",
-        "  model: claude-3-5-haiku-latest",
+        "  provider: claude",
         "  system_prompt: Generate a branch name",
         "integrations:",
         "  github:",
@@ -102,7 +102,7 @@ describe("loadConfig", () => {
       preRemove: "scripts/pre-remove.sh",
     });
     expect(config.autoName).toEqual({
-      model: "claude-3-5-haiku-latest",
+      provider: "claude",
       systemPrompt: "Generate a branch name",
     });
     expect(config.integrations.github.linkedRepos).toEqual([{ repo: "acme/linked", alias: "linked" }]);

--- a/backend/src/adapters/config.ts
+++ b/backend/src/adapters/config.ts
@@ -195,10 +195,14 @@ function parseLifecycleHooks(raw: unknown): LifecycleHooksConfig {
 
 function parseAutoName(raw: unknown): AutoNameConfig | null {
   if (!isRecord(raw)) return null;
-  if (typeof raw.model !== "string" || !raw.model.trim()) return null;
+  const provider = raw.provider;
+  if (provider !== "claude" && provider !== "codex") return null;
 
   return {
-    model: raw.model.trim(),
+    provider,
+    ...(typeof raw.model === "string" && raw.model.trim()
+      ? { model: raw.model.trim() }
+      : {}),
     ...(typeof raw.system_prompt === "string" && raw.system_prompt.trim()
       ? { systemPrompt: raw.system_prompt.trim() }
       : {}),

--- a/backend/src/domain/config.ts
+++ b/backend/src/domain/config.ts
@@ -67,7 +67,8 @@ export interface LifecycleHooksConfig {
 }
 
 export interface AutoNameConfig {
-  model: string;
+  provider: "claude" | "codex";
+  model?: string;
   systemPrompt?: string;
 }
 

--- a/backend/src/services/auto-name-service.ts
+++ b/backend/src/services/auto-name-service.ts
@@ -1,31 +1,13 @@
 import type { AutoNameConfig } from "../domain/config";
 import { isValidBranchName } from "../domain/policies";
 
-type AutoNameProvider = "anthropic" | "google" | "openai";
-
-interface ResolvedAutoNameModel {
-  provider: AutoNameProvider;
-  model: string;
+interface SpawnResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
 }
 
-type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
-
-const BRANCH_NAME_SCHEMA = {
-  type: "object",
-  properties: {
-    branch_name: {
-      type: "string",
-      description: "A lowercase kebab-case git branch name with no prefix",
-    },
-  },
-  required: ["branch_name"],
-  additionalProperties: false,
-} as const;
-
-const GEMINI_BRANCH_NAME_SCHEMA = {
-  ...BRANCH_NAME_SCHEMA,
-  propertyOrdering: ["branch_name"],
-} as const;
+type SpawnLike = (args: string[]) => Promise<SpawnResult>;
 
 const DEFAULT_SYSTEM_PROMPT = [
   "Generate a concise git branch name from the task description.",
@@ -34,27 +16,8 @@ const DEFAULT_SYSTEM_PROMPT = [
   "Do not include quotes, code fences, or prefixes like feature/ or fix/.",
 ].join(" ");
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function buildPrompt(task: string): string {
   return `Task description:\n${task.trim()}`;
-}
-
-function parseBranchNamePayload(raw: unknown): string {
-  if (!isRecord(raw) || typeof raw.branch_name !== "string") {
-    throw new Error("Auto-name response did not include branch_name");
-  }
-  return raw.branch_name;
-}
-
-function parseJsonText(text: string): unknown {
-  try {
-    return JSON.parse(text);
-  } catch {
-    throw new Error(`Auto-name response was not valid JSON: ${text}`);
-  }
 }
 
 function normalizeGeneratedBranchName(raw: string): string {
@@ -78,94 +41,58 @@ function normalizeGeneratedBranchName(raw: string): string {
   return branch;
 }
 
-function resolveAutoNameModel(modelSpec: string): ResolvedAutoNameModel {
-  const trimmed = modelSpec.trim();
-  const slashIndex = trimmed.indexOf("/");
-  if (slashIndex > 0) {
-    const provider = trimmed.slice(0, slashIndex);
-    const model = trimmed.slice(slashIndex + 1).trim().replace(/^models\//, "");
-    if (!model) {
-      throw new Error(`Invalid auto_name model: ${modelSpec}`);
-    }
-    if (provider === "anthropic" || provider === "google" || provider === "openai") {
-      return { provider, model };
-    }
-    if (provider === "gemini") {
-      return { provider: "google", model };
-    }
-  }
-
-  if (trimmed.startsWith("claude-")) {
-    return { provider: "anthropic", model: trimmed };
-  }
-  if (trimmed.startsWith("gemini-") || trimmed.startsWith("models/gemini-")) {
-    return { provider: "google", model: trimmed.replace(/^models\//, "") };
-  }
-  if (/^(gpt-|chatgpt-|o\d)/.test(trimmed)) {
-    return { provider: "openai", model: trimmed };
-  }
-
-  throw new Error(
-    `Unsupported auto_name model provider for ${modelSpec}. Use an anthropic/, gemini/, google/, or openai/ prefix, or a known model name.`,
-  );
-}
-
 function getSystemPrompt(config: AutoNameConfig): string {
   return config.systemPrompt?.trim() || DEFAULT_SYSTEM_PROMPT;
 }
 
-function extractAnthropicText(raw: unknown): string | null {
-  if (!isRecord(raw) || !Array.isArray(raw.content)) return null;
-  for (const item of raw.content) {
-    if (!isRecord(item)) continue;
-    if (item.type === "text" && typeof item.text === "string" && item.text.trim()) {
-      return item.text;
-    }
-  }
-  return null;
+async function defaultSpawn(args: string[]): Promise<SpawnResult> {
+  const proc = Bun.spawn(args, {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
 }
 
-function extractGoogleText(raw: unknown): string | null {
-  if (!isRecord(raw) || !Array.isArray(raw.candidates)) return null;
-  for (const candidate of raw.candidates) {
-    if (!isRecord(candidate) || !isRecord(candidate.content) || !Array.isArray(candidate.content.parts)) continue;
-    for (const part of candidate.content.parts) {
-      if (isRecord(part) && typeof part.text === "string" && part.text.trim()) {
-        return part.text;
-      }
-    }
+function buildClaudeArgs(model: string | undefined, systemPrompt: string, prompt: string): string[] {
+  const args = [
+    "claude",
+    "-p",
+    "--system-prompt", systemPrompt,
+    "--output-format", "text",
+    "--no-session-persistence",
+  ];
+  if (model) {
+    args.push("--model", model);
   }
-  return null;
+  args.push(prompt);
+  return args;
 }
 
-function extractOpenAiText(raw: unknown): string | null {
-  if (!isRecord(raw)) return null;
-  if (typeof raw.output_text === "string" && raw.output_text.trim()) {
-    return raw.output_text;
-  }
-  if (!Array.isArray(raw.output)) return null;
-  for (const item of raw.output) {
-    if (!isRecord(item) || !Array.isArray(item.content)) continue;
-    for (const content of item.content) {
-      if (!isRecord(content)) continue;
-      if (typeof content.text === "string" && content.text.trim()) {
-        return content.text;
-      }
-    }
-  }
-  return null;
+function escapeTomlString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
 }
 
-async function readErrorBody(response: Response): Promise<string> {
-  const text = (await response.text()).trim();
-  return text || `HTTP ${response.status}`;
+function buildCodexArgs(model: string | undefined, systemPrompt: string, prompt: string): string[] {
+  const args = [
+    "codex",
+    "-c", `developer_instructions="${escapeTomlString(systemPrompt)}"`,
+    "exec",
+    "--ephemeral",
+  ];
+  if (model) {
+    args.push("-m", model);
+  }
+  args.push(prompt);
+  return args;
 }
 
 export interface AutoNameServiceDependencies {
-  fetchImpl?: FetchLike;
-  anthropicApiKey?: string;
-  geminiApiKey?: string;
-  openaiApiKey?: string;
+  spawnImpl?: SpawnLike;
 }
 
 export interface AutoNameGenerator {
@@ -173,16 +100,10 @@ export interface AutoNameGenerator {
 }
 
 export class AutoNameService implements AutoNameGenerator {
-  private readonly fetchImpl: FetchLike;
-  private readonly anthropicApiKey: string | undefined;
-  private readonly geminiApiKey: string | undefined;
-  private readonly openaiApiKey: string | undefined;
+  private readonly spawnImpl: SpawnLike;
 
   constructor(deps: AutoNameServiceDependencies = {}) {
-    this.fetchImpl = deps.fetchImpl ?? fetch;
-    this.anthropicApiKey = deps.anthropicApiKey ?? Bun.env.ANTHROPIC_API_KEY;
-    this.geminiApiKey = deps.geminiApiKey ?? Bun.env.GEMINI_API_KEY;
-    this.openaiApiKey = deps.openaiApiKey ?? Bun.env.OPENAI_API_KEY;
+    this.spawnImpl = deps.spawnImpl ?? defaultSpawn;
   }
 
   async generateBranchName(config: AutoNameConfig, task: string): Promise<string> {
@@ -191,151 +112,32 @@ export class AutoNameService implements AutoNameGenerator {
       throw new Error("Auto-name requires a prompt");
     }
 
-    const resolved = resolveAutoNameModel(config.model);
-    const branchName = resolved.provider === "anthropic"
-      ? await this.generateWithAnthropic(resolved.model, getSystemPrompt(config), prompt)
-      : resolved.provider === "google"
-      ? await this.generateWithGoogle(resolved.model, getSystemPrompt(config), prompt)
-      : await this.generateWithOpenAI(resolved.model, getSystemPrompt(config), prompt);
+    const systemPrompt = getSystemPrompt(config);
+    const userPrompt = buildPrompt(prompt);
 
-    return normalizeGeneratedBranchName(branchName);
-  }
+    const args = config.provider === "claude"
+      ? buildClaudeArgs(config.model, systemPrompt, userPrompt)
+      : buildCodexArgs(config.model, systemPrompt, userPrompt);
 
-  private async generateWithAnthropic(model: string, systemPrompt: string, task: string): Promise<string> {
-    if (!this.anthropicApiKey) {
-      throw new Error("ANTHROPIC_API_KEY is required for auto_name with Anthropic models");
+    const cli = config.provider === "claude" ? "claude" : "codex";
+
+    let result: SpawnResult;
+    try {
+      result = await this.spawnImpl(args);
+    } catch {
+      throw new Error(`'${cli}' CLI not found. Install it or check your PATH.`);
     }
 
-    const response = await this.fetchImpl("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": this.anthropicApiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model,
-        system: systemPrompt,
-        max_tokens: 64,
-        messages: [{ role: "user", content: buildPrompt(task) }],
-        output_config: {
-          format: {
-            type: "json_schema",
-            schema: BRANCH_NAME_SCHEMA,
-          },
-        },
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Anthropic auto-name request failed: ${await readErrorBody(response)}`);
+    if (result.exitCode !== 0) {
+      const detail = result.stderr.trim() || `exit ${result.exitCode}`;
+      throw new Error(`${cli} failed: ${detail}`);
     }
 
-    const json: unknown = await response.json();
-    if (isRecord(json) && json.stop_reason === "refusal") {
-      throw new Error("Anthropic auto-name request was refused");
-    }
-    if (isRecord(json) && json.stop_reason === "max_tokens") {
-      throw new Error("Anthropic auto-name response hit max_tokens before completing");
-    }
-    const text = extractAnthropicText(json);
-    if (!text) {
-      throw new Error("Anthropic auto-name response did not include text");
-    }
-    return parseBranchNamePayload(parseJsonText(text));
-  }
-
-  private async generateWithGoogle(model: string, systemPrompt: string, task: string): Promise<string> {
-    if (!this.geminiApiKey) {
-      throw new Error("GEMINI_API_KEY is required for auto_name with Gemini models");
+    const output = result.stdout.trim();
+    if (!output) {
+      throw new Error(`${cli} returned empty output`);
     }
 
-    const response = await this.fetchImpl(
-      `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`,
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-goog-api-key": this.geminiApiKey,
-        },
-        body: JSON.stringify({
-          systemInstruction: {
-            parts: [{ text: systemPrompt }],
-          },
-          contents: [
-            {
-              role: "user",
-              parts: [{ text: buildPrompt(task) }],
-            },
-          ],
-          generationConfig: {
-            responseMimeType: "application/json",
-            responseJsonSchema: GEMINI_BRANCH_NAME_SCHEMA,
-          },
-        }),
-      },
-    );
-
-    if (!response.ok) {
-      throw new Error(`Google auto-name request failed: ${await readErrorBody(response)}`);
-    }
-
-    const json: unknown = await response.json();
-    const text = extractGoogleText(json);
-    if (!text) {
-      throw new Error("Google auto-name response did not include text");
-    }
-    return parseBranchNamePayload(parseJsonText(text));
-  }
-
-  private async generateWithOpenAI(model: string, systemPrompt: string, task: string): Promise<string> {
-    if (!this.openaiApiKey) {
-      throw new Error("OPENAI_API_KEY is required for auto_name with OpenAI models");
-    }
-
-    const response = await this.fetchImpl("https://api.openai.com/v1/responses", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${this.openaiApiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        input: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: buildPrompt(task) },
-        ],
-        max_output_tokens: 64,
-        text: {
-          format: {
-            type: "json_schema",
-            name: "branch_name_response",
-            strict: true,
-            schema: BRANCH_NAME_SCHEMA,
-          },
-        },
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`OpenAI auto-name request failed: ${await readErrorBody(response)}`);
-    }
-
-    const json: unknown = await response.json();
-    if (isRecord(json) && Array.isArray(json.output)) {
-      for (const item of json.output) {
-        if (!isRecord(item) || !Array.isArray(item.content)) continue;
-        for (const content of item.content) {
-          if (isRecord(content) && content.type === "refusal" && typeof content.refusal === "string") {
-            throw new Error(`OpenAI auto-name request was refused: ${content.refusal}`);
-          }
-        }
-      }
-    }
-    const text = extractOpenAiText(json);
-    if (!text) {
-      throw new Error("OpenAI auto-name response did not include text");
-    }
-    return parseBranchNamePayload(parseJsonText(text));
+    return normalizeGeneratedBranchName(output);
   }
 }


### PR DESCRIPTION
## Summary
- Replaced direct LLM API calls (Anthropic, Google, OpenAI) with CLI-based providers (`claude -p` and `codex exec`) for auto-name branch generation
- Users no longer need to configure API keys — the CLI tools handle their own authentication
- Config uses `provider: claude | codex` with optional `model` and `system_prompt` fields

## Config example
```yaml
auto_name:
  provider: claude          # or codex
  model: haiku              # optional — omit to use CLI default
  system_prompt: "..."      # optional
```

## Test plan
- [x] All 116 existing tests pass
- [x] New tests cover: correct CLI args for both providers, model flag presence/absence, default system prompt, output normalization, CLI not found, non-zero exit, empty output, TOML escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)