### PR TITLE
fix: register zsh completion for webmux

### DIFF
--- a/bin/src/completions.test.ts
+++ b/bin/src/completions.test.ts
@@ -116,7 +116,10 @@ describe("runCompletionCommand", () => {
     const spy = spyOn(console, "log").mockImplementation(() => {});
     const code = runCompletionCommand(["zsh"]);
     expect(code).toBe(0);
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining("#compdef webmux"));
+    const output = spy.mock.calls[0]?.[0];
+    expect(output).toContain("#compdef webmux");
+    expect(output).toContain("compdef _webmux webmux");
+    expect(output).not.toContain('_webmux "$@"');
     spy.mockRestore();
   });
 

--- a/bin/src/completions.ts
+++ b/bin/src/completions.ts
@@ -167,7 +167,7 @@ _webmux() {
   esac
 }
 
-_webmux "$@"`;
+compdef _webmux webmux`;
 
 const BASH_SCRIPT = `_webmux() {
   local cur prev


### PR DESCRIPTION
## Summary
Fix the generated zsh completion script so it explicitly registers `_webmux` for the `webmux` command instead of leaving zsh to fall back to filename completion.

## Changes
- replace the trailing `_webmux "$@"` line in the generated zsh script with `compdef _webmux webmux`
- extend the completion test to assert the zsh script includes the `compdef` registration
- keep the branch-scoped completion behavior unchanged for `open`, `close`, `remove`, and `merge`

## Test plan
- [x] Run `bun test bin/src/completions.test.ts`
- [x] In zsh, eval the generated script and verify `_comps[webmux]` resolves to `_webmux`

---
Generated with [Claude Code](https://claude.com/claude-code)