### PR TITLE
fix: filter duplicate worktree entry while creating

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -185,6 +185,9 @@
         prompt || undefined,
         Object.keys(envOverrides).length > 0 ? envOverrides : undefined,
       );
+      creatingWorktrees = creatingWorktrees.map((c) =>
+        c.id === id ? { ...c, name: result.branch } : c,
+      );
       await refresh();
       selectedBranch = result.branch;
       if (isMobile) sidebarOpen = false;

--- a/frontend/src/lib/WorktreeList.svelte
+++ b/frontend/src/lib/WorktreeList.svelte
@@ -23,6 +23,8 @@
     onselect: (branch: string) => void;
     onremove: (branch: string) => void;
   } = $props();
+
+  let creatingNames = $derived(new Set(creating.map((c) => c.name)));
 </script>
 
 <ul class="list-none overflow-y-auto flex-1 p-2">
@@ -43,7 +45,6 @@
       </div>
     </li>
   {/each}
-  {@const creatingNames = new Set(creating.map((c) => c.name))}
   {#each worktrees.filter((wt) => !creatingNames.has(wt.branch)) as wt (wt.branch)}
     {@const isActive = wt.branch === selected}
     {@const isRemoving = removing.has(wt.branch)}


### PR DESCRIPTION
## Summary
When a worktree is being created, it could appear twice in the sidebar — once as "creating…" and once as "closed" — because polling or the post-create refresh could fetch the new worktree from the backend before the creating entry was cleared.

## Changes
- Filter the worktree list in `WorktreeList.svelte` to exclude branches that match a currently-creating entry, preventing the duplicate display

## Test plan
- [ ] Create a new worktree and verify it only appears once (as "creating…") until creation completes
- [ ] Verify that after creation completes, the worktree appears normally in the list

---
Generated with [Claude Code](https://claude.com/claude-code)