### PR TITLE
fix: resolve relative linked repo dir and support array github config

### DIFF
--- a/backend/src/adapters/config.ts
+++ b/backend/src/adapters/config.ts
@@ -276,7 +276,9 @@ export function loadConfig(dir: string): ProjectConfig {
         github: {
           linkedRepos: isRecord(parsed.integrations) && isRecord(parsed.integrations.github)
             ? parseLinkedRepos(parsed.integrations.github.linkedRepos)
-            : [],
+            : isRecord(parsed.integrations) && Array.isArray(parsed.integrations.github)
+              ? parseLinkedRepos(parsed.integrations.github)
+              : [],
         },
         linear: {
           enabled: isRecord(parsed.integrations) && isRecord(parsed.integrations.linear) && typeof parsed.integrations.linear.enabled === "boolean"

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -71,7 +71,7 @@ function getFrontendConfig(): {
     startupEnvs: config.startupEnvs,
     linkedRepos: config.integrations.github.linkedRepos.map((lr) => ({
       alias: lr.alias,
-      ...(lr.dir ? { dir: lr.dir } : {}),
+      ...(lr.dir ? { dir: resolve(PROJECT_DIR, lr.dir) } : {}),
     })),
   };
 }


### PR DESCRIPTION
## Summary
- Resolve relative `dir` paths in linked repo config against the project root before sending to the frontend (e.g. `dir: ../api-service` becomes an absolute path)
- Support `integrations.github` as a direct array (shorthand) in addition to `{ linkedRepos: [...] }` format

## Test plan
- [ ] Config with `dir: ../some-repo` resolves to correct absolute path in `/api/config` response
- [ ] Config with `integrations.github: [{ repo: ..., alias: ... }]` array format parses linked repos correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)