### PR TITLE
fix: append branch name to linked repo cursor URL

### DIFF
--- a/frontend/src/lib/TopBar.svelte
+++ b/frontend/src/lib/TopBar.svelte
@@ -75,7 +75,7 @@
       .map((lr) => ({
         alias: lr.alias,
         dir: lr.dir,
-        cursorUrl: makeCursorUrl(lr.dir),
+        cursorUrl: makeCursorUrl(lr.dir && name ? `${lr.dir}/${name}` : null),
         prs: (worktree?.prs ?? []).filter((pr) => pr.repo === lr.alias),
       }))
       .filter((g) => g.prs.length > 0 || g.cursorUrl),


### PR DESCRIPTION
## Summary
- Previously, the linked repo cursor button opened the worktrees root directory (e.g. `../windmill-ee-private__worktrees`), which is just a container — not useful
- Now appends the current branch name to the path (e.g. `../windmill-ee-private__worktrees/feature-x`), so Cursor opens the matching worktree in the linked repo

## Test plan
- [ ] Configure a linked repo with a `dir` pointing to a worktrees directory
- [ ] Select a worktree and verify the linked repo cursor button opens `<dir>/<branch_name>`
- [ ] Verify no cursor button appears when no worktree is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)