### PR TITLE
feat: enforce 40-char max on auto-generated branch names

### DIFF
--- a/backend/src/__tests__/auto-name-service.test.ts
+++ b/backend/src/__tests__/auto-name-service.test.ts
@@ -27,7 +27,7 @@ describe("AutoNameService", () => {
       "--system-prompt", "Generate a branch name",
       "--output-format", "text",
       "--no-session-persistence",
-      "Task description:\nFix the login flow",
+      "Here is the task description: Fix the login flow. You MUST return the branch name only, no other text or comments. Be fast, make it simple, and concise.",
     ]);
   });
 
@@ -72,7 +72,7 @@ describe("AutoNameService", () => {
       "-c", 'developer_instructions="Generate a branch name"',
       "exec",
       "--ephemeral",
-      "Task description:\nImprove search ranking",
+      "Here is the task description: Improve search ranking. You MUST return the branch name only, no other text or comments. Be fast, make it simple, and concise.",
     ]);
   });
 
@@ -149,6 +149,33 @@ describe("AutoNameService", () => {
     await expect(
       service.generateBranchName({ provider: "claude" }, "Fix bug"),
     ).rejects.toThrow("claude returned empty output");
+  });
+
+  it("truncates branch names longer than 40 characters", async () => {
+    const { spawnImpl } = fakeSpawn("this-is-a-very-long-branch-name-that-exceeds-the-forty-character-limit");
+    const service = new AutoNameService({ spawnImpl });
+
+    const branch = await service.generateBranchName(
+      { provider: "claude" },
+      "A very long task description",
+    );
+
+    expect(branch.length).toBeLessThanOrEqual(40);
+    expect(branch).toBe("this-is-a-very-long-branch-name-that-exc");
+  });
+
+  it("removes trailing hyphens after truncation", async () => {
+    // 40th char lands right after a hyphen: "a]b-c" → truncate at 40 → trailing hyphen
+    const { spawnImpl } = fakeSpawn("add-feature-to-handle-user-authentication-flow");
+    const service = new AutoNameService({ spawnImpl });
+
+    const branch = await service.generateBranchName(
+      { provider: "claude" },
+      "Some task",
+    );
+
+    expect(branch.length).toBeLessThanOrEqual(40);
+    expect(branch).not.toMatch(/-$/);
   });
 
   it("escapes special characters in system prompt for codex TOML config", async () => {

--- a/backend/src/services/auto-name-service.ts
+++ b/backend/src/services/auto-name-service.ts
@@ -9,10 +9,13 @@ interface SpawnResult {
 
 type SpawnLike = (args: string[]) => Promise<SpawnResult>;
 
+const MAX_BRANCH_LENGTH = 40;
+
 const DEFAULT_SYSTEM_PROMPT = [
   "Generate a concise git branch name from the task description.",
   "Return only the branch name.",
   "Use lowercase kebab-case.",
+  `Maximum ${MAX_BRANCH_LENGTH} characters.`,
   "Do not include quotes, code fences, or prefixes like feature/ or fix/.",
 ].join(" ");
 
@@ -27,6 +30,7 @@ function normalizeGeneratedBranchName(raw: string): string {
   branch = branch.replace(/[/.]+/g, "-");
   branch = branch.replace(/-+/g, "-");
   branch = branch.replace(/^-+|-+$/g, "");
+  branch = branch.slice(0, MAX_BRANCH_LENGTH).replace(/-+$/, "");
 
   if (!branch) {
     throw new Error("Auto-name model returned an empty branch name");
@@ -65,7 +69,7 @@ function buildClaudeArgs(model: string | undefined, systemPrompt: string, prompt
   if (model) {
     args.push("--model", model);
   }
-  args.push(`Here is the task description: ${prompt}. You MUST return the branch name only, no other text or comments.`);
+  args.push(prompt);
   return args;
 }
 
@@ -87,7 +91,7 @@ function buildCodexArgs(model: string | undefined, systemPrompt: string, prompt:
   if (model) {
     args.push("-m", model);
   }
-  args.push(`Here is the task description: ${prompt}. You MUST return the branch name only, no other text or comments.`);
+  args.push(prompt);
   return args;
 }
 


### PR DESCRIPTION
## Summary
Enforce a 40-character maximum length on branch names auto-generated by Claude and Codex CLIs.

## Changes
- Add `MAX_BRANCH_LENGTH = 40` constant and truncation in `normalizeGeneratedBranchName`
- Add "Maximum 40 characters" instruction to the default system prompt
- Fix double-wrapping bug where `buildClaudeArgs`/`buildCodexArgs` re-wrapped prompts already formatted by `buildPrompt()`
- Add tests for truncation and trailing-hyphen cleanup after truncation
- Fix stale test expectations for prompt format

## Test plan
- [x] All 14 auto-name-service tests pass (`bun test src/__tests__/auto-name-service.test.ts`)
- [ ] Create a worktree with a long task description and verify the branch name is ≤ 40 chars

---
Generated with [Claude Code](https://claude.com/claude-code)