### PR TITLE
fix: persist startupEnvs and checkbox state in save as default

### DIFF
--- a/frontend/src/lib/CreateWorktreeDialog.svelte
+++ b/frontend/src/lib/CreateWorktreeDialog.svelte
@@ -49,12 +49,24 @@
   let prompt = $state(initialPrompt);
   let agent = $state(savedAgent ?? "claude");
   let profile = $state(savedProfile ?? "");
-  const hasSavedDefaults = savedProfile != null || savedAgent != null;
+  const hasSavedDefaults = savedProfile != null || savedAgent != null || savedEnvs != null;
   let saveDefault = $state(hasSavedDefaults);
+
+  function loadSavedEnvs(): Record<string, string | boolean> {
+    if (!savedEnvs) return { ...startupEnvs };
+    try {
+      const parsed = JSON.parse(savedEnvs) as Record<string, string | boolean>;
+      const filtered = Object.fromEntries(
+        Object.entries(parsed).filter(([k]) => k in startupEnvs),
+      );
+      return { ...startupEnvs, ...filtered };
+    } catch {
+      return { ...startupEnvs };
+    }
+  }
+
   // svelte-ignore state_referenced_locally
-  let envValues = $state<Record<string, string | boolean>>(
-    savedEnvs ? { ...startupEnvs, ...JSON.parse(savedEnvs) } : { ...startupEnvs },
-  );
+  let envValues = $state<Record<string, string | boolean>>(loadSavedEnvs());
 
   function focus(node: HTMLElement) {
     node.focus();


### PR DESCRIPTION
## Summary
- **startupEnvs now saved/restored**: env values are JSON-serialized to localStorage when "Save as default" is checked, and merged back on next dialog open
- **Checkbox reflects saved state**: `saveDefault` initializes to `true` when previous defaults exist, so users see defaults are active
- **Clearing works for envs too**: unchecking the box removes the env storage key alongside profile and agent

## Test plan
- [ ] Open Create Worktree dialog with `startupEnvs` configured
- [ ] Fill in env values, check "Save as default", and create a worktree
- [ ] Re-open the dialog — verify env values, profile, agent are restored and checkbox is checked
- [ ] Uncheck "Save as default" and create — verify next dialog open has no saved values and checkbox is unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)