### PR TITLE
fix: isolate pane base index from user tmux config

### DIFF
--- a/backend/src/__tests__/session-service.test.ts
+++ b/backend/src/__tests__/session-service.test.ts
@@ -154,6 +154,7 @@ describe("ensureSessionLayout", () => {
         call.startsWith(`createWindow:${plan.sessionName}:${plan.windowName}:/repo/project/__worktrees/feature-search:shell-cmd`),
       ),
     ).toBe(true);
+    expect(tmux.calls).toContain(`setWindowOption:${plan.sessionName}:${plan.windowName}:pane-base-index:0`);
     expect(
       tmux.calls.some((call) =>
         call.startsWith(`splitWindow:${plan.sessionName}:${plan.windowName}.0:right:25:/repo/project/__worktrees/feature-search:shell-cmd`),

--- a/backend/src/__tests__/tmux-adapter.test.ts
+++ b/backend/src/__tests__/tmux-adapter.test.ts
@@ -1,31 +1,80 @@
-import { afterEach, describe, expect, it } from "bun:test";
-import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  BunTmuxGateway,
   buildProjectSessionName,
   buildWorktreeWindowName,
   parseWindowSummaries,
   sanitizeTmuxNameSegment,
 } from "../adapters/tmux";
 
-function run(args: string[]): void {
-  const result = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" });
+function buildEnv(overrides: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  return {
+    ...env,
+    ...overrides,
+  };
+}
+
+function run(args: string[], env?: Record<string, string>): void {
+  const result = Bun.spawnSync(args, { env, stdout: "pipe", stderr: "pipe" });
   if (result.exitCode !== 0) {
     const stderr = new TextDecoder().decode(result.stderr).trim();
     throw new Error(`${args.join(" ")} failed: ${stderr || `exit ${result.exitCode}`}`);
   }
 }
 
-function read(args: string[]): string {
-  const result = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" });
+function read(args: string[], env?: Record<string, string>): string {
+  const result = Bun.spawnSync(args, { env, stdout: "pipe", stderr: "pipe" });
   if (result.exitCode !== 0) {
     const stderr = new TextDecoder().decode(result.stderr).trim();
     throw new Error(`${args.join(" ")} failed: ${stderr || `exit ${result.exitCode}`}`);
   }
 
   return new TextDecoder().decode(result.stdout).trim();
+}
+
+interface LayoutResult {
+  globalPaneBaseIndex: string;
+  relatedPaneIndexes: string[];
+  unrelatedPaneIndexes: string[];
+}
+
+function parseLayoutResult(output: string): LayoutResult {
+  const value: unknown = JSON.parse(output);
+  if (!value || typeof value !== "object") {
+    throw new Error("layout result must be an object");
+  }
+
+  const {
+    globalPaneBaseIndex,
+    relatedPaneIndexes,
+    unrelatedPaneIndexes,
+  } = value as {
+    globalPaneBaseIndex?: unknown;
+    relatedPaneIndexes?: unknown;
+    unrelatedPaneIndexes?: unknown;
+  };
+
+  if (typeof globalPaneBaseIndex !== "string") {
+    throw new Error("layout result globalPaneBaseIndex must be a string");
+  }
+  if (!Array.isArray(relatedPaneIndexes) || !relatedPaneIndexes.every((entry) => typeof entry === "string")) {
+    throw new Error("layout result relatedPaneIndexes must be a string array");
+  }
+  if (!Array.isArray(unrelatedPaneIndexes) || !unrelatedPaneIndexes.every((entry) => typeof entry === "string")) {
+    throw new Error("layout result unrelatedPaneIndexes must be a string array");
+  }
+
+  return {
+    globalPaneBaseIndex,
+    relatedPaneIndexes,
+    unrelatedPaneIndexes,
+  };
 }
 
 describe("sanitizeTmuxNameSegment", () => {
@@ -78,67 +127,93 @@ describe("parseWindowSummaries", () => {
   });
 });
 
-describe("BunTmuxGateway", () => {
-  let testRoot = "";
-  let originalPath: string | null = null;
-
-  afterEach(async () => {
-    if (testRoot) {
-      try {
-        run(["tmux", "kill-server"]);
-      } catch {}
-
-      await rm(testRoot, { recursive: true, force: true });
-      testRoot = "";
-    }
-
-    if (originalPath !== null) {
-      process.env.PATH = originalPath;
-      originalPath = null;
-    }
-  });
-
-  it("forces 0-based pane indices for new windows when the user config starts at 1", async () => {
-    testRoot = await mkdtemp(join(tmpdir(), "webmux-tmux-"));
-
+describe("ensureSessionLayout", () => {
+  it("keeps the tmux global default at 1 while forcing the workmux window to 0-based panes", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "webmux-tmux-"));
     const homeDir = join(testRoot, "home");
-    const binDir = join(testRoot, "bin");
+    const projectRoot = join(testRoot, "repo");
+    const worktreePath = join(projectRoot, "__worktrees", "feature-search");
     await mkdir(homeDir, { recursive: true });
-    await mkdir(binDir, { recursive: true });
+    await mkdir(worktreePath, { recursive: true });
 
     await Bun.write(join(homeDir, ".tmux.conf"), "set -g base-index 1\nsetw -g pane-base-index 1\n");
+    const env = buildEnv({
+      HOME: homeDir,
+      TMUX: "",
+      TMUX_TMPDIR: testRoot,
+    });
+    const runnerPath = join(testRoot, "run-layout.ts");
+    const tmuxModuleUrl = new URL("../adapters/tmux.ts", import.meta.url).href;
+    const sessionServiceModuleUrl = new URL("../services/session-service.ts", import.meta.url).href;
 
-    const realTmux = read(["which", "tmux"]);
-    const wrapperPath = join(binDir, "tmux");
     await Bun.write(
-      wrapperPath,
+      runnerPath,
       [
-        "#!/bin/sh",
-        "unset TMUX",
-        `export HOME="${homeDir}"`,
-        `export TMUX_TMPDIR="${testRoot}"`,
-        `exec "${realTmux}" "$@"`,
+        `import { ensureSessionLayout, planSessionLayout } from ${JSON.stringify(sessionServiceModuleUrl)};`,
+        `import { buildProjectSessionName, buildWorktreeWindowName, BunTmuxGateway } from ${JSON.stringify(tmuxModuleUrl)};`,
+        "",
+        "function run(args: string[]): void {",
+        '  const result = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" });',
+        "  if (result.exitCode !== 0) {",
+        "    const stderr = new TextDecoder().decode(result.stderr).trim();",
+        '    throw new Error(`${args.join(" ")} failed: ${stderr || `exit ${result.exitCode}`}`);',
+        "  }",
+        "}",
+        "",
+        "function read(args: string[]): string {",
+        '  const result = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" });',
+        "  if (result.exitCode !== 0) {",
+        "    const stderr = new TextDecoder().decode(result.stderr).trim();",
+        '    throw new Error(`${args.join(" ")} failed: ${stderr || `exit ${result.exitCode}`}`);',
+        "  }",
+        '  return new TextDecoder().decode(result.stdout).trim();',
+        "}",
+        "",
+        "const projectRoot = process.argv[2];",
+        "const worktreePath = process.argv[3];",
+        'if (!projectRoot || !worktreePath) throw new Error("expected projectRoot and worktreePath");',
+        "",
+        "const gateway = new BunTmuxGateway();",
+        "const plan = planSessionLayout(",
+        "  projectRoot,",
+        '  "feature/search",',
+        "  [",
+        '    { id: "agent", kind: "agent", focus: true },',
+        '    { id: "shell", kind: "shell", split: "right", sizePct: 25 },',
+        "  ],",
+        "  {",
+        "    repoRoot: projectRoot,",
+        "    worktreePath,",
+        "    paneCommands: {",
+        '      agent: "printf agent-started",',
+        '      shell: "sh",',
+        "    },",
+        "  },",
+        ");",
+        "",
+        "ensureSessionLayout(gateway, plan);",
+        'run(["tmux", "new-session", "-d", "-s", "unrelated", "-c", projectRoot]);',
+        'run(["tmux", "new-window", "-d", "-t", "unrelated", "-n", "plain", "-c", projectRoot]);',
+        "",
+        "console.log(JSON.stringify({",
+        '  globalPaneBaseIndex: read(["tmux", "show-options", "-g", "-w", "-v", "pane-base-index"]),',
+        '  relatedPaneIndexes: read(["tmux", "list-panes", "-t", `${buildProjectSessionName(projectRoot)}:${buildWorktreeWindowName("feature/search")}`, "-F", "#{pane_index}"]).split("\\n").filter(Boolean),',
+        '  unrelatedPaneIndexes: read(["tmux", "list-panes", "-t", "unrelated:plain", "-F", "#{pane_index}"]).split("\\n").filter(Boolean),',
+        "}));",
         "",
       ].join("\n"),
     );
-    await chmod(wrapperPath, 0o755);
 
-    originalPath = process.env.PATH ?? "";
-    process.env.PATH = `${binDir}:${originalPath}`;
-
-    const gateway = new BunTmuxGateway();
-    const sessionName = "wm-test-pane-index";
-    const windowName = "wm-window";
-
-    gateway.ensureServer();
-    gateway.ensureSession(sessionName, testRoot);
-    gateway.createWindow({
-      sessionName,
-      windowName,
-      cwd: testRoot,
-    });
-
-    expect(read(["tmux", "show-options", "-g", "-w", "-v", "pane-base-index"])).toBe("1");
-    expect(read(["tmux", "list-panes", "-t", `${sessionName}:${windowName}`, "-F", "#{pane_index}"])).toBe("0");
+    try {
+      const result = parseLayoutResult(read(["bun", runnerPath, projectRoot, worktreePath], env));
+      expect(result.globalPaneBaseIndex).toBe("1");
+      expect(result.relatedPaneIndexes).toEqual(["0", "1"]);
+      expect(result.unrelatedPaneIndexes).toEqual(["1"]);
+    } finally {
+      try {
+        run(["tmux", "kill-server"], env);
+      } catch {}
+      await rm(testRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/backend/src/adapters/tmux.ts
+++ b/backend/src/adapters/tmux.ts
@@ -100,12 +100,6 @@ export class BunTmuxGateway implements TmuxGateway {
     if (check.exitCode !== 0) {
       assertTmuxOk(["new-session", "-d", "-s", sessionName, "-c", cwd], `create tmux session ${sessionName}`);
     }
-    // Force 0-based pane indices for new windows in this session so our code
-    // works regardless of the user's global pane-base-index setting.
-    assertTmuxOk(
-      ["set-window-option", "-g", "-t", sessionName, "pane-base-index", "0"],
-      `set pane-base-index defaults on ${sessionName}`,
-    );
   }
 
   hasWindow(sessionName: string, windowName: string): boolean {

--- a/backend/src/services/session-service.ts
+++ b/backend/src/services/session-service.ts
@@ -117,6 +117,7 @@ export function ensureSessionLayout(
     cwd: rootPane.cwd,
     command: plan.shellCommand,
   });
+  tmux.setWindowOption(plan.sessionName, plan.windowName, "pane-base-index", "0");
   tmux.setWindowOption(plan.sessionName, plan.windowName, "automatic-rename", "off");
   tmux.setWindowOption(plan.sessionName, plan.windowName, "allow-rename", "off");
 


### PR DESCRIPTION
## Summary
Prevent workmux window creation from breaking when a user's tmux config sets `pane-base-index 1`. The fix now scopes the override to the concrete workmux window so later `.0` pane targets keep working without changing tmux's global default.

## Changes
- remove the adapter-level `set-window-option -g` override from session setup
- set `pane-base-index 0` on the newly created workmux window before any split or pane-targeted commands run
- update the regression test to run the real layout flow in an isolated tmux subprocess and verify the global default stays `1` while the workmux window becomes `0`-based
- add a session-service assertion that the workmux window gets the `pane-base-index` override

## Test plan
- [x] Run `bun test backend/src/__tests__/tmux-adapter.test.ts backend/src/__tests__/session-service.test.ts`
- [ ] Reproduce worktree creation with a user tmux config that sets `setw -g pane-base-index 1` and confirm no `pane 0 not found` error appears
- [x] Confirm the isolated tmux regression test keeps the global default at `1`, leaves an unrelated window at pane index `1`, and gives the workmux window pane indexes `0` and `1`

---
Generated with [Claude Code](https://claude.com/claude-code)