### PR TITLE
fix: resume agent sessions on reopen

### DIFF
--- a/backend/src/__tests__/agent-service.test.ts
+++ b/backend/src/__tests__/agent-service.test.ts
@@ -28,9 +28,26 @@ describe("agent-service command builders", () => {
     expect(claude).toContain("set +a");
     expect(claude).toContain("claude");
     expect(claude).toContain("fix the tests");
+    expect(claude).not.toContain("--continue");
     expect(claude).not.toContain("agent-started");
     expect(claude).not.toContain("title-changed");
     expect(claude).not.toContain("runtime-error");
+  });
+
+  it("uses claude continue on resume without replaying the initial prompt", () => {
+    const command = buildAgentPaneCommand({
+      agent: "claude",
+      runtimeEnvPath: "/tmp/gitdir/webmux/runtime.env",
+      yolo: true,
+      systemPrompt: "stay focused",
+      prompt: "fix the tests",
+      launchMode: "resume",
+    });
+
+    expect(command).toContain("claude --dangerously-skip-permissions --continue");
+    expect(command).not.toContain("--append-system-prompt");
+    expect(command).not.toContain("fix the tests");
+    expect(command).not.toContain("stay focused");
   });
 
   it("builds docker commands that exec inside the container", () => {
@@ -54,6 +71,22 @@ describe("agent-service command builders", () => {
     expect(agent).toContain("codex --yolo");
     expect(agent).toContain("ship the fix");
     expect(agent).not.toContain("agent-stopped");
+  });
+
+  it("uses codex resume --last on resume without replaying the initial prompt", () => {
+    const command = buildAgentPaneCommand({
+      agent: "codex",
+      runtimeEnvPath: "/tmp/gitdir/webmux/runtime.env",
+      yolo: true,
+      systemPrompt: "stay focused",
+      prompt: "ship the fix",
+      launchMode: "resume",
+    });
+
+    expect(command).toContain("codex --yolo resume --last");
+    expect(command).not.toContain("developer_instructions=");
+    expect(command).not.toContain("ship the fix");
+    expect(command).not.toContain("stay focused");
   });
 
   it("adds the claude permissions bypass flag only when profile yolo is enabled", () => {

--- a/backend/src/__tests__/lifecycle-service.test.ts
+++ b/backend/src/__tests__/lifecycle-service.test.ts
@@ -476,7 +476,92 @@ describe("LifecycleService", () => {
     expect(meta).not.toBeNull();
     expect(meta?.branch).toBe("feature-open");
     expect(tmux.listWindows()[0]?.windowName).toBe(buildWorktreeWindowName("feature-open"));
+    expect(tmux.commands[0]?.command).toContain("claude");
+    expect(tmux.commands[0]?.command).not.toContain("--continue");
     expect(runtime.getWorktreeByBranch("feature-open")?.worktreeId).toBe(opened.worktreeId);
+  });
+
+  it("reopens a managed claude worktree with claude continue", async () => {
+    const repoRoot = await initRepo();
+    const runtime = new ProjectRuntime();
+    const tmux = new FakeTmuxGateway();
+    const lifecycle = makeLifecycleService(
+      repoRoot,
+      tmux,
+      runtime,
+      new FakeDockerGateway(),
+      new FakeHookRunner(),
+      {
+        ...TEST_CONFIG,
+        profiles: {
+          ...TEST_CONFIG.profiles,
+          default: {
+            ...TEST_CONFIG.profiles.default,
+            systemPrompt: "Database: ${FRONTEND_PORT}",
+          },
+        },
+      },
+    );
+
+    await lifecycle.createWorktree({
+      branch: "feature-continue",
+      prompt: "fix the tests",
+    });
+
+    tmux.commands.length = 0;
+    await lifecycle.closeWorktree("feature-continue");
+    await lifecycle.openWorktree("feature-continue");
+
+    const agentCommand = tmux.commands.at(-1)?.command;
+
+    expect(agentCommand).toContain("claude --continue");
+    expect(agentCommand).not.toContain("--append-system-prompt");
+    expect(agentCommand).not.toContain("Database:");
+    expect(agentCommand).not.toContain("fix the tests");
+  });
+
+  it("reopens a managed codex worktree with codex resume --last", async () => {
+    const repoRoot = await initRepo();
+    const runtime = new ProjectRuntime();
+    const tmux = new FakeTmuxGateway();
+    const lifecycle = makeLifecycleService(
+      repoRoot,
+      tmux,
+      runtime,
+      new FakeDockerGateway(),
+      new FakeHookRunner(),
+      {
+        ...TEST_CONFIG,
+        workspace: {
+          ...TEST_CONFIG.workspace,
+          defaultAgent: "codex",
+        },
+        profiles: {
+          ...TEST_CONFIG.profiles,
+          default: {
+            ...TEST_CONFIG.profiles.default,
+            yolo: true,
+            systemPrompt: "Database: ${FRONTEND_PORT}",
+          },
+        },
+      },
+    );
+
+    await lifecycle.createWorktree({
+      branch: "feature-codex-resume",
+      prompt: "ship the fix",
+    });
+
+    tmux.commands.length = 0;
+    await lifecycle.closeWorktree("feature-codex-resume");
+    await lifecycle.openWorktree("feature-codex-resume");
+
+    const agentCommand = tmux.commands.at(-1)?.command;
+
+    expect(agentCommand).toContain("codex --yolo resume --last");
+    expect(agentCommand).not.toContain("developer_instructions=");
+    expect(agentCommand).not.toContain("Database:");
+    expect(agentCommand).not.toContain("ship the fix");
   });
 
   it("closes the tmux window without removing the worktree or branch", async () => {

--- a/backend/src/services/agent-service.ts
+++ b/backend/src/services/agent-service.ts
@@ -1,5 +1,7 @@
 import type { AgentKind } from "../domain/config";
 
+export type AgentLaunchMode = "fresh" | "resume";
+
 function quoteShell(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -13,11 +15,14 @@ function buildAgentInvocation(input: {
   yolo?: boolean;
   systemPrompt?: string;
   prompt?: string;
+  launchMode?: AgentLaunchMode;
 }): string {
-  const promptSuffix = input.prompt ? ` ${quoteShell(input.prompt)}` : "";
-
   if (input.agent === "codex") {
     const yoloFlag = input.yolo ? " --yolo" : "";
+    if (input.launchMode === "resume") {
+      return `codex${yoloFlag} resume --last`;
+    }
+    const promptSuffix = input.prompt ? ` ${quoteShell(input.prompt)}` : "";
     if (input.systemPrompt) {
       return `codex${yoloFlag} -c ${quoteShell(`developer_instructions=${input.systemPrompt}`)}${promptSuffix}`;
     }
@@ -25,6 +30,10 @@ function buildAgentInvocation(input: {
   }
 
   const yoloFlag = input.yolo ? " --dangerously-skip-permissions" : "";
+  if (input.launchMode === "resume") {
+    return `claude${yoloFlag} --continue`;
+  }
+  const promptSuffix = input.prompt ? ` ${quoteShell(input.prompt)}` : "";
   if (input.systemPrompt) {
     return `claude${yoloFlag} --append-system-prompt ${quoteShell(input.systemPrompt)}${promptSuffix}`;
   }
@@ -37,6 +46,7 @@ function buildAgentCommand(input: {
   yolo?: boolean;
   systemPrompt?: string;
   prompt?: string;
+  launchMode?: AgentLaunchMode;
 }): string {
   return `${buildRuntimeBootstrap(input.runtimeEnvPath)}; ${buildAgentInvocation(input)}`;
 }
@@ -62,6 +72,7 @@ export function buildAgentPaneCommand(input: {
   yolo?: boolean;
   systemPrompt?: string;
   prompt?: string;
+  launchMode?: AgentLaunchMode;
 }): string {
   return buildAgentCommand(input);
 }
@@ -87,6 +98,7 @@ export function buildDockerAgentPaneCommand(input: {
   yolo?: boolean;
   systemPrompt?: string;
   prompt?: string;
+  launchMode?: AgentLaunchMode;
 }): string {
   return buildDockerExecCommand(
     input.containerName,

--- a/backend/src/services/lifecycle-service.ts
+++ b/backend/src/services/lifecycle-service.ts
@@ -21,6 +21,7 @@ import type { WorktreeCreationPhase, WorktreeMeta } from "../domain/model";
 import { allocateServicePorts, isValidBranchName, isValidEnvKey } from "../domain/policies";
 import type { AutoNameGenerator } from "./auto-name-service";
 import {
+  type AgentLaunchMode,
   buildAgentPaneCommand,
   buildDockerAgentPaneCommand,
   buildDockerShellCommand,
@@ -184,6 +185,7 @@ export class LifecycleService {
         initialized,
         worktreePath,
         prompt: input.prompt,
+        launchMode: "fresh",
       });
 
       await this.reportCreateProgress({
@@ -218,6 +220,7 @@ export class LifecycleService {
   }> {
     try {
       const resolved = await this.resolveExistingWorktree(branch);
+      const launchMode: AgentLaunchMode = resolved.meta ? "resume" : "fresh";
       const initialized = resolved.meta
         ? await this.refreshManagedArtifacts(resolved)
         : await this.initializeUnmanagedWorktree(resolved);
@@ -233,6 +236,7 @@ export class LifecycleService {
         agent: initialized.meta.agent,
         initialized,
         worktreePath: resolved.entry.path,
+        launchMode,
       });
 
       await this.deps.reconciliation.reconcile(this.deps.projectRoot);
@@ -467,6 +471,7 @@ export class LifecycleService {
     initialized: InitializeManagedWorktreeResult;
     worktreePath: string;
     prompt?: string;
+    launchMode: AgentLaunchMode;
   }): Promise<void> {
     if (input.profile.runtime === "docker") {
       const dockerProfile = this.requireDockerProfile(input.profile);
@@ -485,6 +490,7 @@ export class LifecycleService {
         initialized: input.initialized,
         worktreePath: input.worktreePath,
         prompt: input.prompt,
+        launchMode: input.launchMode,
         containerName,
       }));
       return;
@@ -497,6 +503,7 @@ export class LifecycleService {
       initialized: input.initialized,
       worktreePath: input.worktreePath,
       prompt: input.prompt,
+      launchMode: input.launchMode,
     }));
   }
 
@@ -507,9 +514,10 @@ export class LifecycleService {
     initialized: InitializeManagedWorktreeResult;
     worktreePath: string;
     prompt?: string;
+    launchMode: AgentLaunchMode;
     containerName?: string;
   }) {
-    const systemPrompt = input.profile.systemPrompt
+    const systemPrompt = input.launchMode === "fresh" && input.profile.systemPrompt
       ? expandTemplate(input.profile.systemPrompt, input.initialized.runtimeEnv)
       : undefined;
     const containerName = input.containerName;
@@ -530,7 +538,8 @@ export class LifecycleService {
                 runtimeEnvPath: input.initialized.paths.runtimeEnvPath,
                 yolo: input.profile.yolo === true,
                 systemPrompt,
-                prompt: input.prompt,
+                prompt: input.launchMode === "fresh" ? input.prompt : undefined,
+                launchMode: input.launchMode,
               }),
               shell: buildDockerShellCommand(
                 containerName,
@@ -544,7 +553,8 @@ export class LifecycleService {
                 runtimeEnvPath: input.initialized.paths.runtimeEnvPath,
                 yolo: input.profile.yolo === true,
                 systemPrompt,
-                prompt: input.prompt,
+                prompt: input.launchMode === "fresh" ? input.prompt : undefined,
+                launchMode: input.launchMode,
               }),
               shell: buildManagedShellCommand(input.initialized.paths.runtimeEnvPath),
         },


### PR DESCRIPTION
## Summary
Resume the last Claude or Codex conversation when a managed worktree is reopened instead of always starting a fresh interactive agent session.

## Changes
- add an explicit fresh vs resume launch mode to the backend agent command builder
- reopen managed Claude worktrees with `claude --continue` and managed Codex worktrees with `codex resume --last`
- avoid replaying the original create-time prompt or system prompt when reopening a managed worktree
- add backend tests covering fresh vs resume command generation and managed reopen behavior for both agents

## Test plan
- [x] `cd backend && bun test src/__tests__/agent-service.test.ts src/__tests__/lifecycle-service.test.ts`
- [x] `cd backend && bun run check`

---
Generated with [Claude Code](https://claude.com/claude-code)