### PR TITLE
feat: add webmux prune command

### DIFF
--- a/backend/src/__tests__/lifecycle-service.test.ts
+++ b/backend/src/__tests__/lifecycle-service.test.ts
@@ -677,6 +677,36 @@ describe("LifecycleService", () => {
     expect(run(["git", "branch", "--list", "feature-ahead"], repoRoot)).toBe("");
   });
 
+  it("prunes all project worktrees", async () => {
+    const repoRoot = await initRepo();
+    const runtime = new ProjectRuntime();
+    const tmux = new FakeTmuxGateway();
+    const docker = new FakeDockerGateway();
+    const hooks = new FakeHookRunner();
+    const lifecycle = makeLifecycleService(repoRoot, tmux, runtime, docker, hooks);
+
+    await lifecycle.createWorktree({ branch: "feature-prune-host" });
+    await lifecycle.createWorktree({ branch: "feature-prune-docker", profile: "sandbox" });
+    await lifecycle.closeWorktree("feature-prune-host");
+
+    const result = await lifecycle.pruneWorktrees();
+
+    expect(result.removedBranches).toEqual([
+      "feature-prune-docker",
+      "feature-prune-host",
+    ]);
+    expect(hooks.calls.filter((call) => call.name === "preRemove").map((call) => call.cwd).sort()).toEqual([
+      join(repoRoot, "__worktrees", "feature-prune-docker"),
+      join(repoRoot, "__worktrees", "feature-prune-host"),
+    ]);
+    expect(docker.removed).toEqual(["feature-prune-docker"]);
+    expect(new BunGitGateway().listWorktrees(repoRoot).filter((entry) => entry.path !== repoRoot)).toEqual([]);
+    expect(run(["git", "branch", "--list", "feature-prune-host"], repoRoot)).toBe("");
+    expect(run(["git", "branch", "--list", "feature-prune-docker"], repoRoot)).toBe("");
+    expect(tmux.listWindows()).toEqual([]);
+    expect(runtime.listWorktrees()).toEqual([]);
+  });
+
   it("removes the sandbox container before deleting a docker worktree", async () => {
     const repoRoot = await initRepo();
     const runtime = new ProjectRuntime();

--- a/backend/src/services/lifecycle-service.ts
+++ b/backend/src/services/lifecycle-service.ts
@@ -85,6 +85,10 @@ export interface CreateLifecycleWorktreeInput {
   envOverrides?: Record<string, string>;
 }
 
+export interface PruneWorktreesResult {
+  removedBranches: string[];
+}
+
 export class LifecycleError extends Error {
   constructor(
     message: string,
@@ -268,6 +272,23 @@ export class LifecycleService {
     }
   }
 
+  async pruneWorktrees(): Promise<PruneWorktreesResult> {
+    try {
+      const resolvedWorktrees = await this.resolveAllWorktrees();
+      const removedBranches: string[] = [];
+
+      for (const resolved of resolvedWorktrees) {
+        const branch = resolved.entry.branch ?? resolved.entry.path;
+        await this.removeResolvedWorktree(resolved);
+        removedBranches.push(branch);
+      }
+
+      return { removedBranches };
+    } catch (error) {
+      throw this.wrapOperationError(error);
+    }
+  }
+
   async mergeWorktree(branch: string): Promise<void> {
     try {
       const resolved = await this.resolveExistingWorktree(branch);
@@ -396,6 +417,18 @@ export class LifecycleService {
     const gitDir = this.deps.git.resolveWorktreeGitDir(entry.path);
     const meta = await readWorktreeMeta(gitDir);
     return { entry, gitDir, meta };
+  }
+
+  private async resolveAllWorktrees(): Promise<ResolvedLifecycleWorktree[]> {
+    const entries = this.listProjectWorktrees().sort((left, right) =>
+      (left.branch ?? left.path).localeCompare(right.branch ?? right.path)
+    );
+
+    return await Promise.all(entries.map(async (entry) => {
+      const gitDir = this.deps.git.resolveWorktreeGitDir(entry.path);
+      const meta = await readWorktreeMeta(gitDir);
+      return { entry, gitDir, meta };
+    }));
   }
 
   private async initializeUnmanagedWorktree(

--- a/bin/src/completions.test.ts
+++ b/bin/src/completions.test.ts
@@ -119,6 +119,7 @@ describe("runCompletionCommand", () => {
     const output = spy.mock.calls[0]?.[0];
     expect(output).toContain("#compdef webmux");
     expect(output).toContain("compdef _webmux webmux");
+    expect(output).toContain("prune:Remove all worktrees in the current project");
     expect(output).not.toContain('_webmux "$@"');
     spy.mockRestore();
   });
@@ -128,6 +129,7 @@ describe("runCompletionCommand", () => {
     const code = runCompletionCommand(["bash"]);
     expect(code).toBe(0);
     expect(spy).toHaveBeenCalledWith(expect.stringContaining("complete -F _webmux webmux"));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("prune"));
     spy.mockRestore();
   });
 });

--- a/bin/src/completions.ts
+++ b/bin/src/completions.ts
@@ -127,6 +127,7 @@ _webmux() {
     'close:Close a worktree session'
     'remove:Remove a worktree'
     'merge:Merge a worktree into main'
+    'prune:Remove all worktrees in the current project'
     'completion:Generate shell completion script'
   )
 
@@ -176,7 +177,7 @@ const BASH_SCRIPT = `_webmux() {
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
-    COMPREPLY=($(compgen -W "serve init service update add list open close remove merge completion" -- "\${cur}"))
+    COMPREPLY=($(compgen -W "serve init service update add list open close remove merge prune completion" -- "\${cur}"))
     return
   fi
 

--- a/bin/src/webmux.test.ts
+++ b/bin/src/webmux.test.ts
@@ -65,6 +65,17 @@ describe("webmux entrypoint", () => {
     });
   });
 
+  it("parses prune as a worktree command", () => {
+    delete process.env.PORT;
+
+    expect(parseRootArgs(["prune"])).toEqual({
+      port: 5111,
+      debug: false,
+      command: "prune",
+      commandArgs: [],
+    });
+  });
+
   it("runs worktree commands from a project subdirectory", async () => {
     const repoRoot = await mkdtemp(join(tmpdir(), "webmux-cli-"));
     tempDirs.push(repoRoot);

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -25,6 +25,7 @@ Usage:
   webmux close        Close a worktree session without removing it
   webmux remove       Remove a worktree
   webmux merge        Merge a worktree into the main branch and remove it
+  webmux prune        Remove all worktrees in the current project
   webmux completion   Generate shell completion script (bash, zsh)
 
 Options:
@@ -38,7 +39,7 @@ Environment:
 `);
 }
 
-type RootCommand = "serve" | "init" | "service" | "update" | "add" | "list" | "open" | "close" | "remove" | "merge" | "completion" | null;
+type RootCommand = "serve" | "init" | "service" | "update" | "add" | "list" | "open" | "close" | "remove" | "merge" | "prune" | "completion" | null;
 
 interface ParsedRootArgs {
   port: number;
@@ -58,6 +59,7 @@ function isRootCommand(value: string): value is NonNullable<RootCommand> {
     || value === "close"
     || value === "remove"
     || value === "merge"
+    || value === "prune"
     || value === "completion";
 }
 
@@ -121,13 +123,14 @@ export function parseRootArgs(args: string[]): ParsedRootArgs {
   };
 }
 
-function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "open" | "close" | "remove" | "merge" {
+function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "open" | "close" | "remove" | "merge" | "prune" {
   return command === "add"
     || command === "list"
     || command === "open"
     || command === "close"
     || command === "remove"
-    || command === "merge";
+    || command === "merge"
+    || command === "prune";
 }
 
 // ── Load env files from CWD (.env.local overrides .env) ─────────────────────

--- a/bin/src/worktree-commands.test.ts
+++ b/bin/src/worktree-commands.test.ts
@@ -22,6 +22,10 @@ function stubLifecycleService(calls: Array<{ method: string; value: unknown }>) 
     async mergeWorktree(branch: string): Promise<void> {
       calls.push({ method: "mergeWorktree", value: branch });
     },
+    async pruneWorktrees(): Promise<{ removedBranches: string[] }> {
+      calls.push({ method: "pruneWorktrees", value: null });
+      return { removedBranches: ["feature/search", "feature/api"] };
+    },
   };
 }
 
@@ -183,6 +187,66 @@ describe("runWorktreeCommand", () => {
     expect(stdout).toEqual(["Merged feature/search into develop"]);
   });
 
+  it("prunes all worktrees after confirmation", async () => {
+    const { runtime, calls } = makeRuntime();
+    runtime.git = stubGit([
+      { path: "/repo", branch: "main", bare: false },
+      { path: "/repo/.worktrees/feature-search", branch: "feature/search", bare: false },
+      { path: "/repo/.worktrees/feature-api", branch: "feature/api", bare: false },
+    ]);
+    const stdout: string[] = [];
+    const confirmCalls: number[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      {
+        command: "prune",
+        args: [],
+        projectDir: "/repo",
+        port: 5111,
+      },
+      {
+        createRuntime: () => runtime,
+        confirmPrune: async (count) => {
+          confirmCalls.push(count);
+          return true;
+        },
+        stdout: (message) => stdout.push(message),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(confirmCalls).toEqual([2]);
+    expect(calls).toEqual([{ method: "pruneWorktrees", value: null }]);
+    expect(stdout).toEqual(["Pruned 2 worktrees: feature/search, feature/api"]);
+  });
+
+  it("aborts prune when confirmation is declined", async () => {
+    const { runtime, calls } = makeRuntime();
+    runtime.git = stubGit([
+      { path: "/repo", branch: "main", bare: false },
+      { path: "/repo/.worktrees/feature-search", branch: "feature/search", bare: false },
+    ]);
+    const stdout: string[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      {
+        command: "prune",
+        args: [],
+        projectDir: "/repo",
+        port: 5111,
+      },
+      {
+        createRuntime: () => runtime,
+        confirmPrune: async () => false,
+        stdout: (message) => stdout.push(message),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([]);
+    expect(stdout).toEqual(["Aborted."]);
+  });
+
   it("returns a failing exit code when lifecycle execution fails", async () => {
     const stdout: string[] = [];
     const stderr: string[] = [];
@@ -218,6 +282,9 @@ describe("runWorktreeCommand", () => {
               throw new Error("Worktree has uncommitted changes: feature/search");
             },
             async mergeWorktree(): Promise<void> {
+              throw new Error("not used");
+            },
+            async pruneWorktrees(): Promise<{ removedBranches: string[] }> {
               throw new Error("not used");
             },
           },
@@ -328,5 +395,25 @@ describe("runWorktreeCommand", () => {
     expect(exitCode).toBe(0);
     expect(createRuntimeCalled).toBe(false);
     expect(stdout).toEqual(["Usage:\n  webmux list"]);
+  });
+
+  it("prints prune help without creating a runtime", async () => {
+    let createRuntimeCalled = false;
+    const stdout: string[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      { command: "prune", args: ["--help"], projectDir: "/repo", port: 5111 },
+      {
+        createRuntime: () => {
+          createRuntimeCalled = true;
+          throw new Error("unexpected");
+        },
+        stdout: (msg) => stdout.push(msg),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(createRuntimeCalled).toBe(false);
+    expect(stdout).toEqual(["Usage:\n  webmux prune"]);
   });
 });

--- a/bin/src/worktree-commands.ts
+++ b/bin/src/worktree-commands.ts
@@ -1,12 +1,13 @@
+import * as p from "@clack/prompts";
 import { basename, resolve } from "node:path";
 import { readWorktreeMeta } from "../../backend/src/adapters/fs";
 import { buildProjectSessionName, buildWorktreeWindowName } from "../../backend/src/adapters/tmux";
 import type { AgentKind } from "../../backend/src/domain/config";
 import { isValidWorktreeName } from "../../backend/src/domain/policies";
 import { createWebmuxRuntime } from "../../backend/src/runtime";
-import type { CreateLifecycleWorktreeInput } from "../../backend/src/services/lifecycle-service";
+import type { CreateLifecycleWorktreeInput, PruneWorktreesResult } from "../../backend/src/services/lifecycle-service";
 
-export type WorktreeSubcommand = "add" | "list" | "open" | "close" | "remove" | "merge";
+export type WorktreeSubcommand = "add" | "list" | "open" | "close" | "remove" | "merge" | "prune";
 
 interface LifecycleServiceLike {
   createWorktree(input: CreateLifecycleWorktreeInput): Promise<{ branch: string; worktreeId: string }>;
@@ -14,6 +15,7 @@ interface LifecycleServiceLike {
   closeWorktree(branch: string): Promise<void>;
   removeWorktree(branch: string): Promise<void>;
   mergeWorktree(branch: string): Promise<void>;
+  pruneWorktrees(): Promise<PruneWorktreesResult>;
 }
 
 interface WorktreeRuntimeLike {
@@ -45,6 +47,7 @@ interface WorktreeCommandDependencies {
   stdout?: (message: string) => void;
   stderr?: (message: string) => void;
   switchToTmuxWindow?: (projectDir: string, branch: string) => void;
+  confirmPrune?: (worktreeCount: number) => Promise<boolean>;
 }
 
 class CommandUsageError extends Error {}
@@ -73,6 +76,8 @@ export function getWorktreeCommandUsage(command: WorktreeSubcommand): string {
       return "Usage:\n  webmux remove <branch>";
     case "merge":
       return "Usage:\n  webmux merge <branch>";
+    case "prune":
+      return "Usage:\n  webmux prune";
   }
 }
 
@@ -203,6 +208,38 @@ export function parseBranchCommandArgs(args: string[]): string | null {
   return branch;
 }
 
+function parsePruneCommandArgs(args: string[]): boolean {
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      return false;
+    }
+
+    if (arg.startsWith("-")) {
+      throw new CommandUsageError(`Unknown option: ${arg}`);
+    }
+
+    throw new CommandUsageError(`Unexpected argument: ${arg}`);
+  }
+
+  return true;
+}
+
+function listProjectWorktrees(
+  runtime: WorktreeRuntimeLike,
+): Array<{ path: string; branch: string | null; bare: boolean }> {
+  const projectDir = resolve(runtime.projectDir);
+  return runtime.git.listWorktrees(projectDir)
+    .filter((entry) => !entry.bare && resolve(entry.path) !== projectDir);
+}
+
+async function defaultConfirmPrune(worktreeCount: number): Promise<boolean> {
+  const response = await p.confirm({
+    message: `Prune all ${worktreeCount} worktree${worktreeCount === 1 ? "" : "s"}? This action cannot be undone.`,
+    initialValue: false,
+  });
+  return !p.isCancel(response) && response;
+}
+
 function defaultSwitchToTmuxWindow(projectDir: string, branch: string): void {
   const sessionName = buildProjectSessionName(resolve(projectDir));
   const windowName = buildWorktreeWindowName(branch);
@@ -239,8 +276,7 @@ async function listWorktrees(
   stdout: (message: string) => void,
 ): Promise<void> {
   const projectDir = resolve(runtime.projectDir);
-  const entries = runtime.git.listWorktrees(projectDir)
-    .filter((entry) => !entry.bare && resolve(entry.path) !== projectDir);
+  const entries = listProjectWorktrees(runtime);
 
   if (entries.length === 0) {
     stdout("No worktrees found.");
@@ -287,6 +323,7 @@ export async function runWorktreeCommand(
   const stdout = deps.stdout ?? ((message: string) => console.log(message));
   const stderr = deps.stderr ?? ((message: string) => console.error(message));
   const switchToTmuxWindow = deps.switchToTmuxWindow ?? defaultSwitchToTmuxWindow;
+  const confirmPrune = deps.confirmPrune ?? defaultConfirmPrune;
 
   try {
     if (context.command === "add") {
@@ -320,7 +357,39 @@ export async function runWorktreeCommand(
       return 0;
     }
 
-    const command: Exclude<WorktreeSubcommand, "add" | "list"> = context.command;
+    if (context.command === "prune") {
+      if (!parsePruneCommandArgs(context.args)) {
+        stdout(getWorktreeCommandUsage("prune"));
+        return 0;
+      }
+
+      const runtime = createRuntime({
+        projectDir: context.projectDir,
+        port: context.port,
+      });
+      const worktrees = listProjectWorktrees(runtime);
+      if (worktrees.length === 0) {
+        stdout("No worktrees found.");
+        return 0;
+      }
+
+      if (!await confirmPrune(worktrees.length)) {
+        stdout("Aborted.");
+        return 0;
+      }
+
+      const result = await runtime.lifecycleService.pruneWorktrees();
+      if (result.removedBranches.length === 0) {
+        stdout("No worktrees found.");
+        return 0;
+      }
+      stdout(
+        `Pruned ${result.removedBranches.length} worktree${result.removedBranches.length === 1 ? "" : "s"}: ${result.removedBranches.join(", ")}`,
+      );
+      return 0;
+    }
+
+    const command: Exclude<WorktreeSubcommand, "add" | "list" | "prune"> = context.command;
     const branch = parseBranchCommandArgs(context.args);
     if (!branch) {
       stdout(getWorktreeCommandUsage(command));


### PR DESCRIPTION
## Summary
Add a new `webmux prune` CLI command so users can delete all worktrees in the current project from the terminal, with an explicit confirmation step before removal.

## Changes
- add `pruneWorktrees()` to the lifecycle service to remove all project worktrees and return the removed branch names
- add `webmux prune` parsing, help text, confirmation, and output handling in the CLI worktree command layer
- update shell completions and CLI/backend tests to cover prune parsing, confirmation, and full lifecycle cleanup

## Test plan
- [ ] Run `bun run --cwd backend check`
- [ ] Run `bun run --cwd backend test`
- [ ] Run `bun test bin/src`
- [ ] Run `bun run --cwd frontend check`
- [ ] Run `bun run --cwd frontend test`
- [ ] Run `webmux prune` in a repo with multiple worktrees and verify the confirmation prompt and cleanup behavior

---
Generated with [Claude Code](https://claude.com/claude-code)
