### PR TITLE
feat: add existing branch worktree picker

### DIFF
--- a/backend/src/__tests__/git-adapter.test.ts
+++ b/backend/src/__tests__/git-adapter.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   BunGitGateway,
+  listLocalGitBranches,
   parseGitWorktreePorcelain,
   readGitWorktreeStatus,
   removeGitWorktree,
@@ -124,6 +125,7 @@ describe("BunGitGateway", () => {
       repoRoot,
       worktreePath,
       branch: "feature-a",
+      mode: "new",
       baseBranch: "main",
     });
 
@@ -136,6 +138,47 @@ describe("BunGitGateway", () => {
     });
 
     expect(gateway.listWorktrees(repoRoot).some((entry) => entry.path === worktreePath)).toBe(false);
+  });
+
+  it("creates a worktree for an existing branch", async () => {
+    repoRoot = await mkdtemp(join(tmpdir(), "webmux-gitgw-existing-"));
+    run(["git", "init", "-b", "main"], repoRoot);
+    run(["git", "config", "user.name", "Test User"], repoRoot);
+    run(["git", "config", "user.email", "test@example.com"], repoRoot);
+    await Bun.write(join(repoRoot, "README.md"), "# repo\n");
+    run(["git", "add", "README.md"], repoRoot);
+    run(["git", "commit", "-m", "init"], repoRoot);
+    run(["git", "checkout", "-b", "feature-existing"], repoRoot);
+    run(["git", "checkout", "main"], repoRoot);
+
+    const gateway = new BunGitGateway();
+    const worktreePath = join(repoRoot, "__worktrees", "feature-existing");
+    await mkdir(join(repoRoot, "__worktrees"), { recursive: true });
+
+    gateway.createWorktree({
+      repoRoot,
+      worktreePath,
+      branch: "feature-existing",
+      mode: "existing",
+    });
+
+    expect(gateway.listWorktrees(repoRoot).some((entry) => entry.path === worktreePath)).toBe(true);
+    expect(read(["git", "branch", "--show-current"], worktreePath)).toBe("feature-existing");
+  });
+
+  it("lists local branches", async () => {
+    repoRoot = await mkdtemp(join(tmpdir(), "webmux-gitgw-branches-"));
+    run(["git", "init", "-b", "main"], repoRoot);
+    run(["git", "config", "user.name", "Test User"], repoRoot);
+    run(["git", "config", "user.email", "test@example.com"], repoRoot);
+    await Bun.write(join(repoRoot, "README.md"), "# repo\n");
+    run(["git", "add", "README.md"], repoRoot);
+    run(["git", "commit", "-m", "init"], repoRoot);
+    run(["git", "checkout", "-b", "feature-a"], repoRoot);
+    run(["git", "checkout", "-b", "feature-b", "main"], repoRoot);
+    run(["git", "checkout", "main"], repoRoot);
+
+    expect(listLocalGitBranches(repoRoot)).toEqual(["feature-a", "feature-b", "main"]);
   });
 
   it("merges a source branch into a target branch", async () => {

--- a/backend/src/__tests__/lifecycle-service.test.ts
+++ b/backend/src/__tests__/lifecycle-service.test.ts
@@ -453,6 +453,77 @@ describe("LifecycleService", () => {
     expect(await Bun.file(join(worktreePath, "README.md")).exists()).toBe(true);
   });
 
+  it("creates a managed worktree for an existing local branch", async () => {
+    const repoRoot = await initRepo();
+    const runtime = new ProjectRuntime();
+    const tmux = new FakeTmuxGateway();
+    const lifecycle = makeLifecycleService(repoRoot, tmux, runtime);
+
+    run(["git", "checkout", "-b", "feature-follow"], repoRoot);
+    run(["git", "checkout", "main"], repoRoot);
+
+    const created = await lifecycle.createWorktree({
+      mode: "existing",
+      branch: "feature-follow",
+    });
+
+    const worktreePath = join(repoRoot, "__worktrees", "feature-follow");
+    const gitDir = new BunGitGateway().resolveWorktreeGitDir(worktreePath);
+
+    expect(created.branch).toBe("feature-follow");
+    expect(new BunGitGateway().listWorktrees(repoRoot).some((entry) =>
+      entry.branch === "feature-follow" && entry.path === worktreePath
+    )).toBe(true);
+    expect((await readWorktreeMeta(gitDir))?.branch).toBe("feature-follow");
+    expect(run(["git", "branch", "--show-current"], worktreePath)).toBe("feature-follow");
+  });
+
+  it("lists available branches excluding branches already checked out", async () => {
+    const repoRoot = await initRepo();
+    const runtime = new ProjectRuntime();
+    const tmux = new FakeTmuxGateway();
+    const lifecycle = makeLifecycleService(repoRoot, tmux, runtime);
+    const git = new BunGitGateway();
+
+    run(["git", "branch", "feature-available", "main"], repoRoot);
+    run(["git", "branch", "feature-in-use", "main"], repoRoot);
+    git.createWorktree({
+      repoRoot,
+      worktreePath: join(repoRoot, "__worktrees", "feature-in-use"),
+      branch: "feature-in-use",
+      mode: "existing",
+    });
+
+    expect(lifecycle.listAvailableBranches()).toEqual([
+      { name: "feature-available" },
+    ]);
+  });
+
+  it("keeps an existing branch when creation fails after the worktree is created", async () => {
+    const repoRoot = await initRepo();
+    const runtime = new ProjectRuntime();
+    const tmux = new FakeTmuxGateway();
+    const hooks = new FakeHookRunner(() => {
+      throw new Error("post-create failed");
+    });
+    const lifecycle = makeLifecycleService(repoRoot, tmux, runtime, new FakeDockerGateway(), hooks);
+
+    run(["git", "checkout", "-b", "feature-existing-rollback"], repoRoot);
+    run(["git", "checkout", "main"], repoRoot);
+
+    await expect(
+      lifecycle.createWorktree({
+        mode: "existing",
+        branch: "feature-existing-rollback",
+      }),
+    ).rejects.toThrow("post-create failed");
+
+    const worktreePath = join(repoRoot, "__worktrees", "feature-existing-rollback");
+
+    expect(new BunGitGateway().listWorktrees(repoRoot).some((entry) => entry.path === worktreePath)).toBe(false);
+    expect(run(["git", "branch", "--list", "feature-existing-rollback"], repoRoot)).toContain("feature-existing-rollback");
+  });
+
   it("opens an unmanaged worktree by initializing metadata and rebuilding tmux layout", async () => {
     const repoRoot = await initRepo();
     const runtime = new ProjectRuntime();
@@ -465,6 +536,7 @@ describe("LifecycleService", () => {
       repoRoot,
       worktreePath,
       branch: "feature-open",
+      mode: "new",
       baseBranch: "main",
     });
 
@@ -726,6 +798,7 @@ describe("LifecycleService", () => {
       repoRoot,
       worktreePath: unmanagedPath,
       branch: "feature-no-default-open",
+      mode: "new",
       baseBranch: "main",
     });
 

--- a/backend/src/__tests__/reconciliation-service.test.ts
+++ b/backend/src/__tests__/reconciliation-service.test.ts
@@ -32,6 +32,10 @@ class FakeGitGateway implements GitGateway {
     return this.worktrees;
   }
 
+  listLocalBranches(): string[] {
+    return [];
+  }
+
   readWorktreeStatus(cwd: string): GitWorktreeStatus {
     return this.statuses.get(cwd) ?? { dirty: false, aheadCount: 0, currentCommit: null };
   }

--- a/backend/src/__tests__/worktree-storage.test.ts
+++ b/backend/src/__tests__/worktree-storage.test.ts
@@ -47,6 +47,10 @@ class FakeGitGateway implements GitGateway {
     return [];
   }
 
+  listLocalBranches(): string[] {
+    return [];
+  }
+
   readWorktreeStatus() {
     return {
       dirty: false,
@@ -55,8 +59,16 @@ class FakeGitGateway implements GitGateway {
     };
   }
 
-  createWorktree(opts: { repoRoot: string; worktreePath: string; branch: string; baseBranch?: string }): void {
-    this.calls.push(`createWorktree:${opts.repoRoot}:${opts.worktreePath}:${opts.branch}:${opts.baseBranch ?? ""}`);
+  createWorktree(opts: {
+    repoRoot: string;
+    worktreePath: string;
+    branch: string;
+    mode: "new" | "existing";
+    baseBranch?: string;
+  }): void {
+    this.calls.push(
+      `createWorktree:${opts.repoRoot}:${opts.worktreePath}:${opts.branch}:${opts.mode}:${opts.baseBranch ?? ""}`,
+    );
   }
 
   removeWorktree(): void {
@@ -381,6 +393,7 @@ describe("initializeManagedWorktree", () => {
         repoRoot: "/repo/project",
         worktreePath,
         branch: "feature/search-panel",
+        mode: "new",
         baseBranch: "main",
         profile: "default",
         agent: "claude",
@@ -411,7 +424,7 @@ describe("initializeManagedWorktree", () => {
       { git, tmux },
     );
 
-    expect(calls[0]).toBe(`createWorktree:/repo/project:${worktreePath}:feature/search-panel:main`);
+    expect(calls[0]).toBe(`createWorktree:/repo/project:${worktreePath}:feature/search-panel:new:main`);
     expect(calls).toContain("ensureServer");
     expect(calls.some((call) => call.startsWith("createWindow:wm-project-12345678:wm-feature/search-panel"))).toBe(true);
 
@@ -437,6 +450,7 @@ describe("initializeManagedWorktree", () => {
           repoRoot,
           worktreePath,
           branch: "feature-rollback",
+          mode: "new",
           baseBranch: "main",
           profile: "default",
           agent: "claude",
@@ -473,6 +487,7 @@ describe("initializeManagedWorktree", () => {
           repoRoot,
           worktreePath,
           branch: "feature-tmux-rollback",
+          mode: "new",
           baseBranch: "main",
           profile: "default",
           agent: "claude",

--- a/backend/src/adapters/git.ts
+++ b/backend/src/adapters/git.ts
@@ -9,12 +9,24 @@ export interface GitWorktreeEntry {
   bare: boolean;
 }
 
-export interface CreateGitWorktreeOptions {
+export type CreateWorktreeMode = "new" | "existing";
+
+interface BaseCreateGitWorktreeOptions {
   repoRoot: string;
   worktreePath: string;
   branch: string;
+}
+
+export interface CreateNewGitWorktreeOptions extends BaseCreateGitWorktreeOptions {
+  mode: "new";
   baseBranch?: string;
 }
+
+export interface CreateExistingGitWorktreeOptions extends BaseCreateGitWorktreeOptions {
+  mode: "existing";
+}
+
+export type CreateGitWorktreeOptions = CreateNewGitWorktreeOptions | CreateExistingGitWorktreeOptions;
 
 export interface RemoveGitWorktreeOptions {
   repoRoot: string;
@@ -48,6 +60,7 @@ export interface GitGateway {
   resolveWorktreeRoot(cwd: string): string;
   resolveWorktreeGitDir(cwd: string): string;
   listWorktrees(cwd: string): GitWorktreeEntry[];
+  listLocalBranches(cwd: string): string[];
   readWorktreeStatus(cwd: string): GitWorktreeStatus;
   createWorktree(opts: CreateGitWorktreeOptions): void;
   removeWorktree(opts: RemoveGitWorktreeOptions): void;
@@ -191,6 +204,14 @@ export function listGitWorktrees(cwd: string): GitWorktreeEntry[] {
   return parseGitWorktreePorcelain(output);
 }
 
+export function listLocalGitBranches(cwd: string): string[] {
+  const output = runGit(["for-each-ref", "--format=%(refname:short)", "refs/heads"], cwd);
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
 export function readGitWorktreeStatus(cwd: string): GitWorktreeStatus {
   const dirtyOutput = runGit(["status", "--porcelain"], cwd);
   const commit = tryRunGit(["rev-parse", "HEAD"], cwd);
@@ -242,13 +263,22 @@ export class BunGitGateway implements GitGateway {
     return listGitWorktrees(cwd);
   }
 
+  listLocalBranches(cwd: string): string[] {
+    return listLocalGitBranches(cwd);
+  }
+
   readWorktreeStatus(cwd: string): GitWorktreeStatus {
     return readGitWorktreeStatus(cwd);
   }
 
   createWorktree(opts: CreateGitWorktreeOptions): void {
-    const args = ["worktree", "add", "-b", opts.branch, opts.worktreePath];
-    if (opts.baseBranch) args.push(opts.baseBranch);
+    const args = ["worktree", "add"];
+    if (opts.mode === "new") {
+      args.push("-b", opts.branch, opts.worktreePath);
+      if (opts.baseBranch) args.push(opts.baseBranch);
+    } else {
+      args.push(opts.worktreePath, opts.branch);
+    }
     runGit(args, opts.repoRoot);
   }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -314,6 +314,12 @@ async function apiRuntimeEvent(req: Request): Promise<Response> {
   });
 }
 
+async function apiListBranches(): Promise<Response> {
+  return jsonResponse({
+    branches: lifecycleService.listAvailableBranches(),
+  });
+}
+
 async function apiCreateWorktree(req: Request): Promise<Response> {
   const raw: unknown = await req.json();
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
@@ -336,15 +342,21 @@ async function apiCreateWorktree(req: Request): Promise<Response> {
   const prompt = typeof body.prompt === "string" ? body.prompt : undefined;
   const profile = typeof body.profile === "string" ? body.profile : undefined;
   const agent = body.agent === "claude" || body.agent === "codex" ? body.agent : undefined;
+  const mode = body.mode;
+
+  if (mode !== undefined && mode !== "new" && mode !== "existing") {
+    return errorResponse("Invalid worktree create mode", 400);
+  }
 
   if (branch) {
     ensureBranchNotCreating(branch);
   }
 
   log.info(
-    `[worktree:add]${branch ? ` branch=${branch}` : ""}${profile ? ` profile=${profile}` : ""}${agent ? ` agent=${agent}` : ""}${prompt ? ` prompt="${prompt.slice(0, 80)}"` : ""}`,
+    `[worktree:add] mode=${mode ?? "new"}${branch ? ` branch=${branch}` : ""}${profile ? ` profile=${profile}` : ""}${agent ? ` agent=${agent}` : ""}${prompt ? ` prompt="${prompt.slice(0, 80)}"` : ""}`,
   );
   const result = await lifecycleService.createWorktree({
+    mode,
     branch,
     prompt,
     profile,
@@ -448,6 +460,10 @@ Bun.serve({
 
     "/api/config": {
       GET: () => jsonResponse(getFrontendConfig()),
+    },
+
+    "/api/branches": {
+      GET: () => catching("GET /api/branches", () => apiListBranches()),
     },
 
     "/api/project": {

--- a/backend/src/services/lifecycle-service.ts
+++ b/backend/src/services/lifecycle-service.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { ensureAgentRuntimeArtifacts } from "../adapters/agent-runtime";
-import type { GitGateway, GitWorktreeEntry } from "../adapters/git";
+import type { CreateWorktreeMode, GitGateway, GitWorktreeEntry } from "../adapters/git";
 import type { LifecycleHookRunner, RunLifecycleHookInput } from "../adapters/hooks";
 import {
   buildControlEnvMap,
@@ -78,6 +78,7 @@ export interface LifecycleServiceDependencies {
 }
 
 export interface CreateLifecycleWorktreeInput {
+  mode?: CreateWorktreeMode;
   branch?: string;
   prompt?: string;
   profile?: string;
@@ -101,12 +102,14 @@ export class LifecycleService {
     branch: string;
     worktreeId: string;
   }> {
-    const branch = await this.resolveBranch(input.branch, input.prompt);
-    this.ensureBranchAvailable(branch);
+    const mode = input.mode ?? "new";
+    const branch = await this.resolveBranch(input.branch, input.prompt, mode);
+    this.ensureBranchAvailable(branch, mode);
 
     const { profileName, profile } = this.resolveProfile(input.profile);
     const agent = this.resolveAgent(input.agent);
     const worktreePath = this.resolveWorktreePath(branch);
+    const deleteBranchOnRollback = mode === "new";
     let initialized: InitializeManagedWorktreeResult | null = null;
 
     try {
@@ -125,7 +128,8 @@ export class LifecycleService {
           repoRoot: this.deps.projectRoot,
           worktreePath,
           branch,
-          baseBranch: this.deps.config.workspace.mainBranch,
+          mode,
+          ...(mode === "new" ? { baseBranch: this.deps.config.workspace.mainBranch } : {}),
           profile: profileName,
           agent,
           runtime: profile.runtime,
@@ -134,6 +138,7 @@ export class LifecycleService {
           runtimeEnvExtras: { WEBMUX_WORKTREE_PATH: worktreePath },
           controlUrl: this.controlUrl(),
           controlToken: await this.deps.getControlToken(),
+          deleteBranchOnRollback,
         },
         {
           git: this.deps.git,
@@ -201,7 +206,12 @@ export class LifecycleService {
       };
     } catch (error) {
       if (initialized) {
-        const cleanupError = await this.cleanupFailedCreate(branch, worktreePath, profile.runtime);
+        const cleanupError = await this.cleanupFailedCreate(
+          branch,
+          worktreePath,
+          profile.runtime,
+          deleteBranchOnRollback,
+        );
         if (cleanupError) {
           throw this.wrapOperationError(new Error(`${toErrorMessage(error)}; ${cleanupError}`));
         }
@@ -295,11 +305,28 @@ export class LifecycleService {
     }
   }
 
-  private async resolveBranch(rawBranch: string | undefined, prompt: string | undefined): Promise<string> {
+  listAvailableBranches(): Array<{ name: string }> {
+    const localBranches = this.listLocalBranches().filter((branch) => isValidBranchName(branch));
+    const checkedOutBranches = this.listCheckedOutBranches();
+
+    return localBranches
+      .filter((branch) => !checkedOutBranches.has(branch))
+      .sort((left, right) => left.localeCompare(right))
+      .map((name) => ({ name }));
+  }
+
+  private async resolveBranch(
+    rawBranch: string | undefined,
+    prompt: string | undefined,
+    mode: CreateWorktreeMode,
+  ): Promise<string> {
     const explicitBranch = rawBranch?.trim();
-    const branch = explicitBranch
-      || await this.generateAutoName(prompt)
-      || generateBranchName();
+    const branch = mode === "existing"
+      ? explicitBranch
+      : explicitBranch || await this.generateAutoName(prompt) || generateBranchName();
+    if (!branch) {
+      throw new LifecycleError("Existing branch is required", 400);
+    }
     if (!isValidBranchName(branch)) {
       throw new LifecycleError(`Invalid branch name: ${branch}`, 400);
     }
@@ -313,10 +340,21 @@ export class LifecycleService {
     return await this.deps.autoName.generateBranchName(this.deps.config.autoName, prompt);
   }
 
-  private ensureBranchAvailable(branch: string): void {
-    const exists = this.listProjectWorktrees().some((entry) => entry.branch === branch);
-    if (exists) {
-      throw new LifecycleError(`Worktree already exists: ${branch}`, 409);
+  private ensureBranchAvailable(branch: string, mode: CreateWorktreeMode): void {
+    const localBranches = new Set(this.listLocalBranches());
+    if (mode === "new") {
+      if (localBranches.has(branch)) {
+        throw new LifecycleError(`Branch already exists: ${branch}`, 409);
+      }
+      return;
+    }
+
+    if (!localBranches.has(branch)) {
+      throw new LifecycleError(`Branch not found: ${branch}`, 404);
+    }
+
+    if (this.listCheckedOutBranches().has(branch)) {
+      throw new LifecycleError(`Branch already has a worktree: ${branch}`, 409);
     }
   }
 
@@ -367,6 +405,18 @@ export class LifecycleService {
 
   private resolveWorktreePath(branch: string): string {
     return resolve(this.deps.projectRoot, this.deps.config.workspace.worktreeRoot, branch);
+  }
+
+  private listLocalBranches(): string[] {
+    return this.deps.git.listLocalBranches(resolve(this.deps.projectRoot));
+  }
+
+  private listCheckedOutBranches(): Set<string> {
+    return new Set(
+      this.deps.git.listWorktrees(resolve(this.deps.projectRoot))
+        .filter((entry): entry is GitWorktreeEntry & { branch: string } => !entry.bare && entry.branch !== null)
+        .map((entry) => entry.branch),
+    );
   }
 
   private listProjectWorktrees(): GitWorktreeEntry[] {
@@ -563,6 +613,7 @@ export class LifecycleService {
     branch: string,
     worktreePath: string,
     runtime: RuntimeKind,
+    deleteBranch: boolean,
   ): Promise<string | null> {
     const cleanupErrors: string[] = [];
 
@@ -590,8 +641,8 @@ export class LifecycleService {
           worktreePath,
           branch,
           force: true,
-          deleteBranch: true,
-          deleteBranchForce: true,
+          deleteBranch,
+          deleteBranchForce: deleteBranch,
         },
         this.deps.git,
       );

--- a/backend/src/services/worktree-service.ts
+++ b/backend/src/services/worktree-service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { BunGitGateway, type GitGateway } from "../adapters/git";
+import { BunGitGateway, type CreateWorktreeMode, type GitGateway } from "../adapters/git";
 import {
   buildControlEnvMap,
   buildRuntimeEnvMap,
@@ -46,6 +46,7 @@ export interface CreateManagedWorktreeOptions {
   repoRoot: string;
   worktreePath: string;
   branch: string;
+  mode: CreateWorktreeMode;
   baseBranch?: string;
   profile: string;
   agent: AgentKind;
@@ -57,6 +58,7 @@ export interface CreateManagedWorktreeOptions {
   controlToken?: string;
   now?: () => Date;
   worktreeId?: string;
+  deleteBranchOnRollback?: boolean;
   sessionLayoutPlan?: SessionLayoutPlan;
   sessionLayoutPlanBuilder?: (initialized: InitializeManagedWorktreeResult) => SessionLayoutPlan;
 }
@@ -104,7 +106,7 @@ function cleanupSessionLayout(
 }
 
 function rollbackManagedWorktreeCreation(
-  opts: Pick<CreateManagedWorktreeOptions, "repoRoot" | "worktreePath" | "branch">,
+  opts: Pick<CreateManagedWorktreeOptions, "repoRoot" | "worktreePath" | "branch" | "deleteBranchOnRollback">,
   sessionLayoutPlan: SessionLayoutPlan | undefined,
   git: GitGateway,
   deps: CreateManagedWorktreeDependencies,
@@ -123,10 +125,12 @@ function rollbackManagedWorktreeCreation(
     cleanupErrors.push(`worktree rollback failed: ${toErrorMessage(error)}`);
   }
 
-  try {
-    git.deleteBranch(opts.repoRoot, opts.branch, true);
-  } catch (error) {
-    cleanupErrors.push(`branch rollback failed: ${toErrorMessage(error)}`);
+  if (opts.deleteBranchOnRollback ?? true) {
+    try {
+      git.deleteBranch(opts.repoRoot, opts.branch, true);
+    } catch (error) {
+      cleanupErrors.push(`branch rollback failed: ${toErrorMessage(error)}`);
+    }
   }
 
   return cleanupErrors.length > 0 ? joinErrorMessages(cleanupErrors) : null;
@@ -190,6 +194,7 @@ export async function createManagedWorktree(
       repoRoot: opts.repoRoot,
       worktreePath: opts.worktreePath,
       branch: opts.branch,
+      mode: opts.mode,
       baseBranch: opts.baseBranch,
     });
     worktreeCreated = true;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,7 +12,15 @@
   import NotificationToast from "./lib/NotificationToast.svelte";
   import LinearPanel from "./lib/LinearPanel.svelte";
   import LinearDetailDialog from "./lib/LinearDetailDialog.svelte";
-  import type { WorktreeInfo, AppConfig, AppNotification, PrEntry, LinearIssue } from "./lib/types";
+  import type {
+    AvailableBranch,
+    WorktreeCreateMode,
+    WorktreeInfo,
+    AppConfig,
+    AppNotification,
+    PrEntry,
+    LinearIssue,
+  } from "./lib/types";
   import { SSH_STORAGE_KEY, errorMessage, worktreeCreationPhaseLabel } from "./lib/utils";
   import * as api from "./lib/api";
 
@@ -35,9 +43,13 @@
   let pendingCreateCount = $state(0);
   let latestAutoSelectCreateId = -1;
   let nextCreateRequestId = 0;
+  let nextBranchFetchId = 0;
   let sshHost = $state(localStorage.getItem(SSH_STORAGE_KEY) ?? "");
   let applyPollInterval: ((intervalMs: number) => void) | null = null;
   let pendingCreateBranchHint = $state<string | null>(null);
+  let availableBranches = $state<AvailableBranch[]>([]);
+  let availableBranchesLoading = $state(false);
+  let availableBranchesError = $state<string | null>(null);
 
   // Linear integration
   let linearIssues = $state<LinearIssue[]>([]);
@@ -160,6 +172,29 @@
   });
 
   $effect(() => {
+    if (!showCreateDialog) return;
+
+    const fetchId = ++nextBranchFetchId;
+    availableBranches = [];
+    availableBranchesLoading = true;
+    availableBranchesError = null;
+
+    api.fetchAvailableBranches()
+      .then((branches) => {
+        if (fetchId !== nextBranchFetchId) return;
+        availableBranches = branches;
+      })
+      .catch((err: unknown) => {
+        if (fetchId !== nextBranchFetchId) return;
+        availableBranchesError = errorMessage(err);
+      })
+      .finally(() => {
+        if (fetchId !== nextBranchFetchId) return;
+        availableBranchesLoading = false;
+      });
+  });
+
+  $effect(() => {
     document.title = config.name ? `${config.name} - Dashboard` : "Dev Dashboard";
   });
 
@@ -197,6 +232,7 @@
   }
 
   async function handleCreate(
+    mode: WorktreeCreateMode,
     name: string,
     profile: string,
     agent: string,
@@ -212,6 +248,7 @@
 
     try {
       const createPromise = api.createWorktree(
+        mode,
         name || undefined,
         profile,
         agent,
@@ -589,6 +626,9 @@
     autoNameEnabled={config.autoName}
     initialBranch={assignIssue?.branchName ?? ""}
     initialPrompt={assignIssue ? `${assignIssue.title}${assignIssue.description ? '\n\n' + assignIssue.description : ''}` : ""}
+    {availableBranches}
+    {availableBranchesLoading}
+    {availableBranchesError}
     startupEnvs={config.startupEnvs ?? {}}
     oncreate={handleCreate}
     oncancel={() => { showCreateDialog = false; assignIssue = null; }}

--- a/frontend/src/lib/CreateWorktreeDialog.svelte
+++ b/frontend/src/lib/CreateWorktreeDialog.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import type { ProfileConfig } from "./types";
+  import type { AvailableBranch, ProfileConfig, WorktreeCreateMode } from "./types";
   import BaseDialog from "./BaseDialog.svelte";
   import Btn from "./Btn.svelte";
   import StartupEnvFields from "./StartupEnvFields.svelte";
+  import { searchMatch } from "./utils";
 
   let {
     profiles = [],
@@ -10,6 +11,9 @@
     autoNameEnabled = false,
     initialBranch = "",
     initialPrompt = "",
+    availableBranches = [],
+    availableBranchesLoading = false,
+    availableBranchesError = null,
     startupEnvs = {},
     oncreate,
     oncancel,
@@ -19,8 +23,12 @@
     autoNameEnabled?: boolean;
     initialBranch?: string;
     initialPrompt?: string;
+    availableBranches?: AvailableBranch[];
+    availableBranchesLoading?: boolean;
+    availableBranchesError?: string | null;
     startupEnvs?: Record<string, string | boolean>;
     oncreate: (
+      mode: WorktreeCreateMode,
       name: string,
       profile: string,
       agent: string,
@@ -43,14 +51,20 @@
   const savedEnvs = localStorage.getItem(ENV_STORAGE_KEY);
 
   let fallbackProfile = $derived(defaultProfileName || profiles[0]?.name || "default");
+  let mode = $state<WorktreeCreateMode>("new");
   // svelte-ignore state_referenced_locally
-  let name = $state(initialBranch);
+  let newBranchName = $state(initialBranch);
   // svelte-ignore state_referenced_locally
   let prompt = $state(initialPrompt);
+  let selectedExistingBranch = $state("");
+  let branchSearchQuery = $state("");
+  let existingSelectorOpen = $state(false);
   let agent = $state(savedAgent ?? "claude");
   let profile = $state(savedProfile ?? "");
   const hasSavedDefaults = savedProfile != null || savedAgent != null || savedEnvs != null;
   let saveDefault = $state(hasSavedDefaults);
+  let existingBranchFieldEl = $state<HTMLDivElement | undefined>(undefined);
+  let existingBranchSearchEl = $state<HTMLInputElement | undefined>(undefined);
 
   function loadSavedEnvs(): Record<string, string | boolean> {
     if (!savedEnvs) return { ...startupEnvs };
@@ -72,11 +86,64 @@
     node.focus();
   }
 
+  let filteredBranches = $derived(
+    branchSearchQuery.trim()
+      ? availableBranches.filter((branch) => searchMatch(branchSearchQuery, branch.name))
+      : availableBranches,
+  );
+  let canSubmit = $derived(
+    mode === "new" || selectedExistingBranch.length > 0,
+  );
+
   $effect(() => {
     if (!profiles.some((p) => p.name === profile)) {
       profile = fallbackProfile;
     }
   });
+
+  function selectExistingBranch(name: string): void {
+    selectedExistingBranch = name;
+    branchSearchQuery = "";
+    existingSelectorOpen = false;
+  }
+
+  function focusExistingBranchSearch(): void {
+    queueMicrotask(() => existingBranchSearchEl?.focus());
+  }
+
+  function openExistingBranchSelector(): void {
+    mode = "existing";
+    existingSelectorOpen = true;
+    if (!selectedExistingBranch && initialBranch.trim().length > 0) {
+      selectedExistingBranch = initialBranch.trim();
+    }
+    branchSearchQuery = "";
+    focusExistingBranchSearch();
+  }
+
+  function switchToNewBranchMode(): void {
+    mode = "new";
+    existingSelectorOpen = false;
+    branchSearchQuery = "";
+  }
+
+  function handleExistingBranchFocusOut(event: FocusEvent): void {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && existingBranchFieldEl?.contains(nextTarget)) {
+      return;
+    }
+    existingSelectorOpen = false;
+    branchSearchQuery = "";
+  }
+
+  function toggleExistingBranchSelector(): void {
+    existingSelectorOpen = !existingSelectorOpen;
+    if (!existingSelectorOpen) {
+      branchSearchQuery = "";
+      return;
+    }
+    focusExistingBranchSearch();
+  }
 </script>
 
 <BaseDialog onclose={oncancel}>
@@ -100,7 +167,8 @@
           filteredEnvs[k] = v;
         }
       }
-      oncreate(name.trim(), profile, agent, prompt.trim(), filteredEnvs);
+      const branchName = mode === "existing" ? selectedExistingBranch : newBranchName.trim();
+      oncreate(mode, branchName, profile, agent, prompt.trim(), filteredEnvs);
     }}
   >
     <h2 class="text-base mb-4">New Worktree</h2>
@@ -124,16 +192,107 @@
       ></textarea>
     </div>
     <div class="mb-4">
-      <label class="block text-xs text-muted mb-1.5" for="wt-name"
-        >Name <span class="opacity-60">(optional)</span></label
-      >
-      <input
-        id="wt-name"
-        type="text"
-        class="w-full px-2.5 py-1.5 rounded-md border border-edge bg-surface text-primary text-[13px] placeholder:text-muted/50 outline-none focus:border-accent"
-        placeholder={autoNameEnabled ? "generated from prompt if empty" : "auto-generated if empty"}
-        bind:value={name}
-      />
+      {#if mode === "new"}
+        <label class="block text-xs text-muted mb-1.5" for="wt-name"
+          >Branch name <span class="opacity-60">(optional)</span></label
+        >
+        <input
+          id="wt-name"
+          type="text"
+          class="w-full px-2.5 py-1.5 rounded-md border border-edge bg-surface text-primary text-[13px] placeholder:text-muted/50 outline-none focus:border-accent"
+          placeholder={autoNameEnabled ? "generated from prompt if empty" : "auto-generated if empty"}
+          bind:value={newBranchName}
+        />
+        <button
+          type="button"
+          class="mt-2 text-[11px] text-accent hover:underline"
+          onclick={openExistingBranchSelector}
+        >
+          Use existing branch
+        </button>
+      {:else}
+        <div bind:this={existingBranchFieldEl} onfocusout={handleExistingBranchFocusOut}>
+          <span class="block text-xs text-muted mb-1.5">Existing branch</span>
+          <button
+            type="button"
+            class="flex w-full items-center justify-between gap-3 rounded-md border border-edge bg-surface px-2.5 py-1.5 text-left text-[13px] text-primary outline-none transition-colors hover:bg-hover focus:border-accent"
+            aria-expanded={existingSelectorOpen}
+            onclick={toggleExistingBranchSelector}
+          >
+            <span class={selectedExistingBranch ? "font-mono" : "text-muted/50"}>
+              {selectedExistingBranch || "Select a branch"}
+            </span>
+            <span class="text-[11px] text-muted">{existingSelectorOpen ? "▴" : "▾"}</span>
+          </button>
+          {#if existingSelectorOpen}
+            <div class="mt-2 rounded-lg border border-edge bg-surface/60">
+              <div class="border-b border-edge p-2">
+                <input
+                  bind:this={existingBranchSearchEl}
+                  type="text"
+                  class="w-full rounded-md border border-edge bg-surface px-2.5 py-1.5 text-[12px] text-primary placeholder:text-muted/50 outline-none focus:border-accent"
+                  placeholder="Search branches..."
+                  bind:value={branchSearchQuery}
+                  onkeydown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      if (filteredBranches[0]) {
+                        selectExistingBranch(filteredBranches[0].name);
+                      }
+                    }
+                    if (e.key === "Escape") {
+                      e.preventDefault();
+                      existingSelectorOpen = false;
+                      branchSearchQuery = "";
+                    }
+                  }}
+                />
+              </div>
+              {#if availableBranchesLoading}
+                <p class="px-3 py-2 text-xs text-muted">Loading branches...</p>
+              {:else if availableBranchesError}
+                <p class="px-3 py-2 text-xs text-muted">Failed to load branches: {availableBranchesError}</p>
+              {:else if filteredBranches.length === 0}
+                <p class="px-3 py-2 text-xs text-muted">No matching branches</p>
+              {:else}
+                <div class="border-b border-edge px-3 py-2 text-[11px] text-muted">
+                  {filteredBranches.length !== availableBranches.length
+                    ? `${filteredBranches.length}/${availableBranches.length}`
+                    : availableBranches.length}
+                  {" "}available
+                </div>
+                <ul class="max-h-48 overflow-y-auto py-1">
+                  {#each filteredBranches as branch (branch.name)}
+                    <li>
+                      <button
+                        type="button"
+                        class="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-[12px] transition-colors hover:bg-hover
+                          {selectedExistingBranch === branch.name ? 'bg-accent/10' : ''}"
+                        onclick={() => selectExistingBranch(branch.name)}
+                      >
+                        <span class="font-mono text-primary">{branch.name}</span>
+                        {#if selectedExistingBranch === branch.name}
+                          <span class="text-[10px] text-accent">Selected</span>
+                        {/if}
+                      </button>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </div>
+          {/if}
+        </div>
+        <button
+          type="button"
+          class="mt-2 text-[11px] text-accent hover:underline"
+          onclick={switchToNewBranchMode}
+        >
+          Create new branch instead
+        </button>
+        <p class="mt-2 text-[11px] text-muted">
+          Removing this worktree will also delete the branch.
+        </p>
+      {/if}
     </div>
     <StartupEnvFields {startupEnvs} bind:envValues />
     <div class="flex gap-2 mb-4">
@@ -193,6 +352,7 @@
       <Btn
         type="submit"
         variant="cta"
+        disabled={!canSubmit}
         >Create</Btn
       >
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AvailableBranch,
   WorktreeInfo,
   AppConfig,
   AppNotification,
@@ -6,6 +7,7 @@ import type {
   PrEntry,
   ProjectSnapshot,
   ProjectWorktreeSnapshot,
+  WorktreeCreateMode,
 } from "./types";
 
 async function api<T = unknown>(path: string, opts?: RequestInit): Promise<T> {
@@ -73,7 +75,13 @@ export async function fetchWorktrees(): Promise<WorktreeInfo[]> {
   return snapshot.worktrees.map((worktree) => mapWorktree(worktree));
 }
 
+export async function fetchAvailableBranches(): Promise<AvailableBranch[]> {
+  const data = await api<{ branches: AvailableBranch[] }>("branches");
+  return data.branches;
+}
+
 export function createWorktree(
+  mode: WorktreeCreateMode,
   branch: string | undefined,
   profile: string,
   agent: string,
@@ -83,6 +91,7 @@ export function createWorktree(
   return api<{ branch: string }>("worktrees", {
     method: "POST",
     body: JSON.stringify({
+      mode,
       ...(branch ? { branch } : {}),
       profile,
       agent,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -68,6 +68,12 @@ export interface LinearIssue {
   project: string | null;
 }
 
+export type WorktreeCreateMode = "new" | "existing";
+
+export interface AvailableBranch {
+  name: string;
+}
+
 export type WorktreeCreationPhase =
   | "creating_worktree"
   | "preparing_runtime"


### PR DESCRIPTION
## Summary
Add an explicit existing-branch worktree flow, including backend support for following an existing local branch and a frontend picker that keeps new-branch creation as the default path.

## Changes
- add a typed `mode: \"new\" | \"existing\"` worktree creation contract and a new branch-list API endpoint
- update the git and lifecycle services to create worktrees from existing local branches and avoid deleting pre-existing branches on create rollback
- replace the dialog mode cards with an inline existing-branch flow and a searchable dropdown picker that closes on selection or blur
- add backend coverage for existing-branch creation, branch listing, and rollback behavior

## Test plan
- [x] `cd backend && bun run check`
- [x] `cd backend && bun test src/__tests__/git-adapter.test.ts src/__tests__/lifecycle-service.test.ts src/__tests__/worktree-storage.test.ts src/__tests__/reconciliation-service.test.ts`
- [x] `cd frontend && bun run check`
- [x] `cd frontend && bun run test`

---
Generated with [Claude Code](https://claude.com/claude-code)