### PR TITLE
fix: switch to tmux window after webmux open

### DIFF
--- a/bin/src/worktree-commands.test.ts
+++ b/bin/src/worktree-commands.test.ts
@@ -140,6 +140,31 @@ describe("runWorktreeCommand", () => {
     expect(switchCalls).toEqual([{ projectDir: "/repo", branch: "feature/search" }]);
   });
 
+  it("dispatches open through the lifecycle service and switches to tmux", async () => {
+    const { runtime, calls } = makeRuntime();
+    const stdout: string[] = [];
+    const switchCalls: Array<{ projectDir: string; branch: string }> = [];
+
+    const exitCode = await runWorktreeCommand(
+      {
+        command: "open",
+        args: ["feature/search"],
+        projectDir: "/repo",
+        port: 5111,
+      },
+      {
+        createRuntime: () => runtime,
+        stdout: (message) => stdout.push(message),
+        switchToTmuxWindow: (projectDir, branch) => switchCalls.push({ projectDir, branch }),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([{ method: "openWorktree", value: "feature/search" }]);
+    expect(stdout).toEqual(["Opened worktree feature/search"]);
+    expect(switchCalls).toEqual([{ projectDir: "/repo", branch: "feature/search" }]);
+  });
+
   it("prints subcommand help without creating a runtime", async () => {
     let createRuntimeCalled = false;
     const stdout: string[] = [];

--- a/bin/src/worktree-commands.ts
+++ b/bin/src/worktree-commands.ts
@@ -405,6 +405,7 @@ export async function runWorktreeCommand(
       case "open":
         await runtime.lifecycleService.openWorktree(branch);
         stdout(`Opened worktree ${branch}`);
+        switchToTmuxWindow(runtime.projectDir, branch);
         return 0;
       case "close":
         await runtime.lifecycleService.closeWorktree(branch);


### PR DESCRIPTION
## Summary
`webmux open` materialized the tmux session but never switched the user's tmux client to the new window. This adds the missing `switchToTmuxWindow` call so `open` behaves like `add`.

## Changes
- Call `switchToTmuxWindow(runtime.projectDir, branch)` after `openWorktree()` in the `open` command handler
- Add test verifying `switchToTmuxWindow` is invoked with the correct arguments

## Test plan
- [ ] Run `bun test bin/src/worktree-commands.test.ts` — all 17 tests pass
- [ ] Run `webmux open <branch>` from a tmux session and verify the client switches to the opened window

---
Generated with [Claude Code](https://claude.com/claude-code)