### PR TITLE
fix: widen creation dialog and prompt input

### DIFF
--- a/frontend/src/lib/BaseDialog.svelte
+++ b/frontend/src/lib/BaseDialog.svelte
@@ -4,10 +4,12 @@
   let {
     onclose,
     wide = false,
+    className = "",
     children,
   }: {
     onclose: () => void;
     wide?: boolean;
+    className?: string;
     children: Snippet;
   } = $props();
 
@@ -23,7 +25,7 @@
   {onclose}
   class="bg-sidebar text-primary border border-edge rounded-xl p-6 w-[90%] {wide
     ? 'max-w-[560px]'
-    : 'max-w-[380px]'}"
+    : 'max-w-[380px]'} {className}"
 >
   {@render children()}
 </dialog>

--- a/frontend/src/lib/CreateWorktreeDialog.svelte
+++ b/frontend/src/lib/CreateWorktreeDialog.svelte
@@ -146,7 +146,7 @@
   }
 </script>
 
-<BaseDialog onclose={oncancel}>
+<BaseDialog onclose={oncancel} className="md:max-w-[440px]">
   <form
     onsubmit={(e) => {
       e.preventDefault();
@@ -178,7 +178,7 @@
       >
       <textarea
         id="wt-prompt"
-        rows="3"
+        rows="4"
         use:focus
         class="w-full px-2.5 py-1.5 rounded-md border border-edge bg-surface text-primary text-[13px] placeholder:text-muted/50 outline-none focus:border-accent resize-y"
         placeholder="Describe the task for the agent..."


### PR DESCRIPTION
## Summary
Widen the create worktree dialog slightly on desktop and give the prompt input more vertical space so the creation flow feels less cramped.

## Changes
- add an optional class passthrough to the shared base dialog component
- apply a desktop-only max width override to the create worktree dialog
- increase the create dialog prompt textarea from 3 rows to 4 rows

## Test plan
- [ ] Open the create worktree dialog on desktop and confirm the modal is slightly wider
- [ ] Confirm the prompt textarea renders taller and still submits on Enter without Shift
- [ ] Run frontend checks after installing workspace dependencies because `svelte-check` is not currently available in this workspace

---
Generated with [Claude Code](https://claude.com/claude-code)