### PR TITLE
feat: persist last selected worktree

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -21,7 +21,16 @@
     PrEntry,
     LinearIssue,
   } from "./lib/types";
-  import { SSH_STORAGE_KEY, errorMessage, worktreeCreationPhaseLabel, loadSavedTheme, applyTheme } from "./lib/utils";
+  import {
+    SSH_STORAGE_KEY,
+    errorMessage,
+    worktreeCreationPhaseLabel,
+    loadSavedTheme,
+    loadSavedSelectedWorktree,
+    saveSelectedWorktree,
+    resolveSelectedBranch,
+    applyTheme,
+  } from "./lib/utils";
   import { getTheme } from "./lib/themes";
   import type { ThemeKey } from "./lib/themes";
   import * as api from "./lib/api";
@@ -34,7 +43,8 @@
     linkedRepos: [],
   });
   let worktrees = $state<WorktreeInfo[]>([]);
-  let selectedBranch = $state<string | null>(null);
+  let selectedBranch = $state<string | null>(loadSavedSelectedWorktree());
+  let hasLoadedWorktrees = $state(false);
   let removeBranch = $state<string | null>(null);
   let mergeBranch = $state<string | null>(null);
   let removingBranches = $state<Set<string>>(new Set());
@@ -145,18 +155,15 @@
   );
 
   $effect(() => {
-    if (selectedBranch && selectedWorktree) {
-      return;
+    const nextSelectedBranch = resolveSelectedBranch(
+      selectedBranch,
+      selectedWorktree,
+      selectableWorktrees,
+      hasLoadedWorktrees,
+    );
+    if (nextSelectedBranch !== selectedBranch) {
+      selectedBranch = nextSelectedBranch;
     }
-
-    if (selectableWorktrees.length === 0) {
-      selectedBranch = null;
-      return;
-    }
-
-    // Prefer an open worktree, fall back to the first one.
-    const open = selectableWorktrees.find((w) => w.mux === "✓");
-    selectedBranch = (open ?? selectableWorktrees[0]).branch;
   });
 
   $effect(() => {
@@ -173,6 +180,17 @@
 
   $effect(() => {
     applyPollInterval?.(pollIntervalMs);
+  });
+
+  $effect(() => {
+    if (!hasLoadedWorktrees) return;
+    if (selectedWorktree) {
+      saveSelectedWorktree(selectedWorktree.branch);
+      return;
+    }
+    if (selectableWorktrees.length === 0) {
+      saveSelectedWorktree(null);
+    }
   });
 
   $effect(() => {
@@ -224,6 +242,7 @@
   async function refresh() {
     try {
       worktrees = await api.fetchWorktrees();
+      hasLoadedWorktrees = true;
     } catch (err) {
       console.error("Failed to refresh:", err);
     }

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  LAST_SELECTED_WORKTREE_STORAGE_KEY,
+  loadSavedSelectedWorktree,
+  resolveSelectedBranch,
+  saveSelectedWorktree,
+} from "./utils";
+
+describe("worktree selection persistence", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("keeps the saved branch before the first successful worktree load", () => {
+    expect(resolveSelectedBranch("feature/last-used", undefined, [], false)).toBe("feature/last-used");
+  });
+
+  it("keeps the current selection when that worktree still exists", () => {
+    expect(
+      resolveSelectedBranch(
+        "feature/last-used",
+        { branch: "feature/last-used" },
+        [{ branch: "feature/last-used", mux: "✗" }],
+        true,
+      ),
+    ).toBe("feature/last-used");
+  });
+
+  it("falls back to an open worktree when the saved branch is gone", () => {
+    expect(
+      resolveSelectedBranch(
+        "feature/missing",
+        undefined,
+        [
+          { branch: "feature/first", mux: "✗" },
+          { branch: "feature/open", mux: "✓" },
+        ],
+        true,
+      ),
+    ).toBe("feature/open");
+  });
+
+  it("stores and clears the last selected worktree", () => {
+    saveSelectedWorktree("feature/last-used");
+
+    expect(loadSavedSelectedWorktree()).toBe("feature/last-used");
+    expect(localStorage.getItem(LAST_SELECTED_WORKTREE_STORAGE_KEY)).toBe("feature/last-used");
+
+    saveSelectedWorktree(null);
+
+    expect(loadSavedSelectedWorktree()).toBeNull();
+    expect(localStorage.getItem(LAST_SELECTED_WORKTREE_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,9 +1,10 @@
-import type { PrEntry, WorktreeCreationPhase } from "./types";
+import type { PrEntry, WorktreeCreationPhase, WorktreeInfo } from "./types";
 import { THEME_KEYS, getTheme } from "./themes";
 import type { ThemeKey } from "./themes";
 
 export const SSH_STORAGE_KEY = "wt-ssh-host";
 export const THEME_STORAGE_KEY = "wt-theme";
+export const LAST_SELECTED_WORKTREE_STORAGE_KEY = "wt-last-selected-worktree";
 
 export function prLabel(pr: Pick<PrEntry, "repo" | "number">): string {
   return pr.repo ? `${pr.repo} #${pr.number}` : `PR #${pr.number}`;
@@ -61,6 +62,19 @@ export function loadSavedTheme(): ThemeKey {
   return "github-dark";
 }
 
+export function loadSavedSelectedWorktree(): string | null {
+  const stored = localStorage.getItem(LAST_SELECTED_WORKTREE_STORAGE_KEY)?.trim();
+  return stored ? stored : null;
+}
+
+export function saveSelectedWorktree(branch: string | null): void {
+  if (branch) {
+    localStorage.setItem(LAST_SELECTED_WORKTREE_STORAGE_KEY, branch);
+    return;
+  }
+  localStorage.removeItem(LAST_SELECTED_WORKTREE_STORAGE_KEY);
+}
+
 export function applyTheme(key: ThemeKey): void {
   const theme = getTheme(key);
   const root = document.documentElement;
@@ -85,4 +99,18 @@ export function worktreeCreationPhaseLabel(phase: WorktreeCreationPhase | null):
     default:
       return "Creating";
   }
+}
+
+export function resolveSelectedBranch(
+  selectedBranch: string | null,
+  selectedWorktree: Pick<WorktreeInfo, "branch"> | undefined,
+  selectableWorktrees: Array<Pick<WorktreeInfo, "branch" | "mux">>,
+  hasLoadedWorktrees: boolean,
+): string | null {
+  if (selectedBranch && selectedWorktree) return selectedBranch;
+  if (!hasLoadedWorktrees) return selectedBranch;
+  if (selectableWorktrees.length === 0) return null;
+
+  const open = selectableWorktrees.find((worktree) => worktree.mux === "✓");
+  return (open ?? selectableWorktrees[0]).branch;
 }


### PR DESCRIPTION
## Summary
Persist the dashboard's last selected worktree in localStorage so returning to the app restores the last used session instead of always falling back to the first available worktree.

## Changes
- initialize `selectedBranch` from localStorage and defer fallback auto-selection until the first successful worktree fetch completes
- persist and clear the saved worktree selection through shared frontend utility helpers
- add focused tests for saved-selection restore, fallback behavior, and localStorage persistence

## Test plan
- [x] `cd frontend && bun run check`
- [x] `cd frontend && bun run build`
- [x] `cd frontend && bun x vitest run src/lib/utils.test.ts`
- [ ] `cd frontend && bun run test` (currently fails in existing `src/lib/Terminal.test.ts` and `src/lib/TopBar.test.ts`)
- [ ] Manual UI verification in the browser

---
Generated with [Claude Code](https://claude.com/claude-code)