### PR TITLE
fix: isolate terminal sessions and serialize sync

### DIFF
--- a/backend/src/__tests__/pr.test.ts
+++ b/backend/src/__tests__/pr.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { parseReviewComments, mapWithConcurrency } from "../services/pr-service";
+import { mapWithConcurrency, startSerializedInterval } from "../lib/async";
+import { parseReviewComments } from "../services/pr-service";
 
 describe("parseReviewComments", () => {
   it("parses normal review comments", () => {
@@ -105,5 +106,82 @@ describe("mapWithConcurrency", () => {
   it("handles empty input", async () => {
     const result = await mapWithConcurrency([], 5, async (n: number) => n);
     expect(result).toEqual([]);
+  });
+});
+
+describe("startSerializedInterval", () => {
+  it("coalesces overlapping ticks into a single rerun", async () => {
+    const ticks: Array<() => void> = [];
+    const completions: Array<() => void> = [];
+    let runs = 0;
+    const stop = startSerializedInterval(
+      async () => {
+        runs += 1;
+        await new Promise<void>((resolve) => {
+          completions.push(resolve);
+        });
+      },
+      1000,
+      {
+        scheduleEvery: (handler) => {
+          ticks.push(handler);
+          return ticks.length;
+        },
+        cancelSchedule: () => {},
+      },
+    );
+
+    await Promise.resolve();
+    expect(runs).toBe(1);
+
+    ticks[0]!();
+    ticks[0]!();
+    expect(runs).toBe(1);
+
+    completions.shift()?.();
+    for (let i = 0; i < 10 && runs < 2; i += 1) {
+      await Promise.resolve();
+    }
+    expect(runs).toBe(2);
+
+    completions.shift()?.();
+    await Promise.resolve();
+    stop();
+  });
+
+  it("stops scheduling reruns after disposal", async () => {
+    const ticks: Array<() => void> = [];
+    const completions: Array<() => void> = [];
+    let runs = 0;
+    let cancelledHandle: number | null = null;
+    const stop = startSerializedInterval(
+      async () => {
+        runs += 1;
+        await new Promise<void>((resolve) => {
+          completions.push(resolve);
+        });
+      },
+      1000,
+      {
+        scheduleEvery: (handler) => {
+          ticks.push(handler);
+          return 42;
+        },
+        cancelSchedule: (handle) => {
+          cancelledHandle = handle;
+        },
+      },
+    );
+
+    await Promise.resolve();
+    expect(runs).toBe(1);
+    ticks[0]!();
+    stop();
+    completions.shift()?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(cancelledHandle === 42).toBe(true);
+    expect(runs).toBe(1);
   });
 });

--- a/backend/src/__tests__/reconciliation-service.test.ts
+++ b/backend/src/__tests__/reconciliation-service.test.ts
@@ -106,11 +106,25 @@ class FakeTmuxGateway implements TmuxGateway {
 }
 
 class FakePortProbe implements PortProbe {
-  constructor(private readonly listening = new Set<number>()) {}
+  readonly calls: number[] = [];
+
+  constructor(
+    private readonly listening = new Set<number>(),
+    private readonly onProbe?: (port: number) => Promise<void> | void,
+  ) {}
 
   async isListening(port: number): Promise<boolean> {
+    this.calls.push(port);
+    await this.onProbe?.(port);
     return this.listening.has(port);
   }
+}
+
+function resolveProbe(fn: (() => void) | undefined, label: string): void {
+  if (!fn) {
+    throw new Error(`expected ${label} to be available`);
+  }
+  fn();
 }
 
 const TEST_CONFIG: ProjectConfig = {
@@ -277,5 +291,78 @@ describe("ReconciliationService", () => {
     expect(state?.profile).toBeNull();
     expect(state?.agentName).toBeNull();
     expect(state?.services).toEqual([]);
+  });
+
+  it("coalesces concurrent reconcile calls and skips fresh repeats", async () => {
+    const repoRoot = "/repo/project";
+    const managedPath = "/repo/project/__worktrees/feature-fresh";
+    const managedGitDir = await mkdtemp(join(tmpdir(), "webmux-reconcile-fresh-"));
+    tempDirs.push(managedGitDir);
+
+    await writeWorktreeMeta(managedGitDir, {
+      schemaVersion: 1,
+      worktreeId: "wt_fresh",
+      branch: "feature/fresh",
+      createdAt: "2026-03-06T00:00:00.000Z",
+      profile: "default",
+      agent: "claude",
+      runtime: "host",
+      startupEnvValues: {},
+      allocatedPorts: { FRONTEND_PORT: 3010 },
+    });
+
+    const probeState: { release?: () => void } = {};
+    let nowMs = 10_000;
+    const portProbe = new FakePortProbe(new Set([3010]), async () => {
+      await new Promise<void>((resolve) => {
+        probeState.release = resolve;
+      });
+    });
+    const runtime = new ProjectRuntime();
+    const git = new FakeGitGateway(
+      [
+        { path: repoRoot, branch: "main", head: "aaa111", detached: false, bare: false },
+        { path: managedPath, branch: "feature/fresh", head: "bbb222", detached: false, bare: false },
+      ],
+      new Map([[managedPath, managedGitDir]]),
+      new Map([[managedPath, { dirty: false, aheadCount: 0, currentCommit: "bbb222" }]]),
+    );
+    const service = new ReconciliationService(
+      {
+        config: TEST_CONFIG,
+        git,
+        tmux: new FakeTmuxGateway([]),
+        portProbe,
+        runtime,
+      },
+      {
+        freshnessMs: 1000,
+        now: () => nowMs,
+      },
+    );
+
+    const first = service.reconcile(repoRoot);
+    const second = service.reconcile(repoRoot);
+    while (probeState.release === undefined) {
+      await Promise.resolve();
+    }
+
+    expect(portProbe.calls).toEqual([3010]);
+    resolveProbe(probeState.release, "the first probe release");
+    await Promise.all([first, second]);
+    expect(portProbe.calls).toEqual([3010]);
+
+    await service.reconcile(repoRoot);
+    expect(portProbe.calls).toEqual([3010]);
+
+    nowMs += 1001;
+    probeState.release = undefined;
+    const third = service.reconcile(repoRoot);
+    while (probeState.release === undefined) {
+      await Promise.resolve();
+    }
+    expect(portProbe.calls).toEqual([3010, 3010]);
+    resolveProbe(probeState.release, "the second probe release");
+    await third;
   });
 });

--- a/backend/src/__tests__/terminal-adapter.test.ts
+++ b/backend/src/__tests__/terminal-adapter.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const isolatedTmuxScriptPath = new URL("../../../scripts/run-with-isolated-tmux.sh", import.meta.url).pathname;
+
+function buildEnv(overrides: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  return {
+    ...env,
+    ...overrides,
+  };
+}
+
+function read(args: string[], env?: Record<string, string>): string {
+  const result = Bun.spawnSync(args, { env, stdout: "pipe", stderr: "pipe" });
+  if (result.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    throw new Error(`${args.join(" ")} failed: ${stderr || `exit ${result.exitCode}`}`);
+  }
+
+  return new TextDecoder().decode(result.stdout).trim();
+}
+
+describe("terminal adapter", () => {
+  it("keeps concurrent attaches isolated by attach id", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "webmux-terminal-"));
+    const env = buildEnv({
+      TMUX: "",
+      TMUX_TMPDIR: testRoot,
+    });
+    const runnerPath = join(testRoot, "run-terminal.ts");
+    const terminalModuleUrl = new URL("../adapters/terminal.ts", import.meta.url).href;
+
+    await Bun.write(
+      runnerPath,
+      [
+        `import { attach, cleanupStaleSessions, detach } from ${JSON.stringify(terminalModuleUrl)};`,
+        "",
+        "function run(args: string[]): void {",
+        '  const result = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" });',
+        "  if (result.exitCode !== 0) {",
+        "    const stderr = new TextDecoder().decode(result.stderr).trim();",
+        '    throw new Error(`${args.join(" ")} failed: ${stderr || `exit ${result.exitCode}`}`);',
+        "  }",
+        "}",
+        "",
+        "function read(args: string[]): string {",
+        '  const result = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" });',
+        "  if (result.exitCode !== 0) {",
+        "    const stderr = new TextDecoder().decode(result.stderr).trim();",
+        '    throw new Error(`${args.join(" ")} failed: ${stderr || `exit ${result.exitCode}`}`);',
+        "  }",
+        '  return new TextDecoder().decode(result.stdout).trim();',
+        "}",
+        "",
+        "function listManagedSessions(): string[] {",
+        '  return read(["tmux", "list-sessions", "-F", "#{session_name}"])',
+        '    .split("\\n")',
+        "    .filter(Boolean)",
+        '    .filter((name) => name.startsWith(`wm-dash-${Bun.env.PORT || "5111"}-`));',
+        "}",
+        "",
+        "cleanupStaleSessions();",
+        'run(["tmux", "new-session", "-d", "-s", "owner", "-n", "wm-feature/search"]);',
+        'await attach("attach-a", { ownerSessionName: "owner", windowName: "wm-feature/search" }, 80, 24);',
+        'await attach("attach-b", { ownerSessionName: "owner", windowName: "wm-feature/search" }, 80, 24);',
+        "await Bun.sleep(200);",
+        "const afterAttach = listManagedSessions();",
+        'await detach("attach-a");',
+        "await Bun.sleep(100);",
+        "const afterFirstDetach = listManagedSessions();",
+        'await detach("attach-b");',
+        "await Bun.sleep(100);",
+        "const afterSecondDetach = listManagedSessions();",
+        'run(["tmux", "kill-session", "-t", "owner"]);',
+        "console.log(JSON.stringify({ afterAttach, afterFirstDetach, afterSecondDetach }));",
+      ].join("\n"),
+    );
+
+    try {
+      const output = read(["bash", isolatedTmuxScriptPath, "bun", runnerPath], env);
+      const jsonLine = output
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.startsWith("{") && line.endsWith("}"));
+      if (!jsonLine) {
+        throw new Error(`expected terminal runner output, got: ${output}`);
+      }
+      const result = JSON.parse(jsonLine) as {
+        afterAttach: string[];
+        afterFirstDetach: string[];
+        afterSecondDetach: string[];
+      };
+
+      expect(result.afterAttach).toHaveLength(2);
+      expect(result.afterFirstDetach).toHaveLength(1);
+      expect(result.afterSecondDetach).toHaveLength(0);
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/backend/src/adapters/hooks.ts
+++ b/backend/src/adapters/hooks.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { log } from "../lib/log";
 
 export interface RunLifecycleHookInput {
   command: string;
@@ -52,8 +53,8 @@ export class BunLifecycleHookRunner implements LifecycleHookRunner {
 
   async run(input: RunLifecycleHookInput): Promise<void> {
     const cmd = await this.buildCommand(input.cwd, input.command);
-    console.debug(`[hook-runner] Spawning: ${cmd.join(" ")} cwd=${input.cwd}`);
-    console.debug(`[hook-runner] Env keys: ${Object.keys(input.env).join(", ")}`);
+    log.debug(`[hook-runner] Spawning: ${cmd.join(" ")} cwd=${input.cwd}`);
+    log.debug(`[hook-runner] envKeys=${Object.keys(input.env).length}`);
     const proc = Bun.spawn(cmd, {
       cwd: input.cwd,
       env: {
@@ -70,9 +71,9 @@ export class BunLifecycleHookRunner implements LifecycleHookRunner {
       new Response(proc.stderr).text(),
     ]);
 
-    console.debug(`[hook-runner] ${input.name} exitCode=${exitCode}`);
-    if (stdout.trim()) console.debug(`[hook-runner] stdout: ${stdout.trim()}`);
-    if (stderr.trim()) console.debug(`[hook-runner] stderr: ${stderr.trim()}`);
+    log.debug(`[hook-runner] ${input.name} exitCode=${exitCode}`);
+    if (stdout.trim()) log.debug(`[hook-runner] stdout: ${stdout.trim()}`);
+    if (stderr.trim()) log.debug(`[hook-runner] stderr: ${stderr.trim()}`);
 
     if (exitCode !== 0) {
       throw new Error(buildErrorMessage(input.name, exitCode, stdout, stderr));

--- a/backend/src/adapters/terminal.ts
+++ b/backend/src/adapters/terminal.ts
@@ -114,20 +114,20 @@ function killTmuxSession(name: string): void {
 }
 
 export async function attach(
-  worktreeId: string,
+  attachId: string,
   target: TerminalAttachTarget,
   cols: number,
   rows: number,
   initialPane?: number
 ): Promise<void> {
-  log.debug(`[term] attach(${worktreeId}) cols=${cols} rows=${rows} existing=${sessions.has(worktreeId)}`);
-  if (sessions.has(worktreeId)) {
-    await detach(worktreeId);
+  log.debug(`[term] attach(${attachId}) cols=${cols} rows=${rows} existing=${sessions.has(attachId)}`);
+  if (sessions.has(attachId)) {
+    await detach(attachId);
   }
 
   const gName = groupedName();
   log.debug(
-    `[term] attach(${worktreeId}) ownerSession=${target.ownerSessionName} gName=${gName} window=${target.windowName}`,
+    `[term] attach(${attachId}) ownerSession=${target.ownerSessionName} gName=${gName} window=${target.windowName}`,
   );
 
   // Kill stale session with same name if it exists (leftover from previous server run)
@@ -167,8 +167,8 @@ export async function attach(
     cancelled: false,
   };
 
-  sessions.set(worktreeId, session);
-  log.debug(`[term] attach(${worktreeId}) spawned pid=${proc.pid}`);
+  sessions.set(attachId, session);
+  log.debug(`[term] attach(${attachId}) spawned pid=${proc.pid}`);
 
   // Read stdout → push to scrollback + callback
   (async () => {
@@ -191,7 +191,7 @@ export async function attach(
       // Stream closed normally — no action needed.
       // Log anything unexpected so it surfaces during debugging.
       if (!session.cancelled) {
-        log.error(`[term] stdout reader error(${worktreeId})`, err);
+        log.error(`[term] stdout reader error(${attachId})`, err);
       }
     }
   })();
@@ -203,103 +203,103 @@ export async function attach(
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
-        log.debug(`[term] stderr(${worktreeId}): ${textDecoder.decode(value).trimEnd()}`);
+        log.debug(`[term] stderr(${attachId}): ${textDecoder.decode(value).trimEnd()}`);
       }
     } catch { /* stream closed */ }
   })();
 
   proc.exited.then((exitCode) => {
-    log.debug(`[term] proc exited(${worktreeId}) pid=${proc.pid} code=${exitCode}`);
+    log.debug(`[term] proc exited(${attachId}) pid=${proc.pid} code=${exitCode}`);
     // Only clean up if this session is still the active one (not replaced by a new attach)
-    if (sessions.get(worktreeId) === session) {
+    if (sessions.get(attachId) === session) {
       session.onExit?.(exitCode);
-      sessions.delete(worktreeId);
+      sessions.delete(attachId);
     } else {
-      log.debug(`[term] proc exited(${worktreeId}) stale session, skipping cleanup`);
+      log.debug(`[term] proc exited(${attachId}) stale session, skipping cleanup`);
     }
     killTmuxSession(gName);
   });
 }
 
-export async function detach(worktreeId: string): Promise<void> {
-  const session = sessions.get(worktreeId);
+export async function detach(attachId: string): Promise<void> {
+  const session = sessions.get(attachId);
   if (!session) {
-    log.debug(`[term] detach(${worktreeId}) no session found`);
+    log.debug(`[term] detach(${attachId}) no session found`);
     return;
   }
 
-  log.debug(`[term] detach(${worktreeId}) killing pid=${session.proc.pid} tmux=${session.groupedSessionName}`);
+  log.debug(`[term] detach(${attachId}) killing pid=${session.proc.pid} tmux=${session.groupedSessionName}`);
   session.cancelled = true;
   session.proc.kill();
-  sessions.delete(worktreeId);
+  sessions.delete(attachId);
 
   killTmuxSession(session.groupedSessionName);
 }
 
-export function write(worktreeId: string, data: string): void {
-  const session = sessions.get(worktreeId);
+export function write(attachId: string, data: string): void {
+  const session = sessions.get(attachId);
   if (!session) {
-    log.warn(`[term] write(${worktreeId}) NO SESSION - input dropped (${data.length} bytes)`);
+    log.warn(`[term] write(${attachId}) NO SESSION - input dropped (${data.length} bytes)`);
     return;
   }
   try {
     session.proc.stdin.write(textEncoder.encode(data));
     session.proc.stdin.flush();
   } catch (err) {
-    log.error(`[term] write(${worktreeId}) stdin closed`, err);
+    log.error(`[term] write(${attachId}) stdin closed`, err);
   }
 }
 
 /** Send raw hex bytes to the active tmux pane via `tmux send-keys -H`,
  *  bypassing tmux's input parser (needed for CSI u sequences). */
-export async function sendKeys(worktreeId: string, hexBytes: string[]): Promise<void> {
-  const session = sessions.get(worktreeId);
+export async function sendKeys(attachId: string, hexBytes: string[]): Promise<void> {
+  const session = sessions.get(attachId);
   if (!session) return;
   const windowTarget = `${session.groupedSessionName}:${session.windowName}`;
   await tmuxExec(["tmux", "send-keys", "-t", windowTarget, "-H", ...hexBytes]);
 }
 
-export async function resize(worktreeId: string, cols: number, rows: number): Promise<void> {
-  const session = sessions.get(worktreeId);
+export async function resize(attachId: string, cols: number, rows: number): Promise<void> {
+  const session = sessions.get(attachId);
   if (!session) return;
   const windowTarget = `${session.groupedSessionName}:${session.windowName}`;
   const result = await tmuxExec(["tmux", "resize-window", "-t", windowTarget, "-x", String(cols), "-y", String(rows)]);
   if (result.exitCode !== 0) log.warn(`[term] resize failed: ${result.stderr}`);
 }
 
-export function getScrollback(worktreeId: string): string {
-  return sessions.get(worktreeId)?.scrollback.join("") ?? "";
+export function getScrollback(attachId: string): string {
+  return sessions.get(attachId)?.scrollback.join("") ?? "";
 }
 
 export function setCallbacks(
-  worktreeId: string,
+  attachId: string,
   onData: (data: string) => void,
   onExit: (exitCode: number) => void
 ): void {
-  const session = sessions.get(worktreeId);
+  const session = sessions.get(attachId);
   if (session) {
     session.onData = onData;
     session.onExit = onExit;
   }
 }
 
-export async function selectPane(worktreeId: string, paneIndex: number): Promise<void> {
-  const session = sessions.get(worktreeId);
+export async function selectPane(attachId: string, paneIndex: number): Promise<void> {
+  const session = sessions.get(attachId);
   if (!session) {
-    log.debug(`[term] selectPane(${worktreeId}) no session found`);
+    log.debug(`[term] selectPane(${attachId}) no session found`);
     return;
   }
   const target = `${session.groupedSessionName}:${session.windowName}.${paneIndex}`;
-  log.debug(`[term] selectPane(${worktreeId}) pane=${paneIndex} target=${target}`);
+  log.debug(`[term] selectPane(${attachId}) pane=${paneIndex} target=${target}`);
   const [r1, r2] = await Promise.all([
     tmuxExec(["tmux", "select-pane", "-t", target]),
     tmuxExec(["tmux", "resize-pane", "-Z", "-t", target]),
   ]);
-  log.debug(`[term] selectPane(${worktreeId}) select=${r1.exitCode} zoom=${r2.exitCode}`);
+  log.debug(`[term] selectPane(${attachId}) select=${r1.exitCode} zoom=${r2.exitCode}`);
 }
 
-export function clearCallbacks(worktreeId: string): void {
-  const session = sessions.get(worktreeId);
+export function clearCallbacks(attachId: string): void {
+  const session = sessions.get(attachId);
   if (session) {
     session.onData = null;
     session.onExit = null;

--- a/backend/src/lib/async.ts
+++ b/backend/src/lib/async.ts
@@ -1,0 +1,62 @@
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const concurrency = Math.max(1, Math.min(limit, items.length || 1));
+
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const index = next++;
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  return results;
+}
+
+export interface SerializedIntervalDependencies<THandle = ReturnType<typeof setInterval>> {
+  scheduleEvery?: (handler: () => void, intervalMs: number) => THandle;
+  cancelSchedule?: (handle: THandle) => void;
+}
+
+export function startSerializedInterval<THandle = ReturnType<typeof setInterval>>(
+  run: () => Promise<void>,
+  intervalMs: number,
+  deps: SerializedIntervalDependencies<THandle> = {},
+): () => void {
+  const scheduleEvery = deps.scheduleEvery ?? ((handler, ms) => setInterval(handler, ms) as THandle);
+  const cancelSchedule = deps.cancelSchedule ?? ((handle) => clearInterval(handle as ReturnType<typeof setInterval>));
+  let running = false;
+  let rerunRequested = false;
+  let stopped = false;
+
+  const execute = (): void => {
+    if (stopped) return;
+    if (running) {
+      rerunRequested = true;
+      return;
+    }
+
+    running = true;
+    void Promise.resolve()
+      .then(run)
+      .finally(() => {
+        running = false;
+        if (stopped || !rerunRequested) return;
+        rerunRequested = false;
+        execute();
+      });
+  };
+
+  execute();
+  const handle = scheduleEvery(execute, intervalMs);
+
+  return (): void => {
+    stopped = true;
+    cancelSchedule(handle);
+  };
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { join, resolve } from "node:path";
 import { networkInterfaces } from "node:os";
 import { log } from "./lib/log";
@@ -82,6 +83,7 @@ function getFrontendConfig(): {
 interface WsData {
   branch: string;
   worktreeId: string | null;
+  attachId: string | null;
   attached: boolean;
 }
 
@@ -191,8 +193,11 @@ async function resolveTerminalWorktree(branch: string): Promise<{
   attachTarget: TerminalAttachTarget;
 }> {
   ensureBranchNotBusy(branch);
-  await reconciliationService.reconcile(PROJECT_DIR);
-  const state = projectRuntime.getWorktreeByBranch(branch);
+  let state = projectRuntime.getWorktreeByBranch(branch);
+  if (!state || !state.session.exists || !state.session.sessionName) {
+    await reconciliationService.reconcile(PROJECT_DIR);
+    state = projectRuntime.getWorktreeByBranch(branch);
+  }
   if (!state) {
     throw new Error(`Worktree not found: ${branch}`);
   }
@@ -209,9 +214,9 @@ async function resolveTerminalWorktree(branch: string): Promise<{
   };
 }
 
-function getAttachedWorktreeId(ws: { data: WsData; readyState: number; send: (data: string) => void }): string | null {
-  if (ws.data.attached && ws.data.worktreeId) {
-    return ws.data.worktreeId;
+function getAttachedSessionId(ws: { data: WsData; readyState: number; send: (data: string) => void }): string | null {
+  if (ws.data.attached && ws.data.attachId) {
+    return ws.data.attachId;
   }
 
   sendWs(ws, { type: "error", message: "Terminal not attached" });
@@ -295,16 +300,24 @@ async function apiRuntimeEvent(req: Request): Promise<Response> {
   const event = parseRuntimeEvent(raw);
   if (!event) return errorResponse("Invalid runtime event body", 400);
 
-  await reconciliationService.reconcile(PROJECT_DIR);
-
   try {
     projectRuntime.applyEvent(event);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (message.includes("Unknown worktree id")) {
-      return errorResponse(message, 404);
+      await reconciliationService.reconcile(PROJECT_DIR);
+      try {
+        projectRuntime.applyEvent(event);
+      } catch (retryError) {
+        const retryMessage = retryError instanceof Error ? retryError.message : String(retryError);
+        if (retryMessage.includes("Unknown worktree id")) {
+          return errorResponse(retryMessage, 404);
+        }
+        throw retryError;
+      }
+    } else {
+      throw error;
     }
-    throw error;
   }
 
   const notification = runtimeNotifications.recordEvent(event);
@@ -453,7 +466,7 @@ Bun.serve({
   routes: {
     "/ws/:worktree": (req, server) => {
       const branch = decodeURIComponent(req.params.worktree);
-      return server.upgrade(req, { data: { branch, worktreeId: null, attached: false } })
+      return server.upgrade(req, { data: { branch, worktreeId: null, attachId: null, attached: false } })
         ? undefined
         : new Response("WebSocket upgrade failed", { status: 400 });
     },
@@ -588,23 +601,23 @@ Bun.serve({
 
       switch (msg.type) {
         case "input": {
-          const worktreeId = getAttachedWorktreeId(ws);
-          if (!worktreeId) return;
-          write(worktreeId, msg.data);
+          const attachId = getAttachedSessionId(ws);
+          if (!attachId) return;
+          write(attachId, msg.data);
           break;
         }
         case "sendKeys": {
-          const worktreeId = getAttachedWorktreeId(ws);
-          if (!worktreeId) return;
-          await sendKeys(worktreeId, msg.hexBytes);
+          const attachId = getAttachedSessionId(ws);
+          if (!attachId) return;
+          await sendKeys(attachId, msg.hexBytes);
           break;
         }
         case "selectPane":
           {
-            const worktreeId = getAttachedWorktreeId(ws);
-            if (!worktreeId) return;
-            log.debug(`[ws] selectPane pane=${msg.pane} branch=${branch} worktreeId=${worktreeId}`);
-            await selectPane(worktreeId, msg.pane);
+            const attachId = getAttachedSessionId(ws);
+            if (!attachId) return;
+            log.debug(`[ws] selectPane pane=${msg.pane} branch=${branch} attachId=${attachId}`);
+            await selectPane(attachId, msg.pane);
           }
           break;
         case "resize":
@@ -617,19 +630,21 @@ Bun.serve({
                 log.debug(`[ws] initialPane=${msg.initialPane} branch=${branch}`);
               }
               const terminalWorktree = await resolveTerminalWorktree(branch);
+              const attachId = `${terminalWorktree.worktreeId}:${randomUUID()}`;
               ws.data.worktreeId = terminalWorktree.worktreeId;
+              ws.data.attachId = attachId;
               await attach(
-                terminalWorktree.worktreeId,
+                attachId,
                 terminalWorktree.attachTarget,
                 msg.cols,
                 msg.rows,
                 msg.initialPane,
               );
               const { onData, onExit } = makeCallbacks(ws);
-              setCallbacks(terminalWorktree.worktreeId, onData, onExit);
-              const scrollback = getScrollback(terminalWorktree.worktreeId);
+              setCallbacks(attachId, onData, onExit);
+              const scrollback = getScrollback(attachId);
               log.debug(
-                `[ws] attached branch=${branch} worktreeId=${terminalWorktree.worktreeId} scrollback=${scrollback.length} bytes`,
+                `[ws] attached branch=${branch} worktreeId=${terminalWorktree.worktreeId} attachId=${attachId} scrollback=${scrollback.length} bytes`,
               );
               if (scrollback.length > 0) {
                 sendWs(ws, { type: "scrollback", data: scrollback });
@@ -638,14 +653,15 @@ Bun.serve({
               const errMsg = err instanceof Error ? err.message : String(err);
               ws.data.attached = false;
               ws.data.worktreeId = null;
+              ws.data.attachId = null;
               log.error(`[ws] attach failed branch=${branch}: ${errMsg}`);
               sendWs(ws, { type: "error", message: errMsg });
               ws.close(1011, errMsg.slice(0, 123)); // 1011 = Internal Error
             }
           } else {
-            const worktreeId = getAttachedWorktreeId(ws);
-            if (!worktreeId) return;
-            await resize(worktreeId, msg.cols, msg.rows);
+            const attachId = getAttachedSessionId(ws);
+            if (!attachId) return;
+            await resize(attachId, msg.cols, msg.rows);
           }
           break;
       }
@@ -653,11 +669,11 @@ Bun.serve({
 
     async close(ws, code, reason) {
       log.debug(
-        `[ws] close branch=${ws.data.branch} code=${code} reason=${reason} attached=${ws.data.attached} worktreeId=${ws.data.worktreeId}`,
+        `[ws] close branch=${ws.data.branch} code=${code} reason=${reason} attached=${ws.data.attached} worktreeId=${ws.data.worktreeId} attachId=${ws.data.attachId}`,
       );
-      if (ws.data.worktreeId) {
-        clearCallbacks(ws.data.worktreeId);
-        await detach(ws.data.worktreeId);
+      if (ws.data.attachId) {
+        clearCallbacks(ws.data.attachId);
+        await detach(ws.data.attachId);
       }
     },
   },

--- a/backend/src/services/lifecycle-service.ts
+++ b/backend/src/services/lifecycle-service.ts
@@ -36,6 +36,7 @@ import {
   removeManagedWorktree,
   type InitializeManagedWorktreeResult,
 } from "./worktree-service";
+import { log } from "../lib/log";
 
 function generateBranchName(): string {
   return `change-${randomUUID().slice(0, 8)}`;
@@ -204,7 +205,7 @@ export class LifecycleService {
         agent,
         phase: "reconciling",
       });
-      await this.deps.reconciliation.reconcile(this.deps.projectRoot);
+      await this.deps.reconciliation.reconcile(this.deps.projectRoot, { force: true });
 
       return {
         branch,
@@ -253,7 +254,7 @@ export class LifecycleService {
         launchMode,
       });
 
-      await this.deps.reconciliation.reconcile(this.deps.projectRoot);
+      await this.deps.reconciliation.reconcile(this.deps.projectRoot, { force: true });
 
       return {
         branch,
@@ -271,7 +272,7 @@ export class LifecycleService {
         buildProjectSessionName(this.deps.projectRoot),
         buildWorktreeWindowName(branch),
       );
-      await this.deps.reconciliation.reconcile(this.deps.projectRoot);
+      await this.deps.reconciliation.reconcile(this.deps.projectRoot, { force: true });
     } catch (error) {
       throw this.wrapOperationError(error);
     }
@@ -738,7 +739,7 @@ export class LifecycleService {
       this.deps.git,
     );
 
-    await this.deps.reconciliation.reconcile(this.deps.projectRoot);
+    await this.deps.reconciliation.reconcile(this.deps.projectRoot, { force: true });
   }
 
   private async runLifecycleHook(input: {
@@ -747,13 +748,13 @@ export class LifecycleService {
     meta: WorktreeMeta | null;
     worktreePath: string;
   }): Promise<void> {
-    console.debug(`[lifecycle-hook] name=${input.name} command=${input.command ?? "UNDEFINED"} meta=${input.meta ? "present" : "NULL"} cwd=${input.worktreePath}`);
+    log.debug(`[lifecycle-hook] name=${input.name} command=${input.command ?? "UNDEFINED"} meta=${input.meta ? "present" : "NULL"} cwd=${input.worktreePath}`);
     if (!input.command || !input.meta) {
-      console.debug(`[lifecycle-hook] SKIPPING ${input.name}: command=${!!input.command} meta=${!!input.meta}`);
+      log.debug(`[lifecycle-hook] SKIPPING ${input.name}: command=${!!input.command} meta=${!!input.meta}`);
       return;
     }
 
-    console.debug(`[lifecycle-hook] RUNNING ${input.name}: ${input.command} in ${input.worktreePath}`);
+    log.debug(`[lifecycle-hook] RUNNING ${input.name}: ${input.command} in ${input.worktreePath}`);
     const dotenvValues = await loadDotenvLocal(input.worktreePath);
     await this.deps.hooks.run({
       name: input.name,
@@ -763,7 +764,7 @@ export class LifecycleService {
         WEBMUX_WORKTREE_PATH: input.worktreePath,
       }, dotenvValues),
     });
-    console.debug(`[lifecycle-hook] COMPLETED ${input.name}`);
+    log.debug(`[lifecycle-hook] COMPLETED ${input.name}`);
   }
 
   private async reportCreateProgress(progress: CreateWorktreeProgress): Promise<void> {

--- a/backend/src/services/pr-service.ts
+++ b/backend/src/services/pr-service.ts
@@ -1,6 +1,7 @@
 import { readWorktreePrs, writeWorktreePrs } from "../adapters/fs";
 import type { LinkedRepoConfig } from "../domain/config";
 import type { CiCheck, PrComment, PrEntry } from "../domain/model";
+import { mapWithConcurrency, startSerializedInterval } from "../lib/async";
 import { log } from "../lib/log";
 
 const PR_FETCH_LIMIT = 50;
@@ -220,26 +221,6 @@ export async function fetchAllPrs(
   } catch (err) {
     return { ok: false, error: `failed to parse gh output for ${label}: ${err}` };
   }
-}
-
-/** Run async mapper over items with bounded concurrency. */
-export async function mapWithConcurrency<T, R>(
-  items: T[],
-  limit: number,
-  fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let next = 0;
-
-  async function worker(): Promise<void> {
-    while (next < items.length) {
-      const idx = next++;
-      results[idx] = await fn(items[idx]);
-    }
-  }
-
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
-  return results;
 }
 
 /** Fetch inline review comments for a single PR via `gh api` with ETag caching.
@@ -487,24 +468,17 @@ export function startPrMonitor(
   intervalMs: number = 20_000,
   isActive?: () => boolean,
 ): () => void {
-  const run = (): void => {
+  const run = async (): Promise<void> => {
     if (isActive && !isActive()) {
       log.debug("[pr] skipping PR sync: no active clients");
       return;
     }
-    syncPrStatus(getWorktreeGitDirs, linkedRepos, projectDir).catch(
+    await syncPrStatus(getWorktreeGitDirs, linkedRepos, projectDir).catch(
       (err: unknown) => {
         log.error(`[pr] sync error: ${err}`);
       },
     );
   };
 
-  // Run once immediately (non-blocking).
-  run();
-
-  const timer = setInterval(run, intervalMs);
-
-  return (): void => {
-    clearInterval(timer);
-  };
+  return startSerializedInterval(run, intervalMs);
 }

--- a/backend/src/services/reconciliation-service.ts
+++ b/backend/src/services/reconciliation-service.ts
@@ -5,7 +5,8 @@ import type { PortProbe } from "../adapters/port-probe";
 import { buildProjectSessionName, buildWorktreeWindowName, type TmuxGateway, type TmuxWindowSummary } from "../adapters/tmux";
 import { buildRuntimeEnvMap, readWorktreeMeta, readWorktreePrs } from "../adapters/fs";
 import type { ProjectConfig } from "../domain/config";
-import type { ServiceRuntimeState } from "../domain/model";
+import type { PrEntry, ServiceRuntimeState } from "../domain/model";
+import { mapWithConcurrency } from "../lib/async";
 import { ProjectRuntime } from "./project-runtime";
 
 function makeUnmanagedWorktreeId(path: string): string {
@@ -80,11 +81,73 @@ export interface ReconciliationServiceDependencies {
   runtime: ProjectRuntime;
 }
 
-export class ReconciliationService {
-  constructor(private readonly deps: ReconciliationServiceDependencies) {}
+export interface ReconciliationServiceOptions {
+  freshnessMs?: number;
+  now?: () => number;
+  concurrency?: number;
+}
 
-  async reconcile(repoRoot: string): Promise<void> {
+export interface ReconcileOptions {
+  force?: boolean;
+}
+
+interface ReconciledWorktreeState {
+  worktreeId: string;
+  branch: string;
+  path: string;
+  profile: string | null;
+  agentName: "claude" | "codex" | null;
+  runtime: "host" | "docker";
+  git: {
+    dirty: boolean;
+    aheadCount: number;
+    currentCommit: string | null;
+  };
+  session: {
+    exists: boolean;
+    sessionName: string | null;
+    paneCount: number;
+  };
+  services: ServiceRuntimeState[];
+  prs: PrEntry[];
+}
+
+export class ReconciliationService {
+  private readonly freshnessMs: number;
+  private readonly now: () => number;
+  private readonly concurrency: number;
+  private inFlight: Promise<void> | null = null;
+  private lastReconciledAt = 0;
+
+  constructor(
+    private readonly deps: ReconciliationServiceDependencies,
+    options: ReconciliationServiceOptions = {},
+  ) {
+    this.freshnessMs = options.freshnessMs ?? 500;
+    this.now = options.now ?? Date.now;
+    this.concurrency = options.concurrency ?? 4;
+  }
+
+  async reconcile(repoRoot: string, options: ReconcileOptions = {}): Promise<void> {
+    if (this.inFlight) {
+      return await this.inFlight;
+    }
+
+    if (!options.force && this.now() - this.lastReconciledAt < this.freshnessMs) {
+      return;
+    }
+
     const normalizedRepoRoot = resolve(repoRoot);
+    const reconcilePromise = this.runReconcile(normalizedRepoRoot).then(() => {
+      this.lastReconciledAt = this.now();
+    });
+    this.inFlight = reconcilePromise.finally(() => {
+      this.inFlight = null;
+    });
+    return await this.inFlight;
+  }
+
+  private async runReconcile(normalizedRepoRoot: string): Promise<void> {
     const worktrees = this.deps.git.listWorktrees(normalizedRepoRoot);
     const sessionName = buildProjectSessionName(normalizedRepoRoot);
 
@@ -97,60 +160,77 @@ export class ReconciliationService {
 
     const seenWorktreeIds = new Set<string>();
 
-    for (const entry of worktrees) {
-      if (entry.bare) continue;
-      if (resolve(entry.path) === normalizedRepoRoot) continue;
-
+    const candidateEntries = worktrees.filter((entry) =>
+      !entry.bare && resolve(entry.path) !== normalizedRepoRoot
+    );
+    const reconciledStates = await mapWithConcurrency(candidateEntries, this.concurrency, async (entry) => {
       const gitDir = this.deps.git.resolveWorktreeGitDir(entry.path);
       const meta = await readWorktreeMeta(gitDir);
       const branch = resolveBranch(entry, meta?.branch ?? null);
       const worktreeId = meta?.worktreeId ?? makeUnmanagedWorktreeId(entry.path);
+      const gitStatus = this.deps.git.readWorktreeStatus(entry.path);
+      const window = findWindow(windows, sessionName, branch);
 
-      seenWorktreeIds.add(worktreeId);
-
-      this.deps.runtime.upsertWorktree({
+      return {
         worktreeId,
         branch,
         path: entry.path,
         profile: meta?.profile ?? null,
         agentName: meta?.agent ?? null,
         runtime: meta?.runtime ?? "host",
+        git: {
+          dirty: gitStatus.dirty,
+          aheadCount: gitStatus.aheadCount,
+          currentCommit: gitStatus.currentCommit,
+        },
+        session: {
+          exists: window !== null,
+          sessionName: window?.sessionName ?? null,
+          paneCount: window?.paneCount ?? 0,
+        },
+        services: meta
+          ? await buildServiceStates(this.deps, {
+              allocatedPorts: meta.allocatedPorts,
+              startupEnvValues: meta.startupEnvValues,
+              worktreeId: meta.worktreeId,
+              branch,
+              profile: meta.profile,
+              agent: meta.agent,
+              runtime: meta.runtime,
+            })
+          : [],
+        prs: await readWorktreePrs(gitDir),
+      } satisfies ReconciledWorktreeState;
+    });
+
+    for (const state of reconciledStates) {
+      seenWorktreeIds.add(state.worktreeId);
+
+      this.deps.runtime.upsertWorktree({
+        worktreeId: state.worktreeId,
+        branch: state.branch,
+        path: state.path,
+        profile: state.profile,
+        agentName: state.agentName,
+        runtime: state.runtime,
       });
 
-      const gitStatus = this.deps.git.readWorktreeStatus(entry.path);
-      this.deps.runtime.setGitState(worktreeId, {
+      this.deps.runtime.setGitState(state.worktreeId, {
         exists: true,
-        branch,
-        dirty: gitStatus.dirty,
-        aheadCount: gitStatus.aheadCount,
-        currentCommit: gitStatus.currentCommit,
+        branch: state.branch,
+        dirty: state.git.dirty,
+        aheadCount: state.git.aheadCount,
+        currentCommit: state.git.currentCommit,
       });
 
-      const window = findWindow(windows, sessionName, branch);
-      this.deps.runtime.setSessionState(worktreeId, {
-        exists: window !== null,
-        sessionName: window?.sessionName ?? null,
-        paneCount: window?.paneCount ?? 0,
+      this.deps.runtime.setSessionState(state.worktreeId, {
+        exists: state.session.exists,
+        sessionName: state.session.sessionName,
+        paneCount: state.session.paneCount,
       });
 
-      if (meta) {
-        this.deps.runtime.setServices(
-          worktreeId,
-          await buildServiceStates(this.deps, {
-            allocatedPorts: meta.allocatedPorts,
-            startupEnvValues: meta.startupEnvValues,
-            worktreeId: meta.worktreeId,
-            branch,
-            profile: meta.profile,
-            agent: meta.agent,
-            runtime: meta.runtime,
-          }),
-        );
-      } else {
-        this.deps.runtime.setServices(worktreeId, []);
-      }
-
-      this.deps.runtime.setPrs(worktreeId, await readWorktreePrs(gitDir));
+      this.deps.runtime.setServices(state.worktreeId, state.services);
+      this.deps.runtime.setPrs(state.worktreeId, state.prs);
     }
 
     for (const state of this.deps.runtime.listWorktrees()) {

--- a/frontend/src/lib/Terminal.svelte
+++ b/frontend/src/lib/Terminal.svelte
@@ -16,7 +16,8 @@
   const DISCONNECTED_NOTICE = "\r\n\x1b[90m[Disconnected]\x1b[0m";
   const RECONNECTED_NOTICE = "\r\n\x1b[32m[Reconnected]\x1b[0m";
   let containerEl: HTMLDivElement;
-  let term: Terminal;
+  let term!: Terminal;
+  let termReady = false;
   let fitAddon: FitAddon;
   let ws: WebSocket | null = null;
   let resizeObs: ResizeObserver;
@@ -307,10 +308,11 @@
     document.addEventListener("visibilitychange", reconnectIfNeeded);
     window.addEventListener("focus", reconnectIfNeeded);
     window.addEventListener("online", reconnectIfNeeded);
+    termReady = true;
   });
 
   $effect(() => {
-    if (terminalTheme && term) {
+    if (termReady && terminalTheme && term.options) {
       term.options.theme = terminalTheme;
     }
   });

--- a/frontend/src/lib/Terminal.test.ts
+++ b/frontend/src/lib/Terminal.test.ts
@@ -16,6 +16,7 @@ const { MockFitAddon, MockTerminal } = vi.hoisted(() => {
   class MockTerminal {
     static instances: MockTerminal[] = [];
 
+    options: { theme?: unknown } = {};
     cols = 80;
     rows = 24;
     modes = { mouseTrackingMode: "none" };
@@ -186,5 +187,26 @@ describe("Terminal reconnect", () => {
     document.dispatchEvent(new Event("visibilitychange"));
 
     expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it("applies theme updates to the terminal instance", async () => {
+    const initialTheme = getTheme("github-dark").terminal;
+    const nextTheme = getTheme("github-light").terminal;
+    const rendered = render(Terminal, {
+      props: {
+        worktree: "feature/theme",
+        terminalTheme: initialTheme,
+      },
+    });
+
+    const terminal = MockTerminal.instances[0]!;
+    expect(terminal.options.theme).toBe(initialTheme);
+
+    await rendered.rerender({
+      worktree: "feature/theme",
+      terminalTheme: nextTheme,
+    });
+
+    expect(terminal.options.theme).toBe(nextTheme);
   });
 });


### PR DESCRIPTION
## Summary
This PR fixes the terminal attach ownership bug, prevents overlapping PR sync runs, coalesces reconciliation on hot paths, and restores the frontend terminal test baseline.

## Changes
- isolate backend terminal sessions per websocket attach id so one viewer cannot detach or hijack another
- add shared async helpers, serialize PR monitor runs, and coalesce reconciliation while forcing refreshes after lifecycle mutations
- harden frontend terminal theme updates, add regression coverage, and route lifecycle hook debug output through the gated logger

## Test plan
- [x] \
  bun run --cwd backend check
- [x] \
  bun test backend/src/__tests__/lifecycle-service.test.ts
- [x] \
  bun test backend/src/__tests__/agent-service.test.ts backend/src/__tests__/agent-runtime.test.ts backend/src/__tests__/runtime-events.test.ts backend/src/__tests__/project-runtime.test.ts backend/src/__tests__/setup.test.ts backend/src/__tests__/session-service.test.ts backend/src/__tests__/worktree-storage.test.ts backend/src/__tests__/git-adapter.test.ts backend/src/__tests__/domain-policies.test.ts
- [x] \
  bun test backend/src/__tests__/pr.test.ts backend/src/__tests__/reconciliation-service.test.ts backend/src/__tests__/terminal-adapter.test.ts
- [x] \
  bun test bin/src
- [x] \
  bun run --cwd frontend test
- [x] \
  bun run --cwd frontend check
- [x] \
  bun run build

---
Generated with [Claude Code](https://claude.com/claude-code)