### PR TITLE
feat: add native terminal poc groundwork

### DIFF
--- a/backend/src/__tests__/native-terminal-service.test.ts
+++ b/backend/src/__tests__/native-terminal-service.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { ProjectRuntime } from "../services/project-runtime";
+import { buildNativeTerminalTarget } from "../services/native-terminal-service";
+
+describe("buildNativeTerminalTarget", () => {
+  it("returns the native tmux attach target for an open worktree", () => {
+    const runtime = new ProjectRuntime();
+    runtime.upsertWorktree({
+      worktreeId: "wt_search",
+      branch: "feature/search",
+      path: "/repo/__worktrees/feature-search",
+      profile: "default",
+      agentName: "claude",
+      runtime: "host",
+    });
+    runtime.setSessionState("wt_search", {
+      exists: true,
+      sessionName: "wm-project-12345678",
+      paneCount: 3,
+    });
+
+    const target = buildNativeTerminalTarget(
+      "feature/search",
+      runtime.getWorktreeByBranch("feature/search"),
+    );
+
+    expect(target).toEqual({
+      ok: true,
+      data: {
+        worktreeId: "wt_search",
+        branch: "feature/search",
+        path: "/repo/__worktrees/feature-search",
+        ownerSessionName: "wm-project-12345678",
+        windowName: "wm-feature/search",
+        paneCount: 3,
+      },
+    });
+  });
+
+  it("returns a not found error when the branch is unknown", () => {
+    const target = buildNativeTerminalTarget("feature/missing", null);
+
+    expect(target).toEqual({
+      ok: false,
+      reason: "not_found",
+      message: "Worktree not found: feature/missing",
+    });
+  });
+
+  it("returns a closed-session error when the worktree exists but has no tmux window", () => {
+    const runtime = new ProjectRuntime();
+    runtime.upsertWorktree({
+      worktreeId: "wt_closed",
+      branch: "feature/closed",
+      path: "/repo/__worktrees/feature-closed",
+      runtime: "host",
+    });
+
+    const target = buildNativeTerminalTarget(
+      "feature/closed",
+      runtime.getWorktreeByBranch("feature/closed"),
+    );
+
+    expect(target).toEqual({
+      ok: false,
+      reason: "closed",
+      message: "No open tmux window found for worktree: feature/closed",
+    });
+  });
+});

--- a/backend/src/domain/model.ts
+++ b/backend/src/domain/model.ts
@@ -170,3 +170,12 @@ export interface ProjectSnapshot {
   worktrees: WorktreeSnapshot[];
   notifications: NotificationView[];
 }
+
+export interface NativeTerminalTarget {
+  worktreeId: string;
+  branch: string;
+  path: string;
+  ownerSessionName: string;
+  windowName: string;
+  paneCount: number;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,6 +24,7 @@ import { branchMatchesIssue, fetchAssignedIssues } from "./services/linear-servi
 import { LifecycleError } from "./services/lifecycle-service";
 import { startPrMonitor } from "./services/pr-service";
 import { buildProjectSnapshot } from "./services/snapshot-service";
+import { buildNativeTerminalTarget } from "./services/native-terminal-service";
 import { parseRuntimeEvent } from "./domain/events";
 import { isValidWorktreeName } from "./domain/policies";
 import { createWebmuxRuntime } from "./runtime";
@@ -193,21 +194,27 @@ async function resolveTerminalWorktree(branch: string): Promise<{
 }> {
   ensureBranchNotBusy(branch);
   await reconciliationService.reconcile(PROJECT_DIR);
-  const state = projectRuntime.getWorktreeByBranch(branch);
-  if (!state) {
-    throw new Error(`Worktree not found: ${branch}`);
-  }
-  if (!state.session.exists || !state.session.sessionName) {
-    throw new Error(`No open tmux window found for worktree: ${branch}`);
-  }
+  const target = buildNativeTerminalTarget(branch, projectRuntime.getWorktreeByBranch(branch));
+  if (!target.ok) throw new Error(target.message);
 
   return {
-    worktreeId: state.worktreeId,
+    worktreeId: target.data.worktreeId,
     attachTarget: {
-      ownerSessionName: state.session.sessionName,
-      windowName: state.session.windowName,
+      ownerSessionName: target.data.ownerSessionName,
+      windowName: target.data.windowName,
     },
   };
+}
+
+async function apiGetNativeTerminalTarget(branch: string): Promise<Response> {
+  touchDashboardActivity();
+  ensureBranchNotBusy(branch);
+  await reconciliationService.reconcile(PROJECT_DIR);
+  const target = buildNativeTerminalTarget(branch, projectRuntime.getWorktreeByBranch(branch));
+  if (!target.ok) {
+    return errorResponse(target.message, target.reason === "not_found" ? 404 : 409);
+  }
+  return jsonResponse(target.data);
 }
 
 function getAttachedWorktreeId(ws: { data: WsData; readyState: number; send: (data: string) => void }): string | null {
@@ -563,6 +570,14 @@ Bun.serve({
         const name = decodeURIComponent(req.params.name);
         if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
         return catching(`POST /api/worktrees/${name}/open`, () => apiOpenWorktree(name));
+      },
+    },
+
+    "/api/worktrees/:name/terminal-target": {
+      GET: (req) => {
+        const name = decodeURIComponent(req.params.name);
+        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        return catching(`GET /api/worktrees/${name}/terminal-target`, () => apiGetNativeTerminalTarget(name));
       },
     },
 

--- a/backend/src/services/native-terminal-service.ts
+++ b/backend/src/services/native-terminal-service.ts
@@ -1,0 +1,38 @@
+import type { ManagedWorktreeRuntimeState, NativeTerminalTarget } from "../domain/model";
+
+export type NativeTerminalTargetResult =
+  | { ok: true; data: NativeTerminalTarget }
+  | { ok: false; reason: "not_found" | "closed"; message: string };
+
+export function buildNativeTerminalTarget(
+  branch: string,
+  state: ManagedWorktreeRuntimeState | null,
+): NativeTerminalTargetResult {
+  if (!state || !state.git.exists) {
+    return {
+      ok: false,
+      reason: "not_found",
+      message: `Worktree not found: ${branch}`,
+    };
+  }
+
+  if (!state.session.exists || !state.session.sessionName) {
+    return {
+      ok: false,
+      reason: "closed",
+      message: `No open tmux window found for worktree: ${branch}`,
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      worktreeId: state.worktreeId,
+      branch: state.branch,
+      path: state.path,
+      ownerSessionName: state.session.sessionName,
+      windowName: state.session.windowName,
+      paneCount: state.session.paneCount,
+    },
+  };
+}

--- a/docs/macos-native-poc-handoff.txt
+++ b/docs/macos-native-poc-handoff.txt
@@ -1,0 +1,97 @@
+macOS native POC handoff
+
+Context
+- Goal: build the first real macOS SwiftUI POC for a native `webmux` client using `libghostty` as the terminal surface.
+- This repo worktree is on branch `cmux-comparison-research`.
+- The current environment was Linux/NixOS, so only backend and docs groundwork was completed here.
+- There is no uncommitted work left in the branch at handoff time.
+
+What is already done
+- Commit `5c3d56e`: adds architecture notes for two native-terminal POC options.
+- Commit `15b8323`: adds a backend API for native clients to fetch the tmux attach target for a worktree.
+
+Key docs and files
+- `docs/native-terminal-poc-options.md`
+- `backend/src/server.ts`
+- `backend/src/services/native-terminal-service.ts`
+- `backend/src/__tests__/native-terminal-service.test.ts`
+- `backend/src/adapters/terminal.ts`
+- `backend/src/runtime.ts`
+- `README.md`
+
+New backend contract
+- Endpoint: `GET /api/worktrees/:name/terminal-target`
+- Success response shape:
+  - `worktreeId`
+  - `branch`
+  - `path`
+  - `ownerSessionName`
+  - `windowName`
+  - `paneCount`
+- Failure semantics:
+  - `404` if the worktree branch is unknown
+  - `409` if the worktree exists but does not currently have an open tmux window
+
+Validation already done
+- `bun test backend/src/__tests__/native-terminal-service.test.ts`
+- `bun test backend/src/__tests__/snapshot-service.test.ts`
+
+Recommended implementation target
+- Build the smallest possible SwiftUI macOS app first.
+- Do not start with Tauri.
+- Do not try to replace `tmux`.
+- Reuse the current Bun backend as a sidecar first.
+- Use `libghostty` for the embedded terminal view.
+
+Recommended v1 POC scope
+- One macOS app
+- One main window
+- Sidebar listing worktrees
+- One embedded terminal view
+- Select worktree -> attach terminal to its tmux target
+- Create worktree
+- Open worktree
+- Close worktree
+- No PR/CI/Linear native panels yet
+
+Suggested architecture
+- `apps/webmux-macos/`
+- SwiftUI shell for the window and sidebar
+- AppKit wrapper around `GhosttyKit` / `libghostty` for the terminal view
+- `BackendClient` that talks to the existing Bun backend
+- Sidecar launcher that starts the backend locally for the selected project
+
+Recommended first milestones
+1. Create a macOS Swift package or Xcode project for `webmux-macos`.
+2. Add a sidecar launcher for the Bun backend.
+3. Add a minimal `BackendClient` for:
+   - `GET /api/project`
+   - `POST /api/worktrees`
+   - `POST /api/worktrees/:name/open`
+   - `POST /api/worktrees/:name/close`
+   - `GET /api/worktrees/:name/terminal-target`
+4. Get a basic SwiftUI sidebar rendering the project worktrees.
+5. Embed a native `libghostty` terminal view in the main pane.
+6. Attach that terminal view to the tmux target returned by `terminal-target`.
+7. Validate with:
+   - `nvim`
+   - `lazygit`
+   - long-running agent CLI output
+   - terminal resize
+   - copy/paste
+   - switching worktrees
+
+Important product constraints
+- The point of the POC is to validate whether a native terminal materially improves the user experience over the current browser terminal.
+- Keep the existing Bun orchestration logic intact for now.
+- Do not spend time on production packaging or updater work.
+- Do not rewrite GitHub/Linear integrations yet.
+
+Practical note about `libghostty`
+- Use the real Ghostty macOS sources and `GhosttyKit` surface types as reference on the Mac.
+- The previous agent inspected Ghostty upstream and confirmed the macOS app structure is under `macos/Sources/...`, with terminal surface code in the Ghostty surface view layer.
+- Mirror the upstream structure where it helps, rather than inventing a wrapper API from scratch.
+
+Definition of done for this POC
+- A user can launch the app, see worktrees, pick one, and work inside a real native terminal view attached to the correct tmux session/window.
+- The experience with serious terminal workflows is clearly better than the existing browser terminal.

--- a/docs/native-terminal-poc-options.md
+++ b/docs/native-terminal-poc-options.md
@@ -1,0 +1,288 @@
+# Native Terminal POC Options
+
+This note compares two small-scope POC paths for a `webmux` desktop experience with a real native terminal:
+
+1. Tauri app shell with a separate native terminal window
+2. macOS-native SwiftUI app with an embedded `libghostty` terminal view
+
+The goal is not to design the final product. The goal is to prove, as quickly as possible, whether a native terminal materially improves the experience over the current browser terminal.
+
+## Goals
+
+- Prove that a native terminal feels meaningfully better than the current `xterm.js`-based UI
+- Reuse as much of the existing `webmux` orchestration stack as possible
+- Keep `tmux` for persistence and pane/session behavior
+- Keep the POC small enough to complete quickly
+
+## Non-Goals
+
+- No Windows support in the POC
+- No full native rewrite of PR, CI, review, or Linear panels
+- No App Store packaging
+- No updater, signing, or production distribution hardening
+- No attempt to replace `tmux`
+
+## Reusable Pieces From The Current Repo
+
+These parts already exist and should be reused first:
+
+- worktree lifecycle and runtime ownership in `backend/src/runtime.ts`
+- terminal attach behavior in `backend/src/adapters/terminal.ts`
+- current browser UI, if the Tauri shell path is chosen
+
+For both POC paths, the fastest route is to keep the existing Bun backend as a sidecar initially rather than rewriting the orchestration layer.
+
+## Shared Product Test
+
+Both POCs should answer the same question:
+
+- Does a real native terminal make `webmux` feel meaningfully better for serious terminal users?
+
+The validation workflows should be:
+
+- open a worktree and attach to its terminal
+- run `nvim`, `lazygit`, long log streams, and AI agent CLIs
+- resize the terminal repeatedly
+- copy and paste
+- switch focus between worktrees and reopen terminals
+
+If the perceived benefit is weak, stop before investing in a larger native rewrite.
+
+## Option A: Tauri POC With A Separate Native Terminal Window
+
+### Summary
+
+Use Tauri for the main desktop shell and keep the terminal in a separate native window managed by the app.
+
+This is the smallest cross-platform path because it avoids the hardest problem: embedding a native terminal view into a webview-based app.
+
+### User Experience
+
+1. The user launches the Tauri app.
+2. The main window shows the familiar `webmux` dashboard UI.
+3. The user selects a worktree or clicks "Open terminal".
+4. The app automatically opens or focuses a native terminal window for that worktree.
+5. Closing the terminal window closes the attach session, not the worktree.
+
+The user does not manually start the terminal app. Tauri manages the terminal windows.
+
+### Simplest Architecture
+
+- Tauri hosts the main application window
+- The current Svelte frontend is reused with minimal changes
+- The current Bun backend runs as a local sidecar
+- A small platform-native terminal host binary is launched by the app
+- That terminal host creates a `libghostty` window and attaches to the target `tmux` session
+
+For the POC, the Bun backend can stay on `127.0.0.1` if that is the fastest way to reuse the current API and state model. That is acceptable for a POC even if it is not the desired final architecture.
+
+### Why This Path Is Simple
+
+- The current dashboard UI is reused almost as-is
+- The current backend is reused almost as-is
+- The native terminal is isolated in its own window
+- There is no need to solve mixed webview plus native terminal layout in one window
+
+### New Components
+
+1. `apps/tauri-shell`
+   - Tauri app
+   - starts and stops the Bun sidecar
+   - launches and tracks native terminal windows
+
+2. `apps/terminal-host-macos`
+   - tiny native macOS host around `libghostty`
+   - opens one terminal window
+   - attaches to the target `tmux` session
+
+3. `apps/terminal-host-linux`
+   - tiny native Linux host around `libghostty`
+   - same contract as the macOS host
+
+### IPC Contract
+
+For the smallest possible POC, keep IPC simple:
+
+- Tauri main window talks to Bun sidecar over existing HTTP and WebSocket endpoints
+- Tauri launches terminal host processes with simple arguments:
+  - project path
+  - branch or worktree id
+  - tmux session/window target
+  - initial size or theme flags if needed
+
+The terminal host does not need to know all of `webmux`. It only needs enough information to attach to the right session.
+
+### Minimal Scope
+
+- List worktrees
+- Open existing worktree
+- Create a worktree
+- Open one native terminal window per worktree
+- Focus an already-open terminal window when the same worktree is selected again
+- Close a terminal attach session cleanly
+
+### Out Of Scope
+
+- Native PR, CI, review, or Linear views
+- Embedded terminal panes inside the main dashboard window
+- Replacing Bun HTTP/WebSocket with Tauri IPC
+- Multi-window terminal tiling inside the Tauri shell
+
+### Exit Criteria
+
+- A user can create or open a worktree from the Tauri app
+- The app opens a native `libghostty` terminal window automatically
+- Input, resize, copy/paste, and focus work reliably
+- `nvim`, `lazygit`, and an agent CLI all behave correctly enough to compare against the browser version
+
+### Pros
+
+- Smallest path that still proves a native terminal
+- Keeps the current dashboard mostly intact
+- Gives a plausible macOS and Linux story without forcing a single native UI toolkit
+- Avoids the hardest embedding problem
+
+### Cons
+
+- Hybrid stack
+- Two-window experience
+- Main window and terminal window are separate concepts
+- Less "cmux-like" than a single native window
+
+### Rough Effort
+
+- 1 to 2 weeks for a credible internal POC
+
+## Option B: SwiftUI POC With Embedded `libghostty` Terminal View
+
+### Summary
+
+Build a macOS-native app where the main window contains both the sidebar and the terminal view, with `libghostty` embedded directly in the native UI.
+
+This is the cleanest way to test the terminal-first product direction on macOS.
+
+### User Experience
+
+1. The user launches a native macOS app.
+2. The app shows a sidebar of worktrees.
+3. Selecting a worktree swaps the main terminal view to that worktree.
+4. The terminal is a native `libghostty` view inside the main window.
+5. Later iterations can add tabs, inspectors, and more native chrome.
+
+### Simplest Architecture
+
+- macOS app shell in SwiftUI
+- terminal container implemented with AppKit where needed
+- current Bun backend reused as a local sidecar
+- SwiftUI fetches worktree state from the sidecar
+- terminal view attaches to the matching `tmux` target
+
+For the POC, the terminal does not need to know about every `webmux` feature. The Bun sidecar continues to own lifecycle, worktrees, and runtime state.
+
+### Why This Path Is Simple
+
+It is only simple in the macOS-only sense:
+
+- `libghostty` lives in a native UI tree
+- there is no webview in the main interaction path
+- terminal focus, resize, clipboard, and view lifecycle stay native
+
+This is the best path if the main question is "should `webmux` become a native terminal-first app on macOS?"
+
+### New Components
+
+1. `apps/webmux-macos`
+   - SwiftUI shell
+   - sidebar, toolbar, and worktree state
+
+2. `macos/TerminalView`
+   - AppKit wrapper around `libghostty`
+   - owns a terminal session binding
+
+3. `macos/BackendClient`
+   - minimal client for the existing Bun sidecar
+   - list, create, open, close worktrees
+
+### IPC Contract
+
+Keep the POC contract narrow:
+
+- list worktrees
+- create worktree
+- open worktree
+- close worktree
+- fetch enough runtime state to map a worktree to its `tmux` session/window
+
+That is enough to prove the core UX without rebuilding the backend.
+
+### Minimal Scope
+
+- Sidebar with worktree list
+- One embedded terminal view
+- Open or create worktree
+- Switch the terminal between worktrees
+- Clean close and reopen behavior
+
+### Out Of Scope
+
+- Full native PR and CI views
+- Linux
+- Native settings model
+- Production polish and packaging
+
+### Exit Criteria
+
+- A user can do a real session of work inside one native macOS window
+- The terminal feels clearly better than the browser version for serious terminal workflows
+- The app can switch between worktrees without losing the expected `tmux` state
+
+### Pros
+
+- Cleanest terminal integration
+- Closest to a future terminal-first product
+- Best fidelity for macOS UX
+- Fewest layers around the terminal itself
+
+### Cons
+
+- macOS only
+- Less reuse of the current Svelte UI
+- No direct Linux path from the same UI code
+- More divergence from the existing product shell
+
+### Rough Effort
+
+- 2 to 3 weeks for a credible internal macOS POC
+
+## Recommendation
+
+Choose Option A if the question is:
+
+- can `webmux` ship as a desktop app quickly?
+- can we prove native terminal value on both macOS and Linux with minimal product churn?
+
+Choose Option B if the question is:
+
+- should `webmux` become a terminal-first native product on macOS?
+- is the embedded native terminal experience strong enough to justify a larger rewrite?
+
+If the team wants the smallest reversible experiment, start with Option A.
+
+If the team already believes the terminal experience is the product, start with Option B.
+
+## Suggested Sequence
+
+The safest order is:
+
+1. Build Option A first
+2. Validate whether users care about the native terminal enough to justify more investment
+3. If yes, build Option B as the stronger product-direction prototype
+
+That sequence keeps the first POC cheap while preserving the path toward a more ambitious native terminal app later.
+
+## Sources
+
+- Ghostty about: <https://ghostty.org/docs/about>
+- Ghostty features: <https://ghostty.org/docs/features>
+- Tauri IPC: <https://v2.tauri.app/concept/inter-process-communication/>
+- Tauri process model: <https://v2.tauri.app/concept/process-model/>


### PR DESCRIPTION
## Summary
Add the first native-client groundwork for a future macOS `libghostty` POC. This PR introduces a backend contract that exposes the tmux attach target a native terminal needs, plus handoff docs so a Mac-based agent can continue implementation with a real Apple toolchain.

## Changes
- add `GET /api/worktrees/:name/terminal-target` so native clients can resolve the worktree tmux session/window to attach to
- add unit tests for native terminal target resolution and keep the existing snapshot tests passing
- add native-terminal POC notes and a Mac handoff text file describing current state, scope, and next implementation steps

## Test plan
- [x] Run `bun test backend/src/__tests__/native-terminal-service.test.ts`
- [x] Run `bun test backend/src/__tests__/snapshot-service.test.ts`
- [x] Review `docs/native-terminal-poc-options.md` and `docs/macos-native-poc-handoff.txt` for the Mac handoff context
- [ ] Build the SwiftUI/`libghostty` POC on a Mac using this branch

## Manual testing
- No manual runtime testing yet; this environment does not have a macOS toolchain

## Screenshots
- None

## Known limitations
- No SwiftUI client code has been added yet
- The native groundwork is currently backend contract plus documentation only

---
Generated with [Claude Code](https://claude.com/claude-code)