### PR TITLE
feat: share api contract across backend and frontend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,8 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@webmux/api-contract": "workspace:*",
+    "zod": "^3.25.76",
     "yaml": "^2.8.2"
   }
 }

--- a/backend/src/__tests__/api-validation.test.ts
+++ b/backend/src/__tests__/api-validation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { NotificationIdParamsSchema, RunIdParamsSchema, WorktreeNameParamsSchema } from "@webmux/api-contract";
+import { z } from "zod";
+import { parseParams } from "../api-validation";
+
+describe("parseParams", () => {
+  it("decodes encoded worktree names before validation", () => {
+    const parsed = parseParams({ name: "feature%2Fsearch" }, WorktreeNameParamsSchema);
+
+    expect(parsed).toEqual({
+      ok: true,
+      data: { name: "feature/search" },
+    });
+  });
+
+  it("parses numeric route params through the shared contract schemas", () => {
+    const notification = parseParams({ id: "42" }, NotificationIdParamsSchema);
+    const run = parseParams({ runId: "317" }, RunIdParamsSchema);
+
+    expect(notification).toEqual({
+      ok: true,
+      data: { id: 42 },
+    });
+    expect(run).toEqual({
+      ok: true,
+      data: { runId: 317 },
+    });
+  });
+
+  it("returns a 400 response for malformed path encoding", async () => {
+    const parsed = parseParams({ name: "%E0%A4%A" }, WorktreeNameParamsSchema);
+
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) throw new Error("Expected malformed path parameters to fail");
+
+    expect(parsed.response.status).toBe(400);
+    expect(await parsed.response.json()).toEqual({
+      error: "Invalid path parameters: malformed encoding",
+    });
+  });
+
+  it("mentions additional validation errors after the first one", async () => {
+    const schema = z.object({
+      first: z.string(),
+      second: z.string(),
+    });
+
+    const parsed = parseParams({}, schema);
+
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) throw new Error("Expected validation to fail");
+
+    expect(await parsed.response.json()).toEqual({
+      error: "Invalid path parameters: first: Required (and 1 more error)",
+    });
+  });
+});

--- a/backend/src/api-validation.ts
+++ b/backend/src/api-validation.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { errorResponse } from "./lib/http";
+
+type ParseResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; response: Response };
+
+function formatZodError(error: z.ZodError): string {
+  const issue = error.issues[0];
+  if (!issue) return "Invalid request";
+  const path = issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
+  return `${path}${issue.message}`;
+}
+
+function readSearchParams(url: URL): Record<string, string | string[]> {
+  const data: Record<string, string | string[]> = {};
+  for (const key of new Set(url.searchParams.keys())) {
+    const values = url.searchParams.getAll(key);
+    if (values.length === 1) {
+      data[key] = values[0] ?? "";
+      continue;
+    }
+    data[key] = values;
+  }
+  return data;
+}
+
+function parseWithSchema<TSchema extends z.ZodTypeAny>(
+  schema: TSchema,
+  input: unknown,
+  label: string,
+): ParseResult<z.infer<TSchema>> {
+  const parsed = schema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      response: errorResponse(`${label}: ${formatZodError(parsed.error)}`, 400),
+    };
+  }
+  return {
+    ok: true,
+    data: parsed.data,
+  };
+}
+
+export async function parseJsonBody<TSchema extends z.ZodTypeAny>(
+  req: Request,
+  schema: TSchema,
+): Promise<ParseResult<z.infer<TSchema>>> {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return {
+      ok: false,
+      response: errorResponse("Invalid JSON", 400),
+    };
+  }
+  return parseWithSchema(schema, raw, "Invalid request body");
+}
+
+export function parseQuery<TSchema extends z.ZodTypeAny>(
+  req: Request,
+  schema: TSchema,
+): ParseResult<z.infer<TSchema>> {
+  return parseWithSchema(schema, readSearchParams(new URL(req.url)), "Invalid query");
+}
+
+export function parseParams<TSchema extends z.ZodTypeAny>(
+  params: Record<string, string>,
+  schema: TSchema,
+): ParseResult<z.infer<TSchema>> {
+  return parseWithSchema(schema, params, "Invalid path parameters");
+}

--- a/backend/src/api-validation.ts
+++ b/backend/src/api-validation.ts
@@ -9,7 +9,9 @@ function formatZodError(error: z.ZodError): string {
   const issue = error.issues[0];
   if (!issue) return "Invalid request";
   const path = issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
-  return `${path}${issue.message}`;
+  const remainingCount = error.issues.length - 1;
+  const remainingSuffix = remainingCount > 0 ? ` (and ${remainingCount} more error${remainingCount === 1 ? "" : "s"})` : "";
+  return `${path}${issue.message}${remainingSuffix}`;
 }
 
 function readSearchParams(url: URL): Record<string, string | string[]> {
@@ -43,6 +45,22 @@ function parseWithSchema<TSchema extends z.ZodTypeAny>(
   };
 }
 
+function decodeParams(params: Record<string, string>): ParseResult<Record<string, string>> {
+  try {
+    return {
+      ok: true,
+      data: Object.fromEntries(
+        Object.entries(params).map(([key, value]) => [key, decodeURIComponent(value)]),
+      ),
+    };
+  } catch {
+    return {
+      ok: false,
+      response: errorResponse("Invalid path parameters: malformed encoding", 400),
+    };
+  }
+}
+
 export async function parseJsonBody<TSchema extends z.ZodTypeAny>(
   req: Request,
   schema: TSchema,
@@ -70,5 +88,7 @@ export function parseParams<TSchema extends z.ZodTypeAny>(
   params: Record<string, string>,
   schema: TSchema,
 ): ParseResult<z.infer<TSchema>> {
-  return parseWithSchema(schema, params, "Invalid path parameters");
+  const decoded = decodeParams(params);
+  if (!decoded.ok) return decoded;
+  return parseWithSchema(schema, decoded.data, "Invalid path parameters");
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,6 +2,15 @@ import { randomUUID } from "node:crypto";
 import { join, resolve } from "node:path";
 import { mkdirSync } from "node:fs";
 import { networkInterfaces } from "node:os";
+import {
+  apiPaths,
+  AvailableBranchesQuerySchema,
+  CreateWorktreeRequestSchema,
+  PullMainRequestSchema,
+  SendWorktreePromptRequestSchema,
+  SetWorktreeArchivedRequestSchema,
+  ToggleEnabledRequestSchema,
+} from "@webmux/api-contract";
 import { log } from "./lib/log";
 import {
   attach,
@@ -20,6 +29,7 @@ import {
 import { loadControlToken } from "./adapters/control-token";
 import { getDefaultProfileName, persistLocalLinearConfig, persistLocalGitHubConfig, type ProjectConfig } from "./adapters/config";
 import { jsonResponse, errorResponse } from "./lib/http";
+import { parseJsonBody, parseQuery } from "./api-validation";
 import { hasRecentDashboardActivity, touchDashboardActivity } from "./services/dashboard-activity";
 import { buildArchivedWorktreePathSet, normalizeArchivePath } from "./services/archive-service";
 import {
@@ -431,7 +441,10 @@ async function apiRuntimeEvent(req: Request): Promise<Response> {
 }
 
 async function apiListBranches(req: Request): Promise<Response> {
-  const includeRemote = new URL(req.url).searchParams.get("includeRemote") === "true";
+  const parsed = parseQuery(req, AvailableBranchesQuerySchema);
+  if (!parsed.ok) return parsed.response;
+
+  const includeRemote = parsed.data.includeRemote === true;
   return jsonResponse({
     branches: lifecycleService.listAvailableBranches({ includeRemote }),
   });
@@ -444,46 +457,20 @@ async function apiListBaseBranches(): Promise<Response> {
 }
 
 async function apiCreateWorktree(req: Request): Promise<Response> {
-  const raw: unknown = await req.json();
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return errorResponse("Invalid request body", 400);
-  }
-  const body = raw as Record<string, unknown>;
+  const parsed = await parseJsonBody(req, CreateWorktreeRequestSchema);
+  if (!parsed.ok) return parsed.response;
 
-  // Parse envOverrides: must be a plain object with string keys and values
-  let envOverrides: Record<string, string> | undefined;
-  if (body.envOverrides && typeof body.envOverrides === "object" && !Array.isArray(body.envOverrides)) {
-    const raw = body.envOverrides as Record<string, unknown>;
-    const parsed: Record<string, string> = {};
-    for (const [k, v] of Object.entries(raw)) {
-      if (typeof v === "string") parsed[k] = v;
-    }
-    if (Object.keys(parsed).length > 0) envOverrides = parsed;
-  }
-
-  const branch = typeof body.branch === "string" && body.branch.trim() ? body.branch.trim() : undefined;
-  const baseBranch = typeof body.baseBranch === "string" && body.baseBranch.trim() ? body.baseBranch.trim() : undefined;
-  const prompt = typeof body.prompt === "string" && body.prompt.trim() ? body.prompt.trim() : undefined;
-  const profile = typeof body.profile === "string" ? body.profile : undefined;
-  const agent: CreateWorktreeAgentSelection | undefined = body.agent === "claude"
-      || body.agent === "codex"
-      || body.agent === "both"
-    ? body.agent
-    : undefined;
+  const body = parsed.data;
+  const envOverrides = body.envOverrides && Object.keys(body.envOverrides).length > 0 ? body.envOverrides : undefined;
+  const branch = body.branch?.trim() ? body.branch.trim() : undefined;
+  const baseBranch = body.baseBranch?.trim() ? body.baseBranch.trim() : undefined;
+  const prompt = body.prompt?.trim() ? body.prompt.trim() : undefined;
+  const profile = body.profile;
+  const agent: CreateWorktreeAgentSelection | undefined = body.agent;
   const createLinearTicket = body.createLinearTicket === true;
-  const linearTitle = typeof body.linearTitle === "string" && body.linearTitle.trim()
-    ? body.linearTitle.trim()
-    : undefined;
-  const mode = body.mode === "new" || body.mode === "existing" ? body.mode : undefined;
+  const linearTitle = body.linearTitle?.trim() ? body.linearTitle.trim() : undefined;
+  const mode = body.mode;
   const agentSelection = agent ?? config.workspace.defaultAgent;
-
-  if (body.mode !== undefined && body.mode !== "new" && body.mode !== "existing") {
-    return errorResponse("Invalid worktree create mode", 400);
-  }
-
-  if (body.agent !== undefined && body.agent !== "claude" && body.agent !== "codex" && body.agent !== "both") {
-    return errorResponse("Invalid agent selection", 400);
-  }
 
   if (baseBranch && !isValidBranchName(baseBranch)) {
     return errorResponse("Invalid base branch name", 400);
@@ -593,14 +580,9 @@ async function apiCloseWorktree(name: string): Promise<Response> {
 
 async function apiSetWorktreeArchived(name: string, req: Request): Promise<Response> {
   ensureBranchNotBusy(name);
-  const raw: unknown = await req.json();
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return errorResponse("Invalid request body", 400);
-  }
-  const body = raw as Record<string, unknown>;
-  if (typeof body.archived !== "boolean") {
-    return errorResponse("Missing boolean 'archived' field", 400);
-  }
+  const parsed = await parseJsonBody(req, SetWorktreeArchivedRequestSchema);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.data;
 
   log.info(`[worktree:archive] name=${name} archived=${body.archived}`);
   await lifecycleService.setWorktreeArchived(name, body.archived);
@@ -610,14 +592,11 @@ async function apiSetWorktreeArchived(name: string, req: Request): Promise<Respo
 
 async function apiSendPrompt(name: string, req: Request): Promise<Response> {
   ensureBranchNotBusy(name);
-  const raw: unknown = await req.json();
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return errorResponse("Invalid request body", 400);
-  }
-  const body = raw as Record<string, unknown>;
-  const text = typeof body.text === "string" ? body.text : "";
-  if (!text) return errorResponse("Missing 'text' field", 400);
-  const preamble = typeof body.preamble === "string" ? body.preamble : undefined;
+  const parsed = await parseJsonBody(req, SendWorktreePromptRequestSchema);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.data;
+  const text = body.text;
+  const preamble = body.preamble;
   log.info(`[worktree:send] name=${name} text="${text.slice(0, 80)}"`);
   const terminalWorktree = await resolveTerminalWorktree(name);
   const result = await sendTerminalPrompt(
@@ -640,14 +619,9 @@ async function apiMergeWorktree(name: string): Promise<Response> {
 }
 
 async function apiSetLinearAutoCreate(req: Request): Promise<Response> {
-  const raw: unknown = await req.json();
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return errorResponse("Invalid request body", 400);
-  }
-  const body = raw as Record<string, unknown>;
-  if (typeof body.enabled !== "boolean") {
-    return errorResponse("Missing boolean 'enabled' field", 400);
-  }
+  const parsed = await parseJsonBody(req, ToggleEnabledRequestSchema);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.data;
 
   linearAutoCreateEnabled = body.enabled;
   if (linearAutoCreateEnabled) {
@@ -665,14 +639,9 @@ async function apiSetLinearAutoCreate(req: Request): Promise<Response> {
 }
 
 async function apiSetAutoRemoveOnMerge(req: Request): Promise<Response> {
-  const raw: unknown = await req.json();
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return errorResponse("Invalid request body", 400);
-  }
-  const body = raw as Record<string, unknown>;
-  if (typeof body.enabled !== "boolean") {
-    return errorResponse("Missing boolean 'enabled' field", 400);
-  }
+  const parsed = await parseJsonBody(req, ToggleEnabledRequestSchema);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.data;
 
   autoRemoveOnMergeEnabled = body.enabled;
   log.info(`[config] Auto-remove on merge ${autoRemoveOnMergeEnabled ? "enabled" : "disabled"}`);
@@ -684,9 +653,12 @@ async function apiSetAutoRemoveOnMerge(req: Request): Promise<Response> {
 
 async function apiPullMain(req: Request): Promise<Response> {
   const raw: unknown = await req.json().catch(() => ({}));
-  const body = raw && typeof raw === "object" && !Array.isArray(raw) ? raw as Record<string, unknown> : {};
-  const force = body.force === true;
-  const repo = typeof body.repo === "string" ? body.repo : "";
+  const parsed = PullMainRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return errorResponse("Invalid request body", 400);
+  }
+  const force = parsed.data.force === true;
+  const repo = parsed.data.repo ?? "";
 
   let projectRoot = PROJECT_DIR;
   if (repo) {
@@ -824,19 +796,19 @@ Bun.serve({
         : new Response("WebSocket upgrade failed", { status: 400 });
     },
 
-    "/api/config": {
+    [apiPaths.fetchConfig]: {
       GET: () => jsonResponse(getFrontendConfig()),
     },
 
-    "/api/branches": {
+    [apiPaths.fetchAvailableBranches]: {
       GET: (req) => catching("GET /api/branches", () => apiListBranches(req)),
     },
 
-    "/api/base-branches": {
+    [apiPaths.fetchBaseBranches]: {
       GET: () => catching("GET /api/base-branches", () => apiListBaseBranches()),
     },
 
-    "/api/project": {
+    [apiPaths.fetchProject]: {
       GET: () => catching("GET /api/project", () => apiGetProject()),
     },
 
@@ -844,12 +816,12 @@ Bun.serve({
       POST: (req) => catching("POST /api/runtime/events", () => apiRuntimeEvent(req)),
     },
 
-    "/api/worktrees": {
+    [apiPaths.fetchWorktrees]: {
       GET: () => catching("GET /api/worktrees", () => apiGetWorktrees()),
       POST: (req) => catching("POST /api/worktrees", () => apiCreateWorktree(req)),
     },
 
-    "/api/worktrees/:name": {
+    [apiPaths.removeWorktree]: {
       DELETE: (req) => {
         const name = decodeURIComponent(req.params.name);
         if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
@@ -857,7 +829,7 @@ Bun.serve({
       },
     },
 
-    "/api/worktrees/:name/open": {
+    [apiPaths.openWorktree]: {
       POST: (req) => {
         const name = decodeURIComponent(req.params.name);
         if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
@@ -873,7 +845,7 @@ Bun.serve({
       },
     },
 
-    "/api/worktrees/:name/close": {
+    [apiPaths.closeWorktree]: {
       POST: (req) => {
         const name = decodeURIComponent(req.params.name);
         if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
@@ -881,7 +853,7 @@ Bun.serve({
       },
     },
 
-    "/api/worktrees/:name/archive": {
+    [apiPaths.setWorktreeArchived]: {
       PUT: (req) => {
         const name = decodeURIComponent(req.params.name);
         if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
@@ -889,7 +861,7 @@ Bun.serve({
       },
     },
 
-    "/api/worktrees/:name/send": {
+    [apiPaths.sendWorktreePrompt]: {
       POST: (req) => {
         const name = decodeURIComponent(req.params.name);
         if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
@@ -905,7 +877,7 @@ Bun.serve({
       },
     },
 
-    "/api/worktrees/:name/merge": {
+    [apiPaths.mergeWorktree]: {
       POST: (req) => {
         const name = decodeURIComponent(req.params.name);
         if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
@@ -913,7 +885,7 @@ Bun.serve({
       },
     },
 
-    "/api/worktrees/:name/diff": {
+    [apiPaths.fetchWorktreeDiff]: {
       GET: (req) => {
         const name = decodeURIComponent(req.params.name);
         if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
@@ -921,23 +893,23 @@ Bun.serve({
       },
     },
 
-    "/api/linear/issues": {
+    [apiPaths.fetchLinearIssues]: {
       GET: () => catching("GET /api/linear/issues", () => apiGetLinearIssues()),
     },
 
-    "/api/linear/auto-create": {
+    [apiPaths.setLinearAutoCreate]: {
       PUT: (req) => catching("PUT /api/linear/auto-create", () => apiSetLinearAutoCreate(req)),
     },
 
-    "/api/github/auto-remove-on-merge": {
+    [apiPaths.setAutoRemoveOnMerge]: {
       PUT: (req) => catching("PUT /api/github/auto-remove-on-merge", () => apiSetAutoRemoveOnMerge(req)),
     },
 
-    "/api/pull-main": {
+    [apiPaths.pullMain]: {
       POST: (req) => catching("POST /api/pull-main", () => apiPullMain(req)),
     },
 
-    "/api/ci-logs/:runId": {
+    [apiPaths.fetchCiLogs]: {
       GET: (req) => catching(`GET /api/ci-logs/${req.params.runId}`, () => apiCiLogs(req.params.runId)),
     },
 
@@ -945,7 +917,7 @@ Bun.serve({
       GET: () => runtimeNotifications.stream(),
     },
 
-    "/api/notifications/:id/dismiss": {
+    [apiPaths.dismissNotification]: {
       POST: (req) => {
         const id = parseInt(req.params.id, 10);
         if (isNaN(id)) return errorResponse("Invalid notification ID", 400);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,10 +6,13 @@ import {
   apiPaths,
   AvailableBranchesQuerySchema,
   CreateWorktreeRequestSchema,
+  NotificationIdParamsSchema,
   PullMainRequestSchema,
+  RunIdParamsSchema,
   SendWorktreePromptRequestSchema,
   SetWorktreeArchivedRequestSchema,
   ToggleEnabledRequestSchema,
+  WorktreeNameParamsSchema,
 } from "@webmux/api-contract";
 import { log } from "./lib/log";
 import {
@@ -29,7 +32,7 @@ import {
 import { loadControlToken } from "./adapters/control-token";
 import { getDefaultProfileName, persistLocalLinearConfig, persistLocalGitHubConfig, type ProjectConfig } from "./adapters/config";
 import { jsonResponse, errorResponse } from "./lib/http";
-import { parseJsonBody, parseQuery } from "./api-validation";
+import { parseJsonBody, parseParams, parseQuery } from "./api-validation";
 import { hasRecentDashboardActivity, touchDashboardActivity } from "./services/dashboard-activity";
 import { buildArchivedWorktreePathSet, normalizeArchivePath } from "./services/archive-service";
 import {
@@ -714,9 +717,8 @@ async function apiGetWorktreeDiff(name: string): Promise<Response> {
   });
 }
 
-async function apiCiLogs(runId: string): Promise<Response> {
-  if (!/^\d+$/.test(runId)) return errorResponse("Invalid run ID", 400);
-  const proc = Bun.spawn(["gh", "run", "view", runId, "--log-failed"], {
+async function apiCiLogs(runId: number): Promise<Response> {
+  const proc = Bun.spawn(["gh", "run", "view", String(runId), "--log-failed"], {
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -782,6 +784,45 @@ async function apiUploadFiles(name: string, req: Request): Promise<Response> {
   return jsonResponse({ files: results });
 }
 
+function parseWorktreeNameParam(params: Record<string, string>):
+  | { ok: true; data: string }
+  | { ok: false; response: Response } {
+  const parsed = parseParams(params, WorktreeNameParamsSchema);
+  if (!parsed.ok) return parsed;
+  if (!isValidWorktreeName(parsed.data.name)) {
+    return {
+      ok: false,
+      response: errorResponse("Invalid worktree name", 400),
+    };
+  }
+  return {
+    ok: true,
+    data: parsed.data.name,
+  };
+}
+
+function parseRunIdParam(params: Record<string, string>):
+  | { ok: true; data: number }
+  | { ok: false; response: Response } {
+  const parsed = parseParams(params, RunIdParamsSchema);
+  if (!parsed.ok) return parsed;
+  return {
+    ok: true,
+    data: parsed.data.runId,
+  };
+}
+
+function parseNotificationIdParam(params: Record<string, string>):
+  | { ok: true; data: number }
+  | { ok: false; response: Response } {
+  const parsed = parseParams(params, NotificationIdParamsSchema);
+  if (!parsed.ok) return parsed;
+  return {
+    ok: true,
+    data: parsed.data.id,
+  };
+}
+
 // --- Server ---
 
 Bun.serve({
@@ -823,72 +864,81 @@ Bun.serve({
 
     [apiPaths.removeWorktree]: {
       DELETE: (req) => {
-        const name = decodeURIComponent(req.params.name);
-        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
         return catching(`DELETE /api/worktrees/${name}`, () => apiDeleteWorktree(name));
       },
     },
 
     [apiPaths.openWorktree]: {
       POST: (req) => {
-        const name = decodeURIComponent(req.params.name);
-        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
         return catching(`POST /api/worktrees/${name}/open`, () => apiOpenWorktree(name));
       },
     },
 
     "/api/worktrees/:name/terminal-launch": {
       GET: (req) => {
-        const name = decodeURIComponent(req.params.name);
-        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
         return catching(`GET /api/worktrees/${name}/terminal-launch`, () => apiGetNativeTerminalLaunch(name));
       },
     },
 
     [apiPaths.closeWorktree]: {
       POST: (req) => {
-        const name = decodeURIComponent(req.params.name);
-        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
         return catching(`POST /api/worktrees/${name}/close`, () => apiCloseWorktree(name));
       },
     },
 
     [apiPaths.setWorktreeArchived]: {
       PUT: (req) => {
-        const name = decodeURIComponent(req.params.name);
-        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
         return catching(`PUT /api/worktrees/${name}/archive`, () => apiSetWorktreeArchived(name, req));
       },
     },
 
     [apiPaths.sendWorktreePrompt]: {
       POST: (req) => {
-        const name = decodeURIComponent(req.params.name);
-        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
         return catching(`POST /api/worktrees/${name}/send`, () => apiSendPrompt(name, req));
       },
     },
 
     "/api/worktrees/:name/upload": {
       POST: (req) => {
-        const name = decodeURIComponent(req.params.name);
-        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
         return catching(`POST /api/worktrees/${name}/upload`, () => apiUploadFiles(name, req));
       },
     },
 
     [apiPaths.mergeWorktree]: {
       POST: (req) => {
-        const name = decodeURIComponent(req.params.name);
-        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
         return catching(`POST /api/worktrees/${name}/merge`, () => apiMergeWorktree(name));
       },
     },
 
     [apiPaths.fetchWorktreeDiff]: {
       GET: (req) => {
-        const name = decodeURIComponent(req.params.name);
-        if (!isValidWorktreeName(name)) return errorResponse("Invalid worktree name", 400);
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
         return catching(`GET /api/worktrees/${name}/diff`, () => apiGetWorktreeDiff(name));
       },
     },
@@ -910,7 +960,11 @@ Bun.serve({
     },
 
     [apiPaths.fetchCiLogs]: {
-      GET: (req) => catching(`GET /api/ci-logs/${req.params.runId}`, () => apiCiLogs(req.params.runId)),
+      GET: (req) => {
+        const parsed = parseRunIdParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        return catching(`GET /api/ci-logs/${parsed.data}`, () => apiCiLogs(parsed.data));
+      },
     },
 
     "/api/notifications/stream": {
@@ -919,8 +973,9 @@ Bun.serve({
 
     [apiPaths.dismissNotification]: {
       POST: (req) => {
-        const id = parseInt(req.params.id, 10);
-        if (isNaN(id)) return errorResponse("Invalid notification ID", 400);
+        const parsed = parseNotificationIdParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const id = parsed.data;
         if (!runtimeNotifications.dismiss(id)) return errorResponse("Not found", 404);
         return jsonResponse({ ok: true });
       },

--- a/bin/src/worktree-commands.test.ts
+++ b/bin/src/worktree-commands.test.ts
@@ -719,7 +719,10 @@ describe("runWorktreeCommand", () => {
 
     it("reports server errors with the error message", async () => {
       globalThis.fetch = (async () => {
-        return new Response(JSON.stringify({ error: "Worktree not found: no-such" }), { status: 404 });
+        return new Response(JSON.stringify({ error: "Worktree not found: no-such" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
       }) as typeof fetch;
 
       const stderr: string[] = [];

--- a/bin/src/worktree-commands.ts
+++ b/bin/src/worktree-commands.ts
@@ -1,4 +1,5 @@
 import * as p from "@clack/prompts";
+import { createApi } from "@webmux/api-contract";
 import { basename, resolve } from "node:path";
 import { readWorktreeArchiveState, readWorktreeMeta } from "../../backend/src/adapters/fs";
 import { buildProjectSessionName, buildWorktreeWindowName } from "../../backend/src/adapters/tmux";
@@ -658,29 +659,23 @@ export async function runWorktreeCommand(
         return 0;
       }
 
-      const url = `http://localhost:${context.port}/api/worktrees/${encodeURIComponent(parsed.branch)}/send`;
-      const body: Record<string, string> = { text: parsed.text };
-      if (parsed.preamble) body.preamble = parsed.preamble;
-
-      let response: Response;
+      const api = createApi(`http://localhost:${context.port}`);
       try {
-        response = await fetch(url, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
+        await api.sendWorktreePrompt({
+          params: { name: parsed.branch },
+          body: {
+            text: parsed.text,
+            ...(parsed.preamble ? { preamble: parsed.preamble } : {}),
+          },
         });
-      } catch {
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith("HTTP")) {
+          throw error;
+        }
+        if (error instanceof Error && !error.message.includes("fetch")) {
+          throw error;
+        }
         throw new Error(`Could not connect to webmux server on port ${context.port}. Is it running?`);
-      }
-
-      if (!response.ok) {
-        const errorBody = await response.text();
-        let message = `Server returned ${response.status}`;
-        try {
-          const json = JSON.parse(errorBody) as Record<string, unknown>;
-          if (typeof json.error === "string") message = json.error;
-        } catch {}
-        throw new Error(message);
       }
 
       stdout(`Sent prompt to ${parsed.branch}`);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@webmux/api-contract": "workspace:*",
     "diff2html": "^3.4.56"
   }
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -52,20 +52,24 @@
   import { setToastController } from "./lib/toast-context";
   import { api, fetchWorktrees, subscribeNotifications } from "./lib/api";
 
-  let config = $state<AppConfig>({
-    name: "",
-    services: [],
-    profiles: [],
-    defaultProfileName: "",
-    autoName: false,
-    linearCreateTicketOption: false,
-    startupEnvs: {},
-    linkedRepos: [],
-    linearAutoCreateWorktrees: false,
-    autoRemoveOnMerge: false,
-    projectDir: "",
-    mainBranch: "",
-  });
+  function createDefaultConfig(): AppConfig {
+    return {
+      name: "",
+      services: [],
+      profiles: [],
+      defaultProfileName: "",
+      autoName: false,
+      linearCreateTicketOption: false,
+      startupEnvs: {},
+      linkedRepos: [],
+      linearAutoCreateWorktrees: false,
+      autoRemoveOnMerge: false,
+      projectDir: "",
+      mainBranch: "",
+    };
+  }
+
+  let config = $state<AppConfig>(createDefaultConfig());
   let worktrees = $state<WorktreeInfo[]>([]);
   let selectedBranch = $state<string | null>(loadSavedSelectedWorktree());
   let hasLoadedWorktrees = $state(false);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -50,15 +50,21 @@
   import { getTheme } from "./lib/themes";
   import type { ThemeKey } from "./lib/themes";
   import { setToastController } from "./lib/toast-context";
-  import * as api from "./lib/api";
+  import { api, fetchWorktrees, subscribeNotifications } from "./lib/api";
 
   let config = $state<AppConfig>({
+    name: "",
     services: [],
     profiles: [],
     defaultProfileName: "",
     autoName: false,
     linearCreateTicketOption: false,
+    startupEnvs: {},
     linkedRepos: [],
+    linearAutoCreateWorktrees: false,
+    autoRemoveOnMerge: false,
+    projectDir: "",
+    mainBranch: "",
   });
   let worktrees = $state<WorktreeInfo[]>([]);
   let selectedBranch = $state<string | null>(loadSavedSelectedWorktree());
@@ -154,10 +160,10 @@
     const inFlight = availableBranchRequests[key];
     if (inFlight) return inFlight;
 
-    const request = api.fetchAvailableBranches({ includeRemote })
-      .then((branches) => {
-        availableBranchCache[key] = branches;
-        return branches;
+    const request = api.fetchAvailableBranches({ query: { includeRemote } })
+      .then((data) => {
+        availableBranchCache[key] = data.branches;
+        return data.branches;
       })
       .finally(() => {
         delete availableBranchRequests[key];
@@ -172,9 +178,9 @@
     if (baseBranchRequest) return baseBranchRequest;
 
     baseBranchRequest = api.fetchBaseBranches()
-      .then((branches) => {
-        baseBranchCache = branches;
-        return branches;
+      .then((data) => {
+        baseBranchCache = data.branches;
+        return data.branches;
       })
       .finally(() => {
         baseBranchRequest = null;
@@ -226,7 +232,7 @@
 
   function handleDismissNotification(id: number): void {
     notifications = notifications.filter((n) => n.id !== id);
-    api.dismissNotification(id).catch(() => {});
+    api.dismissNotification({ params: { id } }).catch(() => {});
   }
 
   function handleSseDismiss(id: number): void {
@@ -502,7 +508,7 @@
 
   async function refresh() {
     try {
-      worktrees = await api.fetchWorktrees();
+      worktrees = await fetchWorktrees();
       hasLoadedWorktrees = true;
     } catch (err) {
       console.error("Failed to refresh:", err);
@@ -535,7 +541,7 @@
     assignIssue = null;
 
     try {
-      const createPromise = api.createWorktree(request);
+      const createPromise = api.createWorktree({ body: request });
       void refresh();
       const result = await createPromise;
       if (shouldAutoSelectCreatedWorktree) {
@@ -601,7 +607,7 @@
 
     removingBranches = new Set([...removingBranches, branch]);
     try {
-      await api.removeWorktree(branch);
+      await api.removeWorktree({ params: { name: branch } });
       invalidateBranchCaches();
       await refresh();
     } catch (err) {
@@ -621,7 +627,7 @@
 
     removingBranches = new Set([...removingBranches, branch]);
     try {
-      await api.mergeWorktree(branch);
+      await api.mergeWorktree({ params: { name: branch } });
       invalidateBranchCaches();
       await refresh();
     } catch (err) {
@@ -637,7 +643,9 @@
     pullMainLoading = true;
     pullMainError = "";
     try {
-      const result = await api.pullMain(pullMainForce);
+      const result = await api.pullMain({
+        body: { ...(pullMainForce ? { force: true } : {}) },
+      });
       if (result.status === "updated" || result.status === "already_up_to_date") {
         pullMainConfirm = false;
         pullMainForce = false;
@@ -665,7 +673,12 @@
     pullLinkedRepoLoading = true;
     pullLinkedRepoError = "";
     try {
-      const result = await api.pullMain(pullLinkedRepoForce, pullLinkedRepoAlias);
+      const result = await api.pullMain({
+        body: {
+          ...(pullLinkedRepoForce ? { force: true } : {}),
+          ...(pullLinkedRepoAlias ? { repo: pullLinkedRepoAlias } : {}),
+        },
+      });
       if (result.status === "updated" || result.status === "already_up_to_date") {
         pullLinkedRepoAlias = null;
         pullLinkedRepoForce = false;
@@ -687,7 +700,7 @@
     if (!branch) return;
     openingBranches = new Set([...openingBranches, branch]);
     try {
-      await api.openWorktree(branch);
+      await api.openWorktree({ params: { name: branch } });
       await refresh();
     } catch (err) {
       showToast({ tone: "error", message: `Failed to open worktree: ${errorMessage(err)}` });
@@ -704,7 +717,10 @@
 
     archivingBranches = new Set([...archivingBranches, branch]);
     try {
-      await api.setWorktreeArchived(branch, { archived: nextArchived });
+      await api.setWorktreeArchived({
+        params: { name: branch },
+        body: { archived: nextArchived },
+      });
       await refresh();
     } catch (err) {
       alert(`Failed to ${actionLabel} worktree: ${errorMessage(err)}`);
@@ -716,7 +732,7 @@
   async function closeWorktree(branch: string): Promise<void> {
     selectNeighborOf(branch);
     try {
-      await api.closeWorktree(branch);
+      await api.closeWorktree({ params: { name: branch } });
       await refresh();
     } catch (err) {
       showToast({ tone: "error", message: `Failed to close worktree: ${errorMessage(err)}` });
@@ -800,7 +816,7 @@
     let intervalMs = pollIntervalMs;
     let interval: ReturnType<typeof setInterval> | undefined;
     window.addEventListener("keydown", handleKeydown);
-    let unsubNotifications = api.subscribeNotifications(handleNotification, handleSseDismiss, handleInitialNotification);
+    let unsubNotifications = subscribeNotifications(handleNotification, handleSseDismiss, handleInitialNotification);
     // Request notification permission (no-op if already granted/denied)
     if (Notification.permission === "default") {
       Notification.requestPermission().catch(() => {});

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -3,27 +3,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppConfig, AppNotification, LinearIssuesResponse, WorktreeInfo } from "./lib/types";
 
 vi.mock("./lib/api", () => ({
-  closeWorktree: vi.fn(),
-  createWorktree: vi.fn(),
-  dismissNotification: vi.fn(),
-  fetchAvailableBranches: vi.fn(),
-  fetchBaseBranches: vi.fn(),
-  fetchCiLogs: vi.fn(),
-  fetchConfig: vi.fn(),
-  fetchWorktreeDiff: vi.fn(),
-  fetchLinearIssues: vi.fn(),
+  api: {
+    closeWorktree: vi.fn(),
+    createWorktree: vi.fn(),
+    dismissNotification: vi.fn(),
+    fetchAvailableBranches: vi.fn(),
+    fetchBaseBranches: vi.fn(),
+    fetchCiLogs: vi.fn(),
+    fetchConfig: vi.fn(),
+    fetchWorktreeDiff: vi.fn(),
+    fetchLinearIssues: vi.fn(),
+    mergeWorktree: vi.fn(),
+    openWorktree: vi.fn(),
+    pullMain: vi.fn(),
+    removeWorktree: vi.fn(),
+    setWorktreeArchived: vi.fn(),
+    sendWorktreePrompt: vi.fn(),
+  },
   fetchWorktrees: vi.fn(),
-  mergeWorktree: vi.fn(),
-  openWorktree: vi.fn(),
-  pullMain: vi.fn(),
-  removeWorktree: vi.fn(),
-  setWorktreeArchived: vi.fn(),
-  sendWorktreePrompt: vi.fn(),
   subscribeNotifications: vi.fn(),
 }));
 
 import App from "./App.svelte";
-import * as api from "./lib/api";
+import { api, fetchWorktrees, subscribeNotifications } from "./lib/api";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -56,12 +58,18 @@ function deferred<T>(): Deferred<T> {
 
 function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {
+    name: "repo",
     services: [],
+    startupEnvs: {},
     profiles: [{ name: "default" }],
     defaultProfileName: "default",
     autoName: false,
     linearCreateTicketOption: false,
     linkedRepos: [],
+    linearAutoCreateWorktrees: false,
+    autoRemoveOnMerge: false,
+    projectDir: "/repo",
+    mainBranch: "main",
     ...overrides,
   };
 }
@@ -188,9 +196,9 @@ describe("App create selection", () => {
     setupBrowserMocks();
 
     vi.mocked(api.fetchConfig).mockResolvedValue(createConfig());
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
-    vi.mocked(api.fetchAvailableBranches).mockResolvedValue([]);
-    vi.mocked(api.fetchBaseBranches).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(api.fetchAvailableBranches).mockResolvedValue({ branches: [] });
+    vi.mocked(api.fetchBaseBranches).mockResolvedValue({ branches: [] });
     vi.mocked(api.fetchLinearIssues).mockResolvedValue(createLinearIssuesResponse());
     vi.mocked(api.fetchWorktreeDiff).mockResolvedValue({
       uncommitted: "",
@@ -198,16 +206,16 @@ describe("App create selection", () => {
       gitStatus: "",
       unpushedCommits: [],
     });
-    vi.mocked(api.subscribeNotifications).mockReturnValue(() => {});
-    vi.mocked(api.openWorktree).mockResolvedValue(undefined);
-    vi.mocked(api.closeWorktree).mockResolvedValue(undefined);
-    vi.mocked(api.removeWorktree).mockResolvedValue(undefined);
+    vi.mocked(subscribeNotifications).mockReturnValue(() => {});
+    vi.mocked(api.openWorktree).mockResolvedValue({ ok: true });
+    vi.mocked(api.closeWorktree).mockResolvedValue({ ok: true });
+    vi.mocked(api.removeWorktree).mockResolvedValue({ ok: true });
     vi.mocked(api.setWorktreeArchived).mockResolvedValue({ ok: true, archived: true });
-    vi.mocked(api.mergeWorktree).mockResolvedValue(undefined);
+    vi.mocked(api.mergeWorktree).mockResolvedValue({ ok: true });
     vi.mocked(api.pullMain).mockResolvedValue({ status: "updated" });
-    vi.mocked(api.dismissNotification).mockResolvedValue(undefined);
-    vi.mocked(api.fetchCiLogs).mockResolvedValue("");
-    vi.mocked(api.sendWorktreePrompt).mockResolvedValue(undefined);
+    vi.mocked(api.dismissNotification).mockResolvedValue({ ok: true });
+    vi.mocked(api.fetchCiLogs).mockResolvedValue({ logs: "" });
+    vi.mocked(api.sendWorktreePrompt).mockResolvedValue({ ok: true });
   });
 
   afterEach(() => {
@@ -224,7 +232,7 @@ describe("App create selection", () => {
     const newWorktree = createWorktree("feature/new");
     const createResult = deferred<{ primaryBranch: string; branches: string[] }>();
 
-    vi.mocked(api.fetchWorktrees)
+    vi.mocked(fetchWorktrees)
       .mockResolvedValueOnce([existingWorktree])
       .mockResolvedValueOnce([existingWorktree, creatingWorktree])
       .mockResolvedValueOnce([existingWorktree, newWorktree])
@@ -238,7 +246,7 @@ describe("App create selection", () => {
     await openCreateDialogAndSubmit("feature/new");
 
     await waitFor(() => {
-      expect(api.fetchWorktrees).toHaveBeenCalledTimes(2);
+      expect(fetchWorktrees).toHaveBeenCalledTimes(2);
     });
     expect(screen.getByRole("button", { name: /^feature\/new\b/i })).toBeInTheDocument();
     expect(screen.getByTitle("main")).toBeInTheDocument();
@@ -247,7 +255,7 @@ describe("App create selection", () => {
     createResult.resolve({ primaryBranch: "feature/new", branches: ["feature/new"] });
 
     await waitFor(() => {
-      expect(api.fetchWorktrees).toHaveBeenCalledTimes(3);
+      expect(fetchWorktrees).toHaveBeenCalledTimes(3);
     });
     expect(screen.getByTitle("main")).toBeInTheDocument();
     expect(screen.queryByTitle("feature/new")).not.toBeInTheDocument();
@@ -261,7 +269,7 @@ describe("App create selection", () => {
     const newWorktree = createWorktree("feature/new");
     const createResult = deferred<{ primaryBranch: string; branches: string[] }>();
 
-    vi.mocked(api.fetchWorktrees)
+    vi.mocked(fetchWorktrees)
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([creatingWorktree])
       .mockResolvedValueOnce([newWorktree])
@@ -276,13 +284,13 @@ describe("App create selection", () => {
     createResult.resolve({ primaryBranch: "feature/new", branches: ["feature/new"] });
 
     await waitFor(() => {
-      expect(api.fetchWorktrees).toHaveBeenCalledTimes(3);
+      expect(fetchWorktrees).toHaveBeenCalledTimes(3);
     });
     expect(screen.getByTitle("feature/new")).toBeInTheDocument();
   });
 
   it("shows an error toast when worktree creation fails", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
     vi.mocked(api.createWorktree).mockRejectedValueOnce(new Error("branch exists"));
 
     render(App);
@@ -297,8 +305,8 @@ describe("App create selection", () => {
   it("dismisses notification toasts through the notification API", async () => {
     let onNotification: ((notification: AppNotification) => void) | undefined;
 
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
-    vi.mocked(api.subscribeNotifications).mockImplementation((handleNotification) => {
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(subscribeNotifications).mockImplementation((handleNotification) => {
       onNotification = handleNotification;
       return () => {};
     });
@@ -316,7 +324,7 @@ describe("App create selection", () => {
     expect(dismissButton).toBeDefined();
     await fireEvent.click(dismissButton!);
 
-    expect(api.dismissNotification).toHaveBeenCalledWith(42);
+    expect(api.dismissNotification).toHaveBeenCalledWith({ params: { id: 42 } });
   });
 
   it("shows a success toast when pulling main succeeds", async () => {
@@ -324,7 +332,7 @@ describe("App create selection", () => {
       projectDir: "/repo",
       mainBranch: "main",
     }));
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
     vi.mocked(api.pullMain).mockResolvedValueOnce({ status: "updated" });
 
     render(App);
@@ -334,7 +342,7 @@ describe("App create selection", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Pull" }));
     await fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Pull" }));
 
-    expect(api.pullMain).toHaveBeenCalledWith(false);
+    expect(api.pullMain).toHaveBeenCalledWith({ body: {} });
     expect(await screen.findByRole("alert")).toHaveTextContent('Pulled latest "main" from remote');
   });
 
@@ -351,7 +359,7 @@ describe("App create selection", () => {
     const createdCodex = createWorktree("codex-feature/new");
     const createResult = deferred<{ primaryBranch: string; branches: string[] }>();
 
-    vi.mocked(api.fetchWorktrees)
+    vi.mocked(fetchWorktrees)
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([creatingClaude, creatingCodex])
       .mockResolvedValueOnce([createdClaude, createdCodex])
@@ -376,13 +384,13 @@ describe("App create selection", () => {
     });
 
     await waitFor(() => {
-      expect(api.fetchWorktrees).toHaveBeenCalledTimes(3);
+      expect(fetchWorktrees).toHaveBeenCalledTimes(3);
     });
     expect(screen.getByTitle("claude-feature/new")).toBeInTheDocument();
   });
 
   it("hides archived worktrees until the archived toggle is enabled", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([
+    vi.mocked(fetchWorktrees).mockResolvedValue([
       createWorktree("feature/active"),
       createWorktree("feature/archived", { archived: true }),
     ]);
@@ -400,7 +408,7 @@ describe("App create selection", () => {
   });
 
   it("keeps the current selection while filtering the worktree list", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([
+    vi.mocked(fetchWorktrees).mockResolvedValue([
       createWorktree("main"),
       createWorktree("feature/alpha"),
       createWorktree("feature/beta"),
@@ -420,7 +428,7 @@ describe("App create selection", () => {
   });
 
   it("clears the worktree search from the trailing clear button", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([
+    vi.mocked(fetchWorktrees).mockResolvedValue([
       createWorktree("feature/alpha"),
       createWorktree("feature/beta"),
     ]);
@@ -437,7 +445,7 @@ describe("App create selection", () => {
   });
 
   it("archives the selected worktree through the API", async () => {
-    vi.mocked(api.fetchWorktrees)
+    vi.mocked(fetchWorktrees)
       .mockResolvedValueOnce([createWorktree("feature/active")])
       .mockResolvedValueOnce([createWorktree("feature/active", { archived: true })])
       .mockResolvedValue([createWorktree("feature/active", { archived: true })]);
@@ -448,12 +456,15 @@ describe("App create selection", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Archive" }));
 
     await waitFor(() => {
-      expect(api.setWorktreeArchived).toHaveBeenCalledWith("feature/active", { archived: true });
+      expect(api.setWorktreeArchived).toHaveBeenCalledWith({
+        params: { name: "feature/active" },
+        body: { archived: true },
+      });
     });
   });
 
   it("shows a setup message in the Linear panel when LINEAR_API_KEY is missing", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
     vi.mocked(api.fetchLinearIssues).mockResolvedValue(
       createLinearIssuesResponse({ availability: "missing_api_key" }),
     );
@@ -473,7 +484,7 @@ describe("App create selection", () => {
   });
 
   it("shows an empty-state message in the Linear panel when Linear is ready but has no issues", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
     vi.mocked(api.fetchLinearIssues).mockResolvedValue(
       createLinearIssuesResponse({ availability: "ready", issues: [] }),
     );
@@ -491,7 +502,7 @@ describe("App create selection", () => {
   });
 
   it("hides the Linear ticket option when disabled in config", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
 
     render(App);
 
@@ -505,7 +516,7 @@ describe("App create selection", () => {
     vi.mocked(api.fetchConfig).mockResolvedValue(createConfig({
       linearCreateTicketOption: true,
     }));
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
     vi.mocked(api.createWorktree).mockResolvedValue({
       primaryBranch: "eng-123-new-flow",
       branches: ["eng-123-new-flow"],
@@ -536,18 +547,20 @@ describe("App create selection", () => {
 
     await waitFor(() => {
       expect(api.createWorktree).toHaveBeenCalledWith({
-        mode: "new",
-        profile: "default",
-        agent: "claude",
-        prompt: "Implement the new flow",
-        createLinearTicket: true,
-        linearTitle: "Ship Linear-backed worktree creation",
+        body: {
+          mode: "new",
+          profile: "default",
+          agent: "claude",
+          prompt: "Implement the new flow",
+          createLinearTicket: true,
+          linearTitle: "Ship Linear-backed worktree creation",
+        },
       });
     });
   });
 
   it("submits paired worktree creation when Both is selected", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
     vi.mocked(api.createWorktree).mockResolvedValue({
       primaryBranch: "claude-feature/new",
       branches: ["claude-feature/new", "codex-feature/new"],
@@ -570,17 +583,19 @@ describe("App create selection", () => {
 
     await waitFor(() => {
       expect(api.createWorktree).toHaveBeenCalledWith({
-        mode: "new",
-        branch: "feature/new",
-        profile: "default",
-        agent: "both",
+        body: {
+          mode: "new",
+          branch: "feature/new",
+          profile: "default",
+          agent: "both",
+        },
       });
     });
   });
 
   it("submits an explicit base branch when provided", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
-    vi.mocked(api.fetchBaseBranches).mockResolvedValue([{ name: "release/base" }]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(api.fetchBaseBranches).mockResolvedValue({ branches: [{ name: "release/base" }] });
     vi.mocked(api.createWorktree).mockResolvedValue({
       primaryBranch: "feature/from-release",
       branches: ["feature/from-release"],
@@ -592,21 +607,23 @@ describe("App create selection", () => {
 
     await waitFor(() => {
       expect(api.createWorktree).toHaveBeenCalledWith({
-        mode: "new",
-        branch: "feature/from-release",
-        baseBranch: "release/base",
-        profile: "default",
-        agent: "claude",
+        body: {
+          mode: "new",
+          branch: "feature/from-release",
+          baseBranch: "release/base",
+          profile: "default",
+          agent: "claude",
+        },
       });
     });
   });
 
   it("caches branch lists across dialog openings and only fetches each mode once", async () => {
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
     vi.mocked(api.fetchAvailableBranches)
-      .mockResolvedValueOnce([{ name: "feature/local-only" }])
-      .mockResolvedValueOnce([{ name: "feature/local-only" }, { name: "feature/remote-only" }]);
-    vi.mocked(api.fetchBaseBranches).mockResolvedValue([{ name: "main" }]);
+      .mockResolvedValueOnce({ branches: [{ name: "feature/local-only" }] })
+      .mockResolvedValueOnce({ branches: [{ name: "feature/local-only" }, { name: "feature/remote-only" }] });
+    vi.mocked(api.fetchBaseBranches).mockResolvedValue({ branches: [{ name: "main" }] });
 
     render(App);
 
@@ -615,7 +632,7 @@ describe("App create selection", () => {
 
     await waitFor(() => {
       expect(api.fetchAvailableBranches).toHaveBeenCalledTimes(1);
-      expect(api.fetchAvailableBranches).toHaveBeenCalledWith({ includeRemote: false });
+      expect(api.fetchAvailableBranches).toHaveBeenCalledWith({ query: { includeRemote: false } });
       expect(api.fetchBaseBranches).toHaveBeenCalledTimes(1);
     });
 
@@ -624,7 +641,7 @@ describe("App create selection", () => {
 
     await waitFor(() => {
       expect(api.fetchAvailableBranches).toHaveBeenCalledTimes(2);
-      expect(api.fetchAvailableBranches).toHaveBeenLastCalledWith({ includeRemote: true });
+      expect(api.fetchAvailableBranches).toHaveBeenLastCalledWith({ query: { includeRemote: true } });
     });
 
     await fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
@@ -648,10 +665,10 @@ describe("App create selection", () => {
   it("keeps the current branch list visible while remote branches are loading", async () => {
     const remoteBranches = deferred<Array<{ name: string }>>();
 
-    vi.mocked(api.fetchWorktrees).mockResolvedValue([]);
+    vi.mocked(fetchWorktrees).mockResolvedValue([]);
     vi.mocked(api.fetchAvailableBranches)
-      .mockResolvedValueOnce([{ name: "feature/local-only" }])
-      .mockReturnValueOnce(remoteBranches.promise);
+      .mockResolvedValueOnce({ branches: [{ name: "feature/local-only" }] })
+      .mockReturnValueOnce(remoteBranches.promise.then((branches) => ({ branches })));
 
     render(App);
 

--- a/frontend/src/lib/CiDetailsDialog.svelte
+++ b/frontend/src/lib/CiDetailsDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { PrEntry } from "./types";
-  import { fetchCiLogs, sendWorktreePrompt } from "./api";
+  import { api } from "./api";
   import { normalizeTextForPrompt } from "./promptUtils";
   import { prLabel, errorMessage } from "./utils";
   import { getToastController } from "./toast-context";
@@ -66,7 +66,7 @@
     logsError = "";
     loadingRunId = check.runId;
     try {
-      const logs = await fetchCiLogs(check.runId);
+      const { logs } = await api.fetchCiLogs({ params: { runId: check.runId } });
       logsByRunId.set(check.runId, logs);
       logsByRunId = new Map(logsByRunId);
     } catch (err) {
@@ -92,7 +92,10 @@
       ].join("\n") + "\n";
     const sanitizedLogs = normalizeTextForPrompt(filteredLogs);
     try {
-      await sendWorktreePrompt(branch, sanitizedLogs, preamble);
+      await api.sendWorktreePrompt({
+        params: { name: branch },
+        body: { text: sanitizedLogs, preamble },
+      });
       toast.success(`Asked agent to fix ${checkName}`);
       onfixsuccess();
     } catch (err) {

--- a/frontend/src/lib/CommentReviewDialog.svelte
+++ b/frontend/src/lib/CommentReviewDialog.svelte
@@ -2,7 +2,7 @@
   import { untrack } from "svelte";
   import { SvelteSet } from "svelte/reactivity";
   import type { PrEntry, PrComment } from "./types";
-  import { sendWorktreePrompt } from "./api";
+  import { api } from "./api";
   import { normalizeTextForPrompt } from "./promptUtils";
   import { prLabel, errorMessage } from "./utils";
   import { getToastController } from "./toast-context";
@@ -86,11 +86,13 @@
       .map((c, i) => formatComment(c, i + 1))
       .join("\n\n");
     try {
-      await sendWorktreePrompt(
-        branch,
-        normalizeTextForPrompt(content, 20000),
-        preamble,
-      );
+      await api.sendWorktreePrompt({
+        params: { name: branch },
+        body: {
+          text: normalizeTextForPrompt(content, 20000),
+          preamble,
+        },
+      });
       toast.success(`Sent ${selected.size} comment${selected.size === 1 ? "" : "s"} to agent`);
       onsendsuccess();
     } catch (err) {

--- a/frontend/src/lib/DiffDialog.svelte
+++ b/frontend/src/lib/DiffDialog.svelte
@@ -3,7 +3,7 @@
   import { ColorSchemeType } from "diff2html/lib/types";
   import "diff2html/bundles/css/diff2html.min.css";
   import type { UnpushedCommit } from "./types";
-  import { fetchWorktreeDiff } from "./api";
+  import { api } from "./api";
   import { errorMessage } from "./utils";
   import BaseDialog from "./BaseDialog.svelte";
   import Btn from "./Btn.svelte";
@@ -29,7 +29,7 @@
   $effect(() => {
     loading = true;
     error = "";
-    fetchWorktreeDiff(branch)
+    api.fetchWorktreeDiff({ params: { name: branch } })
       .then((res) => {
         uncommitted = res.uncommitted;
         uncommittedTruncated = res.uncommittedTruncated;

--- a/frontend/src/lib/DiffDialog.test.ts
+++ b/frontend/src/lib/DiffDialog.test.ts
@@ -2,11 +2,13 @@ import { cleanup, render, screen } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./api", () => ({
-  fetchWorktreeDiff: vi.fn(),
+  api: {
+    fetchWorktreeDiff: vi.fn(),
+  },
 }));
 
 import DiffDialog from "./DiffDialog.svelte";
-import * as api from "./api";
+import { api } from "./api";
 
 const originalDialogShowModal = HTMLDialogElement.prototype.showModal;
 const originalDialogClose = HTMLDialogElement.prototype.close;

--- a/frontend/src/lib/SettingsDialog.svelte
+++ b/frontend/src/lib/SettingsDialog.svelte
@@ -5,7 +5,7 @@
   import BaseDialog from "./BaseDialog.svelte";
   import Btn from "./Btn.svelte";
   import Toggle from "./Toggle.svelte";
-  import * as api from "./api";
+  import { api } from "./api";
 
   let {
     currentTheme,
@@ -39,7 +39,7 @@
   function handleAutoCreateToggle(enabled: boolean) {
     pendingAutoCreate = enabled;
     autoCreateSaving = true;
-    api.setLinearAutoCreate(enabled)
+    api.setLinearAutoCreate({ body: { enabled } })
       .then((result) => {
         onlinearautocreatechange(result.enabled);
       })
@@ -52,7 +52,7 @@
   function handleAutoRemoveToggle(enabled: boolean) {
     pendingAutoRemove = enabled;
     autoRemoveSaving = true;
-    api.setAutoRemoveOnMerge(enabled)
+    api.setAutoRemoveOnMerge({ body: { enabled } })
       .then((result) => {
         onautoremovechange(result.enabled);
       })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,35 +1,12 @@
+import { api } from "@webmux/api-contract";
 import type {
-  AvailableBranch,
-  AvailableBranchesQuery,
-  WorktreeInfo,
-  AppConfig,
   AppNotification,
-  BranchListResponse,
-  CreateWorktreeRequest,
-  CreateWorktreeResponse,
   FileUploadResult,
-  LinearIssue,
-  LinearIssuesResponse,
   ProjectWorktreeSnapshot,
-  SetWorktreeArchivedRequest,
-  SetWorktreeArchivedResponse,
-  WorktreeListResponse,
-  WorktreeDiffResponse,
+  WorktreeInfo,
 } from "./types";
 
-async function api<T = unknown>(path: string, opts?: RequestInit): Promise<T> {
-  const res = await fetch(`/api/${path}`, {
-    headers: { "Content-Type": "application/json" },
-    ...opts,
-  });
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
-  return data as T;
-}
-
-export function fetchConfig(): Promise<AppConfig> {
-  return api<AppConfig>("config");
-}
+export { api };
 
 function mapAgentStatus(status: string): string {
   switch (status) {
@@ -73,113 +50,8 @@ function mapWorktree(snapshot: ProjectWorktreeSnapshot): WorktreeInfo {
 }
 
 export async function fetchWorktrees(): Promise<WorktreeInfo[]> {
-  const response = await api<WorktreeListResponse>("worktrees");
+  const response = await api.fetchWorktrees();
   return response.worktrees.map((worktree) => mapWorktree(worktree));
-}
-
-export async function fetchAvailableBranches(options: AvailableBranchesQuery = {}): Promise<AvailableBranch[]> {
-  const params = new URLSearchParams();
-  if (options.includeRemote) {
-    params.set("includeRemote", "true");
-  }
-
-  const path = params.size > 0 ? `branches?${params.toString()}` : "branches";
-  const data = await api<BranchListResponse>(path);
-  return data.branches;
-}
-
-export async function fetchBaseBranches(): Promise<AvailableBranch[]> {
-  const data = await api<BranchListResponse>("base-branches");
-  return data.branches;
-}
-
-export function createWorktree(request: CreateWorktreeRequest): Promise<CreateWorktreeResponse> {
-  return api<CreateWorktreeResponse>("worktrees", {
-    method: "POST",
-    body: JSON.stringify({
-      mode: request.mode,
-      ...(request.branch ? { branch: request.branch } : {}),
-      ...(request.baseBranch ? { baseBranch: request.baseBranch } : {}),
-      profile: request.profile,
-      agent: request.agent,
-      ...(request.prompt ? { prompt: request.prompt } : {}),
-      ...(request.envOverrides && Object.keys(request.envOverrides).length > 0
-        ? { envOverrides: request.envOverrides }
-        : {}),
-      ...(request.createLinearTicket ? { createLinearTicket: true } : {}),
-      ...(request.linearTitle ? { linearTitle: request.linearTitle } : {}),
-    }),
-  });
-}
-
-export function removeWorktree(name: string): Promise<unknown> {
-  return api(`worktrees/${encodeURIComponent(name)}`, { method: "DELETE" });
-}
-
-export function openWorktree(name: string): Promise<unknown> {
-  return api(`worktrees/${encodeURIComponent(name)}/open`, { method: "POST" });
-}
-
-export function closeWorktree(name: string): Promise<unknown> {
-  return api(`worktrees/${encodeURIComponent(name)}/close`, { method: "POST" });
-}
-
-export function setWorktreeArchived(
-  name: string,
-  request: SetWorktreeArchivedRequest,
-): Promise<SetWorktreeArchivedResponse> {
-  return api<SetWorktreeArchivedResponse>(`worktrees/${encodeURIComponent(name)}/archive`, {
-    method: "PUT",
-    body: JSON.stringify(request),
-  });
-}
-
-export function mergeWorktree(name: string): Promise<unknown> {
-  return api(`worktrees/${encodeURIComponent(name)}/merge`, { method: "POST" });
-}
-
-export function fetchLinearIssues(): Promise<LinearIssuesResponse> {
-  return api<LinearIssuesResponse>("linear/issues");
-}
-
-export function setLinearAutoCreate(enabled: boolean): Promise<{ ok: boolean; enabled: boolean }> {
-  return api<{ ok: boolean; enabled: boolean }>("linear/auto-create", {
-    method: "PUT",
-    body: JSON.stringify({ enabled }),
-  });
-}
-
-export interface PullMainResult {
-  status: "updated" | "already_up_to_date" | "fetch_failed" | "merge_failed";
-  from?: string;
-  to?: string;
-  error?: string;
-}
-
-export function pullMain(force = false, repo?: string): Promise<PullMainResult> {
-  return api<PullMainResult>("pull-main", {
-    method: "POST",
-    body: JSON.stringify({ ...(force ? { force: true } : {}), ...(repo ? { repo } : {}) }),
-  });
-}
-
-export function setAutoRemoveOnMerge(enabled: boolean): Promise<{ ok: boolean; enabled: boolean }> {
-  return api<{ ok: boolean; enabled: boolean }>("github/auto-remove-on-merge", {
-    method: "PUT",
-    body: JSON.stringify({ enabled }),
-  });
-}
-
-export async function fetchCiLogs(runId: number): Promise<string> {
-  const data = await api<{ logs: string }>(`ci-logs/${runId}`);
-  return data.logs;
-}
-
-export async function sendWorktreePrompt(branch: string, text: string, preamble?: string): Promise<void> {
-  await api(`worktrees/${encodeURIComponent(branch)}/send`, {
-    method: "POST",
-    body: JSON.stringify({ text, ...(preamble ? { preamble } : {}) }),
-  });
 }
 
 export function subscribeNotifications(
@@ -213,10 +85,6 @@ export function subscribeNotifications(
   return () => es.close();
 }
 
-export async function dismissNotification(id: number): Promise<void> {
-  await api(`notifications/${id}/dismiss`, { method: "POST" });
-}
-
 export async function uploadFiles(worktree: string, files: File[]): Promise<FileUploadResult> {
   const form = new FormData();
   for (const file of files) {
@@ -229,8 +97,4 @@ export async function uploadFiles(worktree: string, files: File[]): Promise<File
   const data = await res.json();
   if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
   return data as FileUploadResult;
-}
-
-export function fetchWorktreeDiff(branch: string): Promise<WorktreeDiffResponse> {
-  return api<WorktreeDiffResponse>(`worktrees/${encodeURIComponent(branch)}/diff`);
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { api } from "@webmux/api-contract";
+import { createApi } from "@webmux/api-contract";
 import type {
   AppNotification,
   FileUploadResult,
@@ -6,7 +6,7 @@ import type {
   WorktreeInfo,
 } from "./types";
 
-export { api };
+export const api = createApi("");
 
 function mapAgentStatus(status: string): string {
   switch (status) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,135 +1,49 @@
-export interface ServiceStatus {
-  name: string;
-  port: number | null;
-  running: boolean;
-  url?: string | null;
-}
+import type {
+  AgentKind,
+  LinkedLinearIssue,
+  PrEntry,
+  ServiceStatus,
+  WorktreeCreationPhase,
+} from "@webmux/api-contract";
 
-export interface PrComment {
-  type: "comment" | "inline";
-  author: string;
-  body: string;
-  createdAt: string;
-  path?: string;
-  line?: number | null;
-  diffHunk?: string;
-  isReply?: boolean;
-}
-
-export interface CiCheck {
-  name: string;
-  status: "pending" | "success" | "failed" | "skipped";
-  url: string | null;
-  runId: number | null;
-}
-
-export interface PrEntry {
-  repo: string;
-  number: number;
-  state: "open" | "closed" | "merged";
-  url: string;
-  updatedAt: string;
-  ciStatus: "none" | "pending" | "success" | "failed";
-  ciChecks: CiCheck[];
-  comments: PrComment[];
-}
-
-export interface LinearIssueLabel {
-  name: string;
-  color: string;
-}
-
-export interface LinearIssueState {
-  name: string;
-  color: string;
-  type: string;
-}
-
-export interface LinkedLinearIssue {
-  identifier: string;
-  url: string;
-  state: LinearIssueState;
-}
-
-export interface LinearIssue {
-  id: string;
-  identifier: string;
-  title: string;
-  description: string | null;
-  priority: number;
-  priorityLabel: string;
-  url: string;
-  branchName: string;
-  dueDate: string | null;
-  updatedAt: string;
-  state: LinearIssueState;
-  team: { name: string; key: string };
-  labels: LinearIssueLabel[];
-  project: string | null;
-}
-
-export type LinearIssueAvailability = "disabled" | "missing_api_key" | "ready";
-
-export interface LinearIssuesResponse {
-  availability: LinearIssueAvailability;
-  issues: LinearIssue[];
-}
+export type {
+  AgentKind,
+  AppConfig,
+  AppNotification,
+  AvailableBranch,
+  AvailableBranchesQuery,
+  BranchListResponse,
+  CiCheck,
+  CreateWorktreeAgentSelection,
+  CreateWorktreeRequest,
+  CreateWorktreeResponse,
+  LinearIssue,
+  LinearIssueAvailability,
+  LinearIssueLabel,
+  LinearIssueState,
+  LinearIssuesResponse,
+  LinkedLinearIssue,
+  LinkedRepoInfo,
+  PrComment,
+  PrEntry,
+  ProfileConfig,
+  ProjectSnapshot,
+  ProjectWorktreeSnapshot,
+  PullMainResult,
+  ServiceConfig,
+  ServiceStatus,
+  SetWorktreeArchivedRequest,
+  SetWorktreeArchivedResponse,
+  UnpushedCommit,
+  WorktreeCreationPhase,
+  WorktreeCreationState,
+  WorktreeCreateMode,
+  WorktreeDiffResponse,
+  WorktreeListResponse,
+} from "@webmux/api-contract";
 
 export interface FileUploadResult {
   files: Array<{ path: string }>;
-}
-
-export type AgentKind = "claude" | "codex";
-export type CreateWorktreeAgentSelection = AgentKind | "both";
-export type WorktreeCreateMode = "new" | "existing";
-
-export interface AvailableBranch {
-  name: string;
-}
-
-export interface AvailableBranchesQuery {
-  includeRemote?: boolean;
-}
-
-export interface BranchListResponse {
-  branches: AvailableBranch[];
-}
-
-export interface CreateWorktreeRequest {
-  mode: WorktreeCreateMode;
-  branch?: string;
-  baseBranch?: string;
-  profile: string;
-  agent: CreateWorktreeAgentSelection;
-  prompt?: string;
-  envOverrides?: Record<string, string>;
-  createLinearTicket?: boolean;
-  linearTitle?: string;
-}
-
-export interface CreateWorktreeResponse {
-  primaryBranch: string;
-  branches: string[];
-}
-
-export interface SetWorktreeArchivedRequest {
-  archived: boolean;
-}
-
-export interface SetWorktreeArchivedResponse {
-  ok: boolean;
-  archived: boolean;
-}
-
-export type WorktreeCreationPhase =
-  | "creating_worktree"
-  | "preparing_runtime"
-  | "running_post_create_hook"
-  | "starting_session"
-  | "reconciling";
-
-export interface WorktreeCreationState {
-  phase: WorktreeCreationPhase;
 }
 
 export interface WorktreeInfo {
@@ -145,7 +59,7 @@ export interface WorktreeInfo {
   status: string;
   elapsed: string;
   profile: string | null;
-  agentName: string | null;
+  agentName: AgentKind | null;
   services: ServiceStatus[];
   paneCount: number;
   prs: PrEntry[];
@@ -154,23 +68,9 @@ export interface WorktreeInfo {
   creationPhase: WorktreeCreationPhase | null;
 }
 
-export interface ServiceConfig {
-  name: string;
-  portEnv: string;
-}
-
-export interface ProfileConfig {
-  name: string;
-  systemPrompt?: string;
-}
-
-export interface AppNotification {
-  id: number;
-  branch: string;
-  type: "agent_stopped" | "pr_opened" | "runtime_error" | "worktree_auto_removed";
-  message: string;
-  url?: string;
-  timestamp: number;
+export interface WorktreeListRow {
+  worktree: WorktreeInfo;
+  depth: number;
 }
 
 export type ToastTone = "info" | "success" | "error";
@@ -194,73 +94,3 @@ export interface NotificationToastItem extends ToastInput {
 }
 
 export type ToastItem = UiToastItem | NotificationToastItem;
-
-export interface ProjectWorktreeSnapshot {
-  branch: string;
-  baseBranch?: string;
-  path: string;
-  dir: string;
-  archived: boolean;
-  profile: string | null;
-  agentName: string | null;
-  mux: boolean;
-  dirty: boolean;
-  unpushed: boolean;
-  paneCount: number;
-  status: string;
-  elapsed: string;
-  services: ServiceStatus[];
-  prs: PrEntry[];
-  linearIssue: LinkedLinearIssue | null;
-  creation: WorktreeCreationState | null;
-}
-
-export interface ProjectSnapshot {
-  project: {
-    name: string;
-    mainBranch: string;
-  };
-  worktrees: ProjectWorktreeSnapshot[];
-  notifications: AppNotification[];
-}
-
-export interface WorktreeListResponse {
-  worktrees: ProjectWorktreeSnapshot[];
-}
-
-export interface WorktreeListRow {
-  worktree: WorktreeInfo;
-  depth: number;
-}
-
-export interface LinkedRepoInfo {
-  alias: string;
-  dir?: string;
-}
-
-export interface UnpushedCommit {
-  hash: string;
-  message: string;
-}
-
-export interface WorktreeDiffResponse {
-  uncommitted: string;
-  uncommittedTruncated: boolean;
-  gitStatus: string;
-  unpushedCommits: UnpushedCommit[];
-}
-
-export interface AppConfig {
-  name?: string;
-  services: ServiceConfig[];
-  profiles: ProfileConfig[];
-  defaultProfileName: string;
-  autoName: boolean;
-  linearCreateTicketOption: boolean;
-  startupEnvs?: Record<string, string | boolean>;
-  linkedRepos?: LinkedRepoInfo[];
-  linearAutoCreateWorktrees?: boolean;
-  autoRemoveOnMerge?: boolean;
-  projectDir?: string;
-  mainBranch?: string;
-}

--- a/package.json
+++ b/package.json
@@ -21,8 +21,12 @@
   },
   "workspaces": [
     "backend",
-    "frontend"
+    "frontend",
+    "packages/*"
   ],
+  "dependencies": {
+    "@webmux/api-contract": "workspace:*"
+  },
   "scripts": {
     "dev": "bash dev.sh",
     "start": "bun bin/webmux.js",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "start": "bun bin/webmux.js",
     "build": "cd frontend && bun run build && cd .. && bun build backend/src/server.ts --target=bun --outfile=backend/dist/server.js && bun build bin/src/webmux.ts --target=bun --outfile=bin/webmux.js",
     "prepublishOnly": "bun run build",
-    "test": "bun run --cwd backend test && bun test bin/src && bun run --cwd frontend test",
-    "test:coverage": "bun run --cwd backend test --coverage && bun test --coverage bin/src && bun run --cwd frontend test:coverage"
+    "test": "bun run --cwd backend test && bun test packages/api-contract/src && bun test bin/src && bun run --cwd frontend test",
+    "test:coverage": "bun run --cwd backend test --coverage && bun test --coverage packages/api-contract/src && bun test --coverage bin/src && bun run --cwd frontend test:coverage"
   },
   "files": [
     "bin/webmux.js",

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@webmux/api-contract",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@ts-rest/core": "^3.52.1",
+    "zod": "^3.25.76"
+  }
+}

--- a/packages/api-contract/src/client.test.ts
+++ b/packages/api-contract/src/client.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { createApi } from "./client";
+
+function success(body: unknown): { status: number; body: unknown; headers: Headers } {
+  return {
+    status: 200,
+    body,
+    headers: new Headers(),
+  };
+}
+
+describe("createApi", () => {
+  it("encodes slash-containing path params before ts-rest interpolates them", async () => {
+    const paths: string[] = [];
+    const api = createApi("https://example.com", {
+      api: async ({ path }) => {
+        paths.push(path);
+        return success({ ok: true });
+      },
+    });
+
+    await api.sendWorktreePrompt({
+      params: { name: "feature/search" },
+      body: { text: "Fix the failing tests" },
+    });
+
+    expect(paths).toEqual(["https://example.com/api/worktrees/feature%2Fsearch/send"]);
+  });
+
+  it("preserves numeric path params for notification and CI routes", async () => {
+    const paths: string[] = [];
+    const api = createApi("https://example.com", {
+      api: async ({ path }) => {
+        paths.push(path);
+        if (path.endsWith("/dismiss")) {
+          return success({ ok: true });
+        }
+        return success({ logs: "" });
+      },
+    });
+
+    await api.dismissNotification({ params: { id: 42 } });
+    await api.fetchCiLogs({ params: { runId: 317 } });
+
+    expect(paths).toEqual([
+      "https://example.com/api/notifications/42/dismiss",
+      "https://example.com/api/ci-logs/317",
+    ]);
+  });
+
+  it("throws API error messages from json error bodies", async () => {
+    const api = createApi("https://example.com", {
+      api: async () => ({
+        status: 404,
+        body: { error: "Not found" },
+        headers: new Headers(),
+      }),
+    });
+
+    await expect(api.dismissNotification({ params: { id: 7 } })).rejects.toThrow("Not found");
+  });
+
+  it("throws API error messages from stringified json error bodies", async () => {
+    const api = createApi("https://example.com", {
+      api: async () => ({
+        status: 502,
+        body: JSON.stringify({ error: "Gateway unavailable" }),
+        headers: new Headers(),
+      }),
+    });
+
+    await expect(api.fetchCiLogs({ params: { runId: 99 } })).rejects.toThrow("Gateway unavailable");
+  });
+});

--- a/packages/api-contract/src/client.ts
+++ b/packages/api-contract/src/client.ts
@@ -1,0 +1,81 @@
+import { initClient } from "@ts-rest/core";
+import { apiContract } from "./contract";
+
+export function createApiClient(baseUrl: string) {
+  return initClient(apiContract, {
+    baseUrl,
+    baseHeaders: {},
+  });
+}
+
+type SuccessStatus = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 208 | 226;
+
+type SuccessBody<TResponse> = Extract<TResponse, { status: SuccessStatus }> extends { body: infer TBody }
+  ? TBody
+  : never;
+
+type UnwrappedClient<TClient> = {
+  [K in keyof TClient]: TClient[K] extends (...args: infer TArgs) => Promise<infer TResponse>
+    ? (...args: TArgs) => Promise<SuccessBody<TResponse>>
+    : TClient[K];
+};
+
+function errorMessageFromResponse(body: unknown, status: number): string {
+  if (typeof body === "string") {
+    try {
+      const parsed = JSON.parse(body) as unknown;
+      return errorMessageFromResponse(parsed, status);
+    } catch {
+      return body.trim() || `HTTP ${status}`;
+    }
+  }
+  if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
+    return body.error;
+  }
+  return `HTTP ${status}`;
+}
+
+function encodeArgs(args: unknown[]): unknown[] {
+  const [first, ...rest] = args;
+  if (!first || typeof first !== "object" || !("params" in first) || !first.params || typeof first.params !== "object") {
+    return args;
+  }
+
+  const encodedParams = Object.fromEntries(
+    Object.entries(first.params).map(([key, value]) => [key, encodeURIComponent(String(value))]),
+  );
+
+  return [
+    {
+      ...first,
+      params: encodedParams,
+    },
+    ...rest,
+  ];
+}
+
+export function createApi(baseUrl: string): UnwrappedClient<ReturnType<typeof createApiClient>> {
+  const client = createApiClient(baseUrl);
+
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+
+      return async (...args: unknown[]) => {
+        const response = await value(...encodeArgs(args));
+        if (!response || typeof response !== "object" || !("status" in response) || !("body" in response)) {
+          throw new Error("Malformed API client response");
+        }
+        if (typeof response.status !== "number" || response.status < 200 || response.status >= 300) {
+          throw new Error(errorMessageFromResponse(response.body, response.status));
+        }
+        return response.body;
+      };
+    },
+  }) as unknown as UnwrappedClient<ReturnType<typeof createApiClient>>;
+}
+
+export const api = createApi("");

--- a/packages/api-contract/src/client.ts
+++ b/packages/api-contract/src/client.ts
@@ -1,10 +1,14 @@
-import { initClient } from "@ts-rest/core";
+import { initClient, type InitClientArgs } from "@ts-rest/core";
 import { apiContract } from "./contract";
 
-export function createApiClient(baseUrl: string) {
+export type ApiClientOptions = Omit<InitClientArgs, "baseUrl">;
+
+export function createApiClient(baseUrl: string, options: ApiClientOptions = {}) {
   return initClient(apiContract, {
     baseUrl,
+    throwOnUnknownStatus: true,
     baseHeaders: {},
+    ...options,
   });
 }
 
@@ -19,6 +23,30 @@ type UnwrappedClient<TClient> = {
     ? (...args: TArgs) => Promise<SuccessBody<TResponse>>
     : TClient[K];
 };
+
+type RouteCall = (...args: unknown[]) => Promise<unknown>;
+type RouteResponse = { status: number; body: unknown };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isRouteResponse(value: unknown): value is RouteResponse {
+  return isRecord(value)
+    && "status" in value
+    && typeof value.status === "number"
+    && "body" in value;
+}
+
+function unwrapResponse(response: unknown): unknown {
+  if (!isRouteResponse(response)) {
+    throw new Error("Malformed API client response");
+  }
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(errorMessageFromResponse(response.body, response.status));
+  }
+  return response.body;
+}
 
 function errorMessageFromResponse(body: unknown, status: number): string {
   if (typeof body === "string") {
@@ -35,7 +63,9 @@ function errorMessageFromResponse(body: unknown, status: number): string {
   return `HTTP ${status}`;
 }
 
-function encodeArgs(args: unknown[]): unknown[] {
+// ts-rest interpolates path params verbatim, so names like `feature/foo`
+// must be encoded before they are inserted into `/api/.../:name/...`.
+function withEncodedPathParams(args: unknown[]): unknown[] {
   const [first, ...rest] = args;
   if (!first || typeof first !== "object" || !("params" in first) || !first.params || typeof first.params !== "object") {
     return args;
@@ -54,28 +84,24 @@ function encodeArgs(args: unknown[]): unknown[] {
   ];
 }
 
-export function createApi(baseUrl: string): UnwrappedClient<ReturnType<typeof createApiClient>> {
-  const client = createApiClient(baseUrl);
-
-  return new Proxy(client, {
-    get(target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver);
-      if (typeof value !== "function") {
-        return value;
-      }
-
-      return async (...args: unknown[]) => {
-        const response = await value(...encodeArgs(args));
-        if (!response || typeof response !== "object" || !("status" in response) || !("body" in response)) {
-          throw new Error("Malformed API client response");
-        }
-        if (typeof response.status !== "number" || response.status < 200 || response.status >= 300) {
-          throw new Error(errorMessageFromResponse(response.body, response.status));
-        }
-        return response.body;
-      };
-    },
-  }) as unknown as UnwrappedClient<ReturnType<typeof createApiClient>>;
+function wrapRouteCall(routeCall: RouteCall): RouteCall {
+  return async (...args: unknown[]) => unwrapResponse(await routeCall(...withEncodedPathParams(args)));
 }
 
-export const api = createApi("");
+function wrapClient<TClient extends Record<string, unknown>>(client: TClient): UnwrappedClient<TClient> {
+  return Object.fromEntries(
+    Object.entries(client).map(([key, value]) => {
+      if (typeof value === "function") {
+        return [key, wrapRouteCall((...args) => Promise.resolve(Reflect.apply(value, undefined, args)))];
+      }
+      if (isRecord(value)) {
+        return [key, wrapClient(value)];
+      }
+      return [key, value];
+    }),
+  ) as UnwrappedClient<TClient>;
+}
+
+export function createApi(baseUrl: string, options: ApiClientOptions = {}): UnwrappedClient<ReturnType<typeof createApiClient>> {
+  return wrapClient(createApiClient(baseUrl, options));
+}

--- a/packages/api-contract/src/contract.ts
+++ b/packages/api-contract/src/contract.ts
@@ -1,0 +1,239 @@
+import { initContract } from "@ts-rest/core";
+import {
+  AppConfigSchema,
+  AvailableBranchesQuerySchema,
+  BranchListResponseSchema,
+  CiLogsResponseSchema,
+  CreateWorktreeRequestSchema,
+  CreateWorktreeResponseSchema,
+  EnabledResponseSchema,
+  ErrorResponseSchema,
+  OkResponseSchema,
+  ProjectSnapshotSchema,
+  PullMainRequestSchema,
+  PullMainResponseSchema,
+  RunIdParamsSchema,
+  SendWorktreePromptRequestSchema,
+  SetWorktreeArchivedRequestSchema,
+  SetWorktreeArchivedResponseSchema,
+  ToggleEnabledRequestSchema,
+  WorktreeDiffResponseSchema,
+  WorktreeListResponseSchema,
+  WorktreeNameParamsSchema,
+  NotificationIdParamsSchema,
+  LinearIssuesResponseSchema,
+} from "./schemas";
+
+const c = initContract();
+
+export const apiPaths = {
+  fetchConfig: "/api/config",
+  fetchAvailableBranches: "/api/branches",
+  fetchBaseBranches: "/api/base-branches",
+  fetchProject: "/api/project",
+  fetchWorktrees: "/api/worktrees",
+  createWorktree: "/api/worktrees",
+  removeWorktree: "/api/worktrees/:name",
+  openWorktree: "/api/worktrees/:name/open",
+  closeWorktree: "/api/worktrees/:name/close",
+  setWorktreeArchived: "/api/worktrees/:name/archive",
+  sendWorktreePrompt: "/api/worktrees/:name/send",
+  mergeWorktree: "/api/worktrees/:name/merge",
+  fetchWorktreeDiff: "/api/worktrees/:name/diff",
+  fetchLinearIssues: "/api/linear/issues",
+  setLinearAutoCreate: "/api/linear/auto-create",
+  setAutoRemoveOnMerge: "/api/github/auto-remove-on-merge",
+  pullMain: "/api/pull-main",
+  fetchCiLogs: "/api/ci-logs/:runId",
+  dismissNotification: "/api/notifications/:id/dismiss",
+} as const;
+
+const commonErrorResponses = {
+  400: ErrorResponseSchema,
+  404: ErrorResponseSchema,
+  409: ErrorResponseSchema,
+  500: ErrorResponseSchema,
+  502: ErrorResponseSchema,
+  503: ErrorResponseSchema,
+} as const;
+
+export const apiContract = c.router({
+  fetchConfig: {
+    method: "GET",
+    path: apiPaths.fetchConfig,
+    responses: {
+      200: AppConfigSchema,
+    },
+  },
+  fetchAvailableBranches: {
+    method: "GET",
+    path: apiPaths.fetchAvailableBranches,
+    query: AvailableBranchesQuerySchema,
+    responses: {
+      200: BranchListResponseSchema,
+      400: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+  },
+  fetchBaseBranches: {
+    method: "GET",
+    path: apiPaths.fetchBaseBranches,
+    responses: {
+      200: BranchListResponseSchema,
+      500: ErrorResponseSchema,
+    },
+  },
+  fetchProject: {
+    method: "GET",
+    path: apiPaths.fetchProject,
+    responses: {
+      200: ProjectSnapshotSchema,
+      500: ErrorResponseSchema,
+      502: ErrorResponseSchema,
+    },
+  },
+  fetchWorktrees: {
+    method: "GET",
+    path: apiPaths.fetchWorktrees,
+    responses: {
+      200: WorktreeListResponseSchema,
+      500: ErrorResponseSchema,
+      502: ErrorResponseSchema,
+    },
+  },
+  createWorktree: {
+    method: "POST",
+    path: apiPaths.createWorktree,
+    body: CreateWorktreeRequestSchema,
+    responses: {
+      201: CreateWorktreeResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  removeWorktree: {
+    method: "DELETE",
+    path: apiPaths.removeWorktree,
+    pathParams: WorktreeNameParamsSchema,
+    responses: {
+      200: OkResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  openWorktree: {
+    method: "POST",
+    path: apiPaths.openWorktree,
+    pathParams: WorktreeNameParamsSchema,
+    body: c.noBody(),
+    responses: {
+      200: OkResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  closeWorktree: {
+    method: "POST",
+    path: apiPaths.closeWorktree,
+    pathParams: WorktreeNameParamsSchema,
+    body: c.noBody(),
+    responses: {
+      200: OkResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  setWorktreeArchived: {
+    method: "PUT",
+    path: apiPaths.setWorktreeArchived,
+    pathParams: WorktreeNameParamsSchema,
+    body: SetWorktreeArchivedRequestSchema,
+    responses: {
+      200: SetWorktreeArchivedResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  sendWorktreePrompt: {
+    method: "POST",
+    path: apiPaths.sendWorktreePrompt,
+    pathParams: WorktreeNameParamsSchema,
+    body: SendWorktreePromptRequestSchema,
+    responses: {
+      200: OkResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  mergeWorktree: {
+    method: "POST",
+    path: apiPaths.mergeWorktree,
+    pathParams: WorktreeNameParamsSchema,
+    body: c.noBody(),
+    responses: {
+      200: OkResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  fetchWorktreeDiff: {
+    method: "GET",
+    path: apiPaths.fetchWorktreeDiff,
+    pathParams: WorktreeNameParamsSchema,
+    responses: {
+      200: WorktreeDiffResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  fetchLinearIssues: {
+    method: "GET",
+    path: apiPaths.fetchLinearIssues,
+    responses: {
+      200: LinearIssuesResponseSchema,
+      500: ErrorResponseSchema,
+      502: ErrorResponseSchema,
+    },
+  },
+  setLinearAutoCreate: {
+    method: "PUT",
+    path: apiPaths.setLinearAutoCreate,
+    body: ToggleEnabledRequestSchema,
+    responses: {
+      200: EnabledResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  setAutoRemoveOnMerge: {
+    method: "PUT",
+    path: apiPaths.setAutoRemoveOnMerge,
+    body: ToggleEnabledRequestSchema,
+    responses: {
+      200: EnabledResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  pullMain: {
+    method: "POST",
+    path: apiPaths.pullMain,
+    body: PullMainRequestSchema,
+    responses: {
+      200: PullMainResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  fetchCiLogs: {
+    method: "GET",
+    path: apiPaths.fetchCiLogs,
+    pathParams: RunIdParamsSchema,
+    responses: {
+      200: CiLogsResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  dismissNotification: {
+    method: "POST",
+    path: apiPaths.dismissNotification,
+    pathParams: NotificationIdParamsSchema,
+    body: c.noBody(),
+    responses: {
+      200: OkResponseSchema,
+      400: ErrorResponseSchema,
+      404: ErrorResponseSchema,
+    },
+  },
+}, {
+  strictStatusCodes: true,
+});

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -1,3 +1,3 @@
 export { apiContract, apiPaths } from "./contract";
-export { api, createApi, createApiClient } from "./client";
+export { createApi, createApiClient } from "./client";
 export * from "./schemas";

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -1,0 +1,3 @@
+export { apiContract, apiPaths } from "./contract";
+export { api, createApi, createApiClient } from "./client";
+export * from "./schemas";

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -1,0 +1,322 @@
+import { z } from "zod";
+
+const BooleanLikeSchema = z.union([
+  z.boolean(),
+  z.literal("true").transform(() => true),
+  z.literal("false").transform(() => false),
+]);
+
+export const ErrorResponseSchema = z.object({
+  error: z.string(),
+});
+
+export const OkResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
+export const EnabledResponseSchema = z.object({
+  ok: z.literal(true),
+  enabled: z.boolean(),
+});
+
+export const AgentKindSchema = z.enum(["claude", "codex"]);
+export const CreateWorktreeAgentSelectionSchema = z.enum(["claude", "codex", "both"]);
+export const WorktreeCreateModeSchema = z.enum(["new", "existing"]);
+export const WorktreeCreationPhaseSchema = z.enum([
+  "creating_worktree",
+  "preparing_runtime",
+  "running_post_create_hook",
+  "starting_session",
+  "reconciling",
+]);
+
+export const AvailableBranchSchema = z.object({
+  name: z.string(),
+});
+
+export const AvailableBranchesQuerySchema = z.object({
+  includeRemote: BooleanLikeSchema.optional(),
+});
+
+export const BranchListResponseSchema = z.object({
+  branches: z.array(AvailableBranchSchema),
+});
+
+export const CreateWorktreeRequestSchema = z.object({
+  mode: WorktreeCreateModeSchema.optional(),
+  branch: z.string().optional(),
+  baseBranch: z.string().optional(),
+  profile: z.string().optional(),
+  agent: CreateWorktreeAgentSelectionSchema.optional(),
+  prompt: z.string().optional(),
+  envOverrides: z.record(z.string()).optional(),
+  createLinearTicket: z.literal(true).optional(),
+  linearTitle: z.string().optional(),
+});
+
+export const CreateWorktreeResponseSchema = z.object({
+  primaryBranch: z.string(),
+  branches: z.array(z.string()),
+});
+
+export const SetWorktreeArchivedRequestSchema = z.object({
+  archived: z.boolean(),
+});
+
+export const SetWorktreeArchivedResponseSchema = z.object({
+  ok: z.literal(true),
+  archived: z.boolean(),
+});
+
+export const ToggleEnabledRequestSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export const SendWorktreePromptRequestSchema = z.object({
+  text: z.string().min(1),
+  preamble: z.string().optional(),
+});
+
+export const PullMainRequestSchema = z.object({
+  force: z.boolean().optional(),
+  repo: z.string().optional(),
+});
+
+export const PullMainStatusSchema = z.enum([
+  "updated",
+  "already_up_to_date",
+  "fetch_failed",
+  "merge_failed",
+]);
+
+export const PullMainResponseSchema = z.object({
+  status: PullMainStatusSchema,
+  from: z.string().optional(),
+  to: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export const ServiceStatusSchema = z.object({
+  name: z.string(),
+  port: z.number().nullable(),
+  running: z.boolean(),
+  url: z.string().nullable().optional(),
+});
+
+export const PrCommentSchema = z.object({
+  type: z.enum(["comment", "inline"]),
+  author: z.string(),
+  body: z.string(),
+  createdAt: z.string(),
+  path: z.string().optional(),
+  line: z.number().nullable().optional(),
+  diffHunk: z.string().optional(),
+  isReply: z.boolean().optional(),
+});
+
+export const CiCheckSchema = z.object({
+  name: z.string(),
+  status: z.enum(["pending", "success", "failed", "skipped"]),
+  url: z.string().nullable(),
+  runId: z.number().nullable(),
+});
+
+export const PrEntrySchema = z.object({
+  repo: z.string(),
+  number: z.number(),
+  state: z.enum(["open", "closed", "merged"]),
+  url: z.string(),
+  updatedAt: z.string(),
+  ciStatus: z.enum(["none", "pending", "success", "failed"]),
+  ciChecks: z.array(CiCheckSchema),
+  comments: z.array(PrCommentSchema),
+});
+
+export const LinearIssueLabelSchema = z.object({
+  name: z.string(),
+  color: z.string(),
+});
+
+export const LinearIssueStateSchema = z.object({
+  name: z.string(),
+  color: z.string(),
+  type: z.string(),
+});
+
+export const LinkedLinearIssueSchema = z.object({
+  identifier: z.string(),
+  url: z.string(),
+  state: LinearIssueStateSchema,
+});
+
+export const LinearIssueSchema = z.object({
+  id: z.string(),
+  identifier: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  priority: z.number(),
+  priorityLabel: z.string(),
+  url: z.string(),
+  branchName: z.string(),
+  dueDate: z.string().nullable(),
+  updatedAt: z.string(),
+  state: LinearIssueStateSchema,
+  team: z.object({
+    name: z.string(),
+    key: z.string(),
+  }),
+  labels: z.array(LinearIssueLabelSchema),
+  project: z.string().nullable(),
+});
+
+export const LinearIssueAvailabilitySchema = z.enum(["disabled", "missing_api_key", "ready"]);
+
+export const LinearIssuesResponseSchema = z.object({
+  availability: LinearIssueAvailabilitySchema,
+  issues: z.array(LinearIssueSchema),
+});
+
+export const WorktreeCreationStateSchema = z.object({
+  phase: WorktreeCreationPhaseSchema,
+});
+
+export const AppNotificationSchema = z.object({
+  id: z.number(),
+  branch: z.string(),
+  type: z.enum(["agent_stopped", "pr_opened", "runtime_error", "worktree_auto_removed"]),
+  message: z.string(),
+  url: z.string().optional(),
+  timestamp: z.number(),
+});
+
+export const ProjectWorktreeSnapshotSchema = z.object({
+  branch: z.string(),
+  baseBranch: z.string().optional(),
+  path: z.string(),
+  dir: z.string(),
+  archived: z.boolean(),
+  profile: z.string().nullable(),
+  agentName: AgentKindSchema.nullable(),
+  mux: z.boolean(),
+  dirty: z.boolean(),
+  unpushed: z.boolean(),
+  paneCount: z.number(),
+  status: z.string(),
+  elapsed: z.string(),
+  services: z.array(ServiceStatusSchema),
+  prs: z.array(PrEntrySchema),
+  linearIssue: LinkedLinearIssueSchema.nullable(),
+  creation: WorktreeCreationStateSchema.nullable(),
+});
+
+export const ProjectSnapshotSchema = z.object({
+  project: z.object({
+    name: z.string(),
+    mainBranch: z.string(),
+  }),
+  worktrees: z.array(ProjectWorktreeSnapshotSchema),
+  notifications: z.array(AppNotificationSchema),
+});
+
+export const WorktreeListResponseSchema = z.object({
+  worktrees: z.array(ProjectWorktreeSnapshotSchema),
+});
+
+export const UnpushedCommitSchema = z.object({
+  hash: z.string(),
+  message: z.string(),
+});
+
+export const WorktreeDiffResponseSchema = z.object({
+  uncommitted: z.string(),
+  uncommittedTruncated: z.boolean(),
+  gitStatus: z.string(),
+  unpushedCommits: z.array(UnpushedCommitSchema),
+});
+
+export const ServiceConfigSchema = z.object({
+  name: z.string(),
+  portEnv: z.string(),
+});
+
+export const ProfileConfigSchema = z.object({
+  name: z.string(),
+  systemPrompt: z.string().optional(),
+});
+
+export const LinkedRepoInfoSchema = z.object({
+  alias: z.string(),
+  dir: z.string().optional(),
+});
+
+export const AppConfigSchema = z.object({
+  name: z.string(),
+  services: z.array(ServiceConfigSchema),
+  profiles: z.array(ProfileConfigSchema),
+  defaultProfileName: z.string(),
+  autoName: z.boolean(),
+  linearCreateTicketOption: z.boolean(),
+  startupEnvs: z.record(z.union([z.string(), z.boolean()])),
+  linkedRepos: z.array(LinkedRepoInfoSchema),
+  linearAutoCreateWorktrees: z.boolean(),
+  autoRemoveOnMerge: z.boolean(),
+  projectDir: z.string(),
+  mainBranch: z.string(),
+});
+
+export const CiLogsResponseSchema = z.object({
+  logs: z.string(),
+});
+
+export const WorktreeNameParamsSchema = z.object({
+  name: z.string(),
+});
+
+export const NotificationIdParamsSchema = z.object({
+  id: z.union([z.number(), z.string()]).transform((value) => String(value)),
+});
+
+export const RunIdParamsSchema = z.object({
+  runId: z.union([z.number(), z.string()]).transform((value) => String(value)),
+});
+
+export type AgentKind = z.infer<typeof AgentKindSchema>;
+export type CreateWorktreeAgentSelection = z.infer<typeof CreateWorktreeAgentSelectionSchema>;
+export type WorktreeCreateMode = z.infer<typeof WorktreeCreateModeSchema>;
+export type WorktreeCreationPhase = z.infer<typeof WorktreeCreationPhaseSchema>;
+export type AvailableBranch = z.infer<typeof AvailableBranchSchema>;
+export type AvailableBranchesQuery = { includeRemote?: boolean };
+export type BranchListResponse = z.infer<typeof BranchListResponseSchema>;
+export type CreateWorktreeRequest = z.infer<typeof CreateWorktreeRequestSchema>;
+export type CreateWorktreeResponse = z.infer<typeof CreateWorktreeResponseSchema>;
+export type SetWorktreeArchivedRequest = z.infer<typeof SetWorktreeArchivedRequestSchema>;
+export type SetWorktreeArchivedResponse = z.infer<typeof SetWorktreeArchivedResponseSchema>;
+export type ToggleEnabledRequest = z.infer<typeof ToggleEnabledRequestSchema>;
+export type SendWorktreePromptRequest = z.infer<typeof SendWorktreePromptRequestSchema>;
+export type PullMainRequest = z.infer<typeof PullMainRequestSchema>;
+export type PullMainResult = z.infer<typeof PullMainResponseSchema>;
+export type ServiceStatus = z.infer<typeof ServiceStatusSchema>;
+export type PrComment = z.infer<typeof PrCommentSchema>;
+export type CiCheck = z.infer<typeof CiCheckSchema>;
+export type PrEntry = z.infer<typeof PrEntrySchema>;
+export type LinearIssueLabel = z.infer<typeof LinearIssueLabelSchema>;
+export type LinearIssueState = z.infer<typeof LinearIssueStateSchema>;
+export type LinkedLinearIssue = z.infer<typeof LinkedLinearIssueSchema>;
+export type LinearIssue = z.infer<typeof LinearIssueSchema>;
+export type LinearIssueAvailability = z.infer<typeof LinearIssueAvailabilitySchema>;
+export type LinearIssuesResponse = z.infer<typeof LinearIssuesResponseSchema>;
+export type WorktreeCreationState = z.infer<typeof WorktreeCreationStateSchema>;
+export type AppNotification = z.infer<typeof AppNotificationSchema>;
+export type ProjectWorktreeSnapshot = z.infer<typeof ProjectWorktreeSnapshotSchema>;
+export type ProjectSnapshot = z.infer<typeof ProjectSnapshotSchema>;
+export type WorktreeListResponse = z.infer<typeof WorktreeListResponseSchema>;
+export type UnpushedCommit = z.infer<typeof UnpushedCommitSchema>;
+export type WorktreeDiffResponse = z.infer<typeof WorktreeDiffResponseSchema>;
+export type ServiceConfig = z.infer<typeof ServiceConfigSchema>;
+export type ProfileConfig = z.infer<typeof ProfileConfigSchema>;
+export type LinkedRepoInfo = z.infer<typeof LinkedRepoInfoSchema>;
+export type AppConfig = z.infer<typeof AppConfigSchema>;
+export type CiLogsResponse = z.infer<typeof CiLogsResponseSchema>;
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+export type OkResponse = z.infer<typeof OkResponseSchema>;
+export type EnabledResponse = z.infer<typeof EnabledResponseSchema>;

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -38,6 +38,11 @@ export const AvailableBranchesQuerySchema = z.object({
   includeRemote: BooleanLikeSchema.optional(),
 });
 
+const NumberLikePathParamSchema = z.union([
+  z.number().int().nonnegative(),
+  z.string().regex(/^\d+$/).transform((value) => Number(value)),
+]);
+
 export const BranchListResponseSchema = z.object({
   branches: z.array(AvailableBranchSchema),
 });
@@ -273,11 +278,11 @@ export const WorktreeNameParamsSchema = z.object({
 });
 
 export const NotificationIdParamsSchema = z.object({
-  id: z.union([z.number(), z.string()]).transform((value) => String(value)),
+  id: NumberLikePathParamSchema,
 });
 
 export const RunIdParamsSchema = z.object({
-  runId: z.union([z.number(), z.string()]).transform((value) => String(value)),
+  runId: NumberLikePathParamSchema,
 });
 
 export type AgentKind = z.infer<typeof AgentKindSchema>;
@@ -285,6 +290,7 @@ export type CreateWorktreeAgentSelection = z.infer<typeof CreateWorktreeAgentSel
 export type WorktreeCreateMode = z.infer<typeof WorktreeCreateModeSchema>;
 export type WorktreeCreationPhase = z.infer<typeof WorktreeCreationPhaseSchema>;
 export type AvailableBranch = z.infer<typeof AvailableBranchSchema>;
+// Keep this manual so frontend callers pass booleans instead of raw `"true"`/`"false"` query literals.
 export type AvailableBranchesQuery = { includeRemote?: boolean };
 export type BranchListResponse = z.infer<typeof BranchListResponseSchema>;
 export type CreateWorktreeRequest = z.infer<typeof CreateWorktreeRequestSchema>;


### PR DESCRIPTION
## Summary
This PR adds a shared workspace API contract package backed by Zod and ts-rest so the backend, frontend, and CLI can share endpoint definitions, request/response types, and runtime validation from one source of truth.

## Changes
- add `packages/api-contract` with shared Zod schemas, route definitions, and a typed client wrapper
- validate backend JSON and query inputs from the shared schemas and wire Bun routes through shared API path constants
- switch the frontend and CLI to the shared client, leaving only frontend-specific mapping and transport helpers in `frontend/src/lib/api.ts`

## Test plan
- [x] `bun run --cwd backend check`
- [x] `bun run --cwd frontend check`
- [x] `bun run --cwd frontend test`
- [x] `bun test bin/src/worktree-commands.test.ts`
- [x] `bun run --cwd backend test`

---
Generated with [Claude Code](https://claude.com/claude-code)