### PR TITLE
chore: remove unused webmux startup env hooks

### DIFF
--- a/.webmux.yaml
+++ b/.webmux.yaml
@@ -9,13 +9,6 @@ auto_name:
   provider: claude
   model: haiku
 
-startupEnvs:
-  NODE_ENV: development
-
-lifecycleHooks:
-  postCreate: ./scripts/post-create.sh
-  preRemove: ./scripts/pre-remove.sh
-
 services:
   - name: BE
     portEnv: PORT

--- a/scripts/post-create.sh
+++ b/scripts/post-create.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo $NODE_ENV >> /tmp/node-env.txt

--- a/scripts/pre-remove.sh
+++ b/scripts/pre-remove.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo "pre-remove" >> /tmp/pre-remove.txt


### PR DESCRIPTION
## Summary
Remove the active webmux startup `NODE_ENV` setting and drop the lifecycle hook scripts that only wrote debug values into `/tmp`.

## Changes
- remove `startupEnvs.NODE_ENV` from the active `.webmux.yaml`
- remove `lifecycleHooks.postCreate` and `lifecycleHooks.preRemove` from the active `.webmux.yaml`
- delete `scripts/post-create.sh` and `scripts/pre-remove.sh` because they had no relevant runtime behavior

## Test plan
- [x] Run `bun test backend/src/__tests__/setup.test.ts`
- [ ] Manual testing not run; no UI or runtime code paths changed

---
Generated with [Claude Code](https://claude.com/claude-code)