### PR TITLE
perf: lazy-load diff dialog

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -19,6 +19,7 @@
     AppConfig,
     AppNotification,
     CreateWorktreeRequest,
+    DiffDialogProps,
     PrEntry,
     LinearIssueAvailability,
     LinearIssue,
@@ -50,12 +51,6 @@
   import type { ThemeKey } from "./lib/themes";
   import { setToastController } from "./lib/toast-context";
   import { api, fetchWorktrees, subscribeNotifications } from "./lib/api";
-
-  type DiffDialogProps = {
-    branch: string;
-    cursorUrl?: string | null;
-    onclose: () => void;
-  };
 
   function createDefaultConfig(): AppConfig {
     return {
@@ -1275,14 +1270,12 @@
   />
 {/if}
 
-{#if showDiffDialog && selectedBranch}
-  {#if DiffDialogComponent}
-    <DiffDialogComponent
-      branch={selectedBranch}
-      cursorUrl={makeCursorUrl(selectedWorktree?.dir, sshHost)}
-      onclose={() => (showDiffDialog = false)}
-    />
-  {/if}
+{#if showDiffDialog && selectedBranch && DiffDialogComponent}
+  <DiffDialogComponent
+    branch={selectedBranch}
+    cursorUrl={makeCursorUrl(selectedWorktree?.dir, sshHost)}
+    onclose={() => (showDiffDialog = false)}
+  />
 {/if}
 
 {#if detailIssue}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, type Component } from "svelte";
   import WorktreeList from "./lib/WorktreeList.svelte";
   import TopBar from "./lib/TopBar.svelte";
   import Terminal from "./lib/Terminal.svelte";
@@ -8,7 +8,6 @@
   import SettingsDialog from "./lib/SettingsDialog.svelte";
   import CiDetailsDialog from "./lib/CiDetailsDialog.svelte";
   import CommentReviewDialog from "./lib/CommentReviewDialog.svelte";
-  import DiffDialog from "./lib/DiffDialog.svelte";
   import PaneBar from "./lib/PaneBar.svelte";
   import ToastStack from "./lib/ToastStack.svelte";
   import LinearPanel from "./lib/LinearPanel.svelte";
@@ -52,6 +51,12 @@
   import { setToastController } from "./lib/toast-context";
   import { api, fetchWorktrees, subscribeNotifications } from "./lib/api";
 
+  type DiffDialogProps = {
+    branch: string;
+    cursorUrl?: string | null;
+    onclose: () => void;
+  };
+
   function createDefaultConfig(): AppConfig {
     return {
       name: "",
@@ -81,6 +86,7 @@
   let ciDetailsPr = $state<PrEntry | null>(null);
   let commentReviewPr = $state<PrEntry | null>(null);
   let showDiffDialog = $state(false);
+  let DiffDialogComponent = $state<Component<DiffDialogProps> | null>(null);
   let pullMainConfirm = $state(false);
   let pullMainLoading = $state(false);
   let pullMainError = $state("");
@@ -114,6 +120,7 @@
   let availableBranchRequests: Partial<Record<BranchCacheKey, Promise<AvailableBranch[]>>> = {};
   let baseBranchCache: AvailableBranch[] | null = null;
   let baseBranchRequest: Promise<AvailableBranch[]> | null = null;
+  let diffDialogLoad: Promise<void> | null = null;
 
   // Linear integration
   let linearIssues = $state<LinearIssue[]>([]);
@@ -227,6 +234,34 @@
     setTimeout(() => {
       uiToasts = uiToasts.filter((item) => item.id !== id);
     }, AUTO_DISMISS_MS);
+  }
+
+  function ensureDiffDialogLoaded(): Promise<void> {
+    if (DiffDialogComponent) return Promise.resolve();
+    if (diffDialogLoad) return diffDialogLoad;
+
+    diffDialogLoad = import("./lib/DiffDialog.svelte")
+      .then(({ default: component }) => {
+        DiffDialogComponent = component;
+      })
+      .finally(() => {
+        diffDialogLoad = null;
+      });
+
+    return diffDialogLoad;
+  }
+
+  async function openDiffDialog(): Promise<void> {
+    try {
+      await ensureDiffDialogLoaded();
+      showDiffDialog = true;
+    } catch (err: unknown) {
+      showToast({
+        tone: "error",
+        message: "Failed to load changes view.",
+        detail: errorMessage(err),
+      });
+    }
   }
 
   function handleInitialNotification(n: AppNotification): void {
@@ -1068,7 +1103,7 @@
         if (selectedBranch) removeBranch = selectedBranch;
       }}
       onsettings={() => (showSettingsDialog = true)}
-      ondirtyclick={() => (showDiffDialog = true)}
+      ondirtyclick={openDiffDialog}
       onCiClick={(pr) => (ciDetailsPr = pr)}
       onReviewsClick={(pr) => (commentReviewPr = pr)}
       onbellopen={handleBellOpen}
@@ -1241,11 +1276,13 @@
 {/if}
 
 {#if showDiffDialog && selectedBranch}
-  <DiffDialog
-    branch={selectedBranch}
-    cursorUrl={makeCursorUrl(selectedWorktree?.dir, sshHost)}
-    onclose={() => (showDiffDialog = false)}
-  />
+  {#if DiffDialogComponent}
+    <DiffDialogComponent
+      branch={selectedBranch}
+      cursorUrl={makeCursorUrl(selectedWorktree?.dir, sshHost)}
+      onclose={() => (showDiffDialog = false)}
+    />
+  {/if}
 {/if}
 
 {#if detailIssue}

--- a/frontend/src/lib/DiffDialog.svelte
+++ b/frontend/src/lib/DiffDialog.svelte
@@ -2,7 +2,7 @@
   import { html as diff2html } from "diff2html";
   import { ColorSchemeType } from "diff2html/lib/types";
   import "diff2html/bundles/css/diff2html.min.css";
-  import type { UnpushedCommit } from "./types";
+  import type { DiffDialogProps, UnpushedCommit } from "./types";
   import { api } from "./api";
   import { errorMessage } from "./utils";
   import BaseDialog from "./BaseDialog.svelte";
@@ -13,11 +13,7 @@
     branch,
     cursorUrl = null,
     onclose,
-  }: {
-    branch: string;
-    cursorUrl?: string | null;
-    onclose: () => void;
-  } = $props();
+  }: DiffDialogProps = $props();
 
   let uncommitted = $state("");
   let uncommittedTruncated = $state(false);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -46,6 +46,12 @@ export interface FileUploadResult {
   files: Array<{ path: string }>;
 }
 
+export interface DiffDialogProps {
+  branch: string;
+  cursorUrl?: string | null;
+  onclose: () => void;
+}
+
 export interface WorktreeInfo {
   branch: string;
   baseBranch?: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,17 @@ const port = parseInt(process.env.FRONTEND_PORT || "5112");
 
 export default defineConfig({
   plugins: [svelte(), tailwindcss()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules/@xterm/")) {
+            return "vendor-xterm";
+          }
+        },
+      },
+    },
+  },
   server: {
     port,
     proxy: {


### PR DESCRIPTION
## Summary
Lazy-load the diff dialog so `diff2html` is no longer part of the initial frontend bundle, while keeping the heavier `xterm` dependency in its own vendor chunk.

## Changes
- replace the eager `DiffDialog` import in `frontend/src/App.svelte` with an on-demand `import()` that loads the dialog the first time the user opens it
- cache the loaded diff dialog component in app state and show an error toast if the lazy import fails
- keep `@xterm/*` split into a dedicated Rollup chunk in `frontend/vite.config.ts` and remove the no-longer-needed manual chunking for `diff2html`

## Test plan
- [x] `cd frontend && bun run test`
- [x] `cd frontend && bun run build`
- [x] `bun run build`
- [x] Verified the frontend build now emits `DiffDialog` as a separate chunk and keeps the main entry at about 253 kB
- [x] Non-visual change; no screenshots applicable

## Limitations
- this only defers `DiffDialog`; the terminal code path is still eagerly loaded when the main app renders it

---
Generated with [Claude Code](https://claude.com/claude-code)