### PR TITLE
fix: keep dashboard pr sync active

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -461,6 +461,7 @@ async function apiGetProject(): Promise<Response> {
 }
 
 async function apiGetWorktrees(): Promise<Response> {
+  touchDashboardActivity();
   return jsonResponse({
     worktrees: (await readProjectSnapshot()).worktrees,
   });


### PR DESCRIPTION
## Summary
Restore regular dashboard activity tracking for the `/api/worktrees` route so the PR monitor keeps syncing open pull request state while the classic frontend is polling.

## Changes
- add `touchDashboardActivity()` back to `apiGetWorktrees()` in the backend server
- keep the centralized snapshot flow unchanged while restoring the old activity behavior
- ensure regular frontend polling continues to count as active dashboard traffic for PR syncing

## Test plan
- [x] `bun run --cwd backend check`
- [x] `bash scripts/run-with-isolated-tmux.sh bun run --cwd backend test`
- [ ] Open the regular frontend and confirm worktrees continue reflecting open PRs after the dashboard has been open for more than 15 seconds

---
Generated with [Codex](https://openai.com/codex)