### PR TITLE
fix: lock diff viewer to dark colors

### DIFF
--- a/frontend/src/lib/DiffDialog.svelte
+++ b/frontend/src/lib/DiffDialog.svelte
@@ -42,7 +42,7 @@
 
   const diffOpts = {
     outputFormat: "line-by-line" as const,
-    colorScheme: ColorSchemeType.AUTO,
+    colorScheme: ColorSchemeType.DARK,
     drawFileList: false,
   };
 

--- a/frontend/src/lib/DiffDialog.test.ts
+++ b/frontend/src/lib/DiffDialog.test.ts
@@ -58,4 +58,25 @@ describe("DiffDialog", () => {
       "cursor://file/tmp/feature/status",
     );
   });
+
+  it("renders uncommitted diffs with the app's dark color scheme", async () => {
+    vi.mocked(api.fetchWorktreeDiff).mockResolvedValue({
+      uncommitted:
+        "diff --git a/src/example.ts b/src/example.ts\nindex e69de29..4b825dc 100644\n--- a/src/example.ts\n+++ b/src/example.ts\n@@ -0,0 +1 @@\n+const value = 1;\n",
+      uncommittedTruncated: false,
+      gitStatus: "",
+      unpushedCommits: [],
+    });
+
+    const { container } = render(DiffDialog, {
+      props: {
+        branch: "feature/diff-colors",
+        onclose: vi.fn(),
+      },
+    });
+
+    await screen.findByRole("button", { name: "Current diff" });
+
+    expect(container.querySelector(".d2h-wrapper")).toHaveClass("d2h-dark-color-scheme");
+  });
 });


### PR DESCRIPTION
## Summary
Keep the diff viewer on a deterministic dark color scheme so it no longer switches palettes based on each user's `prefers-color-scheme` setting.

## Changes
- change the diff viewer to render `diff2html` with `ColorSchemeType.DARK` instead of `AUTO`
- keep the existing app-level dark theme overrides aligned with the diff renderer output
- add a `DiffDialog` test that asserts rendered diffs use the dark color scheme class

## Test plan
- [x] `cd frontend && bun run test`
- [x] `cd frontend && bun run check`
- [ ] Manual browser verification of the fixed diff dialog

---
Generated with [Claude Code](https://claude.com/claude-code)