### PR TITLE
fix: extend auto-name timeout fallback

### DIFF
--- a/backend/src/services/auto-name-service.ts
+++ b/backend/src/services/auto-name-service.ts
@@ -17,7 +17,7 @@ type SpawnLike = (args: string[], options?: SpawnOptions) => Promise<SpawnResult
 
 const MAX_BRANCH_LENGTH = 40;
 const DEFAULT_AUTO_NAME_MODEL = "claude-haiku-4-5-20251001";
-const AUTO_NAME_TIMEOUT_MS = 10_000;
+const AUTO_NAME_TIMEOUT_MS = 15_000;
 
 const DEFAULT_SYSTEM_PROMPT = [
   "Generate a concise git branch name from the task description.",


### PR DESCRIPTION
## Summary
Increase the auto-name service fallback timeout from 10 seconds to 15 seconds so branch name generation has a longer window before falling back to a random change name.

## Changes
- Update the backend auto-name timeout constant from `10_000` ms to `15_000` ms.
- Keep the existing fallback behavior unchanged when the timeout is reached.

## Test plan
- [x] `bun test backend/src/__tests__/auto-name-service.test.ts`

---
Generated with Codex