### PR TITLE
fix: move api-contract to devDependencies to unbreak global install

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "frontend",
     "packages/*"
   ],
-  "dependencies": {
-    "@webmux/api-contract": "workspace:*"
-  },
+  "dependencies": {},
   "scripts": {
     "dev": "bash dev.sh",
     "start": "bun bin/webmux.js",
@@ -41,6 +39,7 @@
     "frontend/dist/"
   ],
   "devDependencies": {
+    "@webmux/api-contract": "workspace:*",
     "@clack/prompts": "^1.1.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tailwindcss/vite": "^4.2.0",


### PR DESCRIPTION
## Summary
- `bun install -g webmux@latest` is completely broken — fails for all users with `error: Workspace dependency "@webmux/api-contract" not found`
- Root cause: `@webmux/api-contract` is listed as a runtime `dependency` with `workspace:*`, which can't resolve outside the monorepo
- The package is already inlined into `bin/webmux.js` and `backend/dist/server.js` by `bun build`, so it only needs to be a devDependency for local workspace resolution

## Changes
- Move `@webmux/api-contract` from `dependencies` to `devDependencies`

## Test plan
- [x] `bun install` resolves cleanly
- [x] `bun run build` produces working bundles with api-contract inlined
- [x] `bun run test` — all 364 tests pass
- [x] `npm pack` + `bun install -g ./webmux-0.28.1.tgz` installs and runs successfully
- [x] `webmux --version` returns `0.28.1` after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)