### PR TITLE
fix: delay codex terminal prompt submission

### DIFF
--- a/backend/src/__tests__/agent-chat-service.test.ts
+++ b/backend/src/__tests__/agent-chat-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { getAgentDefinition } from "../services/agent-registry";
-import { resolveAgentChatSupport } from "../services/agent-chat-service";
+import { resolveAgentChatSupport, resolveAgentTerminalSubmitDelayMs } from "../services/agent-chat-service";
 import type { ProjectConfig } from "../domain/config";
 
 const TEST_CONFIG: ProjectConfig = {
@@ -98,5 +98,22 @@ describe("resolveAgentChatSupport", () => {
       error: "Unknown agent: missing",
       status: 404,
     });
+  });
+
+  it("uses the same terminal submit delay for built-in Codex prompts", () => {
+    expect(resolveAgentTerminalSubmitDelayMs({
+      agentId: "codex",
+      agent: getAgentDefinition(TEST_CONFIG, "codex"),
+    })).toBe(200);
+
+    expect(resolveAgentTerminalSubmitDelayMs({
+      agentId: "claude",
+      agent: getAgentDefinition(TEST_CONFIG, "claude"),
+    })).toBe(0);
+
+    expect(resolveAgentTerminalSubmitDelayMs({
+      agentId: "gemini",
+      agent: getAgentDefinition(TEST_CONFIG, "gemini"),
+    })).toBe(0);
   });
 });

--- a/backend/src/__tests__/terminal-adapter.test.ts
+++ b/backend/src/__tests__/terminal-adapter.test.ts
@@ -198,7 +198,7 @@ describe("terminal adapter", () => {
     expect(tmuxCalls).toEqual([
       ["tmux", "send-keys", "-t", "owner:wm-feature/search.0", "-l", "--", "Preamble:\n"],
       ["tmux", "load-buffer", "-b", expect.stringMatching(/^wm-prompt-/), "-",],
-      ["tmux", "paste-buffer", "-b", expect.stringMatching(/^wm-prompt-/), "-t", "owner:wm-feature/search.0", "-d"],
+      ["tmux", "paste-buffer", "-rp", "-b", expect.stringMatching(/^wm-prompt-/), "-t", "owner:wm-feature/search.0", "-d"],
       ["tmux", "send-keys", "-t", "owner:wm-feature/search.0", "Enter"],
     ]);
   });

--- a/backend/src/__tests__/terminal-adapter.test.ts
+++ b/backend/src/__tests__/terminal-adapter.test.ts
@@ -189,13 +189,14 @@ describe("terminal adapter", () => {
       },
       "reply with EXACTLY OK",
       0,
-      undefined,
+      "Preamble:\n",
       200,
     );
 
     expect(result).toEqual({ ok: true });
     expect(slept).toEqual([200]);
     expect(tmuxCalls).toEqual([
+      ["tmux", "send-keys", "-t", "owner:wm-feature/search.0", "-l", "--", "Preamble:\n"],
       ["tmux", "load-buffer", "-b", expect.stringMatching(/^wm-prompt-/), "-",],
       ["tmux", "paste-buffer", "-b", expect.stringMatching(/^wm-prompt-/), "-t", "owner:wm-feature/search.0", "-d"],
       ["tmux", "send-keys", "-t", "owner:wm-feature/search.0", "Enter"],

--- a/backend/src/adapters/terminal.ts
+++ b/backend/src/adapters/terminal.ts
@@ -422,7 +422,7 @@ export async function sendPrompt(
     return { ok: false, error: `load-buffer failed${load.stderr ? `: ${load.stderr}` : ""}` };
   }
 
-  const paste = await tmuxExec(["tmux", "paste-buffer", "-b", bufferName, "-t", paneTarget, "-d"]);
+  const paste = await tmuxExec(["tmux", "paste-buffer", "-rp", "-b", bufferName, "-t", paneTarget, "-d"]);
   if (paste.exitCode !== 0) {
     return { ok: false, error: `paste-buffer failed${paste.stderr ? `: ${paste.stderr}` : ""}` };
   }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -49,7 +49,7 @@ import { isRecord, isStringArray } from "./lib/type-guards";
 import { parseJsonBody, parseParams, parseQuery } from "./api-validation";
 import { hasRecentDashboardActivity, touchDashboardActivity } from "./services/dashboard-activity";
 import { buildArchivedWorktreePathSet, normalizeArchivePath } from "./services/archive-service";
-import { resolveAgentChatSupport } from "./services/agent-chat-service";
+import { resolveAgentChatSupport, resolveAgentTerminalSubmitDelayMs } from "./services/agent-chat-service";
 import { validateCustomAgentInput } from "./services/agent-validation-service";
 import { getAgentDefinition, isBuiltInAgentId, listAgentDetails, listAgentSummaries, normalizeCustomAgentId } from "./services/agent-registry";
 import {
@@ -319,6 +319,7 @@ async function withRemovingBranch<T>(branch: string, fn: () => Promise<T>): Prom
 async function resolveTerminalWorktree(branch: string): Promise<{
   worktreeId: string;
   attachTarget: TerminalAttachTarget;
+  agentName: WorktreeSnapshot["agentName"];
 }> {
   ensureBranchNotBusy(branch);
   let state = projectRuntime.getWorktreeByBranch(branch);
@@ -339,6 +340,7 @@ async function resolveTerminalWorktree(branch: string): Promise<{
       ownerSessionName: state.session.sessionName,
       windowName: state.session.windowName,
     },
+    agentName: state.agentName,
   };
 }
 
@@ -507,6 +509,13 @@ function resolveWorktreeAgentChatSupport(worktree: WorktreeSnapshot, action: "ch
     agentLabel: worktree.agentLabel,
     agent: worktree.agentName ? getAgentDefinition(config, worktree.agentName) : null,
     action,
+  });
+}
+
+function resolveWorktreeTerminalSubmitDelayMs(agentName: WorktreeSnapshot["agentName"]): number {
+  return resolveAgentTerminalSubmitDelayMs({
+    agentId: agentName,
+    agent: agentName ? getAgentDefinition(config, agentName) : null,
   });
 }
 
@@ -929,12 +938,14 @@ async function apiSendPrompt(name: string, req: Request): Promise<Response> {
   const preamble = body.preamble;
   log.info(`[worktree:send] name=${name} text="${text.slice(0, 80)}"`);
   const terminalWorktree = await resolveTerminalWorktree(name);
+  const submitDelayMs = resolveWorktreeTerminalSubmitDelayMs(terminalWorktree.agentName);
   const result = await sendTerminalPrompt(
     terminalWorktree.worktreeId,
     terminalWorktree.attachTarget,
     text,
     0,
     preamble,
+    submitDelayMs,
   );
   if (!result.ok) return errorResponse(result.error, 503);
   return jsonResponse({ ok: true });

--- a/backend/src/services/agent-chat-service.ts
+++ b/backend/src/services/agent-chat-service.ts
@@ -5,6 +5,16 @@ export interface AgentChatSupport {
   submitDelayMs: number;
 }
 
+const CODEX_SUBMIT_DELAY_MS = 200;
+
+export function resolveAgentTerminalSubmitDelayMs(input: {
+  agentId: string | null;
+  agent: AgentDefinition | null;
+}): number {
+  if (!input.agentId || !input.agent || input.agent.kind !== "builtin") return 0;
+  return input.agent.implementation.agent === "codex" ? CODEX_SUBMIT_DELAY_MS : 0;
+}
+
 export function resolveAgentChatSupport(input: {
   agentId: string | null;
   agentLabel: string | null;
@@ -51,7 +61,7 @@ export function resolveAgentChatSupport(input: {
       ok: true,
       data: {
         provider: input.agent.implementation.agent,
-        submitDelayMs: input.agent.implementation.agent === "codex" ? 200 : 0,
+        submitDelayMs: resolveAgentTerminalSubmitDelayMs(input),
       },
     };
   }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -365,14 +365,8 @@
   let terminalRef:
     | {
         sendSelectPane: (pane: number) => void;
-        sendInput: (data: string) => void;
       }
     | undefined = $state();
-
-  // Safety buffer after backend confirms paste-buffer completion.
-  // paste-buffer exits once tmux has queued the data, but the PTY write
-  // may not be fully flushed yet — this small delay lets it settle.
-  const ENTER_DELAY_MS = 200;
 
   let openingBranches = $state<Set<string>>(new Set());
   let archivingBranches = $state<Set<string>>(new Set());
@@ -1278,7 +1272,6 @@
     onclose={() => (ciDetailsPr = null)}
     onfixsuccess={() => {
       ciDetailsPr = null;
-      setTimeout(() => terminalRef?.sendInput("\r"), ENTER_DELAY_MS);
     }}
   />
 {/if}
@@ -1290,7 +1283,6 @@
     onclose={() => (commentReviewPr = null)}
     onsendsuccess={() => {
       commentReviewPr = null;
-      setTimeout(() => terminalRef?.sendInput("\r"), ENTER_DELAY_MS);
     }}
   />
 {/if}


### PR DESCRIPTION
## Summary
Apply the existing Codex terminal submit delay to the generic worktree prompt endpoint, and preserve multiline prompt bodies when tmux pastes them into agent TUIs. This covers PR comment prompts and similar terminal-sent prompts.

## Changes
- Extract the built-in Codex 200 ms submit delay into shared agent chat support logic.
- Pass the resolved submit delay through `/api/worktrees/:name/send` for Codex worktrees.
- Paste prompt bodies with `tmux paste-buffer -rp` so LF characters are preserved and bracketed paste is used when supported.
- Remove the frontend's redundant delayed Enter after PR comment and CI prompt sends.
- Add focused coverage for Codex delay resolution and prompt submission flags with preamble text.

## Test plan
- [x] `bun test backend/src/__tests__/agent-chat-service.test.ts backend/src/__tests__/terminal-adapter.test.ts`
- [x] `bun run --cwd backend check`
- [x] `bun run --cwd frontend check`
- [x] `bun run --cwd frontend test -- App.test.ts`
- [x] `bash scripts/run-with-isolated-tmux.sh bun run --cwd backend test`
- [x] Isolated tmux byte capture verified default `paste-buffer` converts LF to CR, while `paste-buffer -rp` preserves LF and emits bracketed paste markers when requested.

## Manual testing
User reproduced the long PR comment send issue before the `-rp` follow-up. Needs one more dashboard retry with the long PR comment after this commit.

## Screenshots
Not applicable.

---
Generated with [Claude Code](https://claude.com/claude-code)