### PR TITLE
feat: add codex agent lifecycle hooks

### DIFF
--- a/backend/src/__tests__/agent-runtime.test.ts
+++ b/backend/src/__tests__/agent-runtime.test.ts
@@ -5,6 +5,19 @@ import { join } from "node:path";
 import { ensureAgentRuntimeArtifacts } from "../adapters/agent-runtime";
 import { ensureWorktreeStorageDirs } from "../adapters/fs";
 
+async function writeControlEnv(agentCtlPath: string, controlUrl: string): Promise<void> {
+  await Bun.write(
+    join(agentCtlPath, "..", "control.env"),
+    [
+      `WEBMUX_CONTROL_URL='${controlUrl}'`,
+      "WEBMUX_CONTROL_TOKEN='test-token'",
+      "WEBMUX_WORKTREE_ID='worktree-1'",
+      "WEBMUX_BRANCH='feature/test'",
+      "",
+    ].join("\n"),
+  );
+}
+
 describe("ensureAgentRuntimeArtifacts", () => {
   const tempDirs: string[] = [];
 
@@ -61,11 +74,12 @@ describe("ensureAgentRuntimeArtifacts", () => {
     expect(codexHooks.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toContain("codex-user-prompt-submit");
     expect(codexHooks.hooks?.PermissionRequest?.[0]?.hooks?.[0]?.command).toContain("codex-permission-request");
     expect(codexHooks.hooks?.PreToolUse?.[0]?.hooks?.[0]?.command).toContain("status-changed --lifecycle running");
+    expect(codexHooks.hooks?.PreToolUse?.[0]?.hooks?.[0]?.command).toContain("--best-effort");
     expect(codexHooks.hooks?.Stop?.[0]?.hooks?.[0]?.command).toContain("codex-stop");
-    expect(codexHooks.hooks?.PostToolUse?.[0]?.hooks?.[0]?.command).toContain("status-changed --lifecycle running");
-    expect(codexHooks.hooks?.PostToolUse?.[1]?.matcher).toBe("Bash");
-    expect(codexHooks.hooks?.PostToolUse?.[1]?.hooks?.[0]?.command).toContain("codex-post-tool-use");
-    expect(codexHooks.hooks?.PostToolUse?.[1]?.hooks?.[0]?.timeout).toBe(30);
+    expect(codexHooks.hooks?.PostToolUse).toHaveLength(1);
+    expect(codexHooks.hooks?.PostToolUse?.[0]?.matcher).toBe("Bash");
+    expect(codexHooks.hooks?.PostToolUse?.[0]?.hooks?.[0]?.command).toContain("codex-post-tool-use");
+    expect(codexHooks.hooks?.PostToolUse?.[0]?.hooks?.[0]?.timeout).toBe(30);
     expect(await Bun.file(join(gitDir, "info", "exclude")).text()).toContain(".codex/hooks.json");
   });
 
@@ -75,6 +89,7 @@ describe("ensureAgentRuntimeArtifacts", () => {
     tempDirs.push(gitDir, worktreePath);
 
     await ensureWorktreeStorageDirs(gitDir);
+    const staleGeneratedCommand = `${join(gitDir, "webmux", "webmux-agentctl")} codex-user-prompt-submit`;
     await mkdir(join(worktreePath, ".codex"), { recursive: true });
     await Bun.write(
       join(worktreePath, ".codex", "hooks.json"),
@@ -93,7 +108,15 @@ describe("ensureAgentRuntimeArtifacts", () => {
               hooks: [
                 {
                   type: "command",
-                  command: "/old/webmux-agentctl codex-user-prompt-submit",
+                  command: "sh -lc 'echo webmux-agentctl wrapper'",
+                },
+              ],
+            },
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: staleGeneratedCommand,
                 },
               ],
             },
@@ -121,7 +144,90 @@ describe("ensureAgentRuntimeArtifacts", () => {
     ) ?? [];
 
     expect(commands.filter((command) => command.includes("keep-me"))).toHaveLength(1);
+    expect(commands.filter((command) => command.includes("webmux-agentctl wrapper"))).toHaveLength(1);
     expect(commands.filter((command) => command.includes("codex-user-prompt-submit"))).toHaveLength(1);
-    expect(commands.some((command) => command.includes("/old/webmux-agentctl"))).toBe(false);
+    expect(commands.some((command) => command === staleGeneratedCommand)).toBe(false);
+  });
+
+  it("lets Codex stop continue naturally when the control endpoint is unreachable", async () => {
+    const gitDir = await mkdtemp(join(tmpdir(), "webmux-agent-runtime-gitdir-"));
+    const worktreePath = await mkdtemp(join(tmpdir(), "webmux-agent-runtime-worktree-"));
+    tempDirs.push(gitDir, worktreePath);
+
+    await ensureWorktreeStorageDirs(gitDir);
+    const artifacts = await ensureAgentRuntimeArtifacts({
+      gitDir,
+      worktreePath,
+    });
+    await writeControlEnv(artifacts.agentCtlPath, "http://127.0.0.1:1/runtime-events");
+
+    const process = Bun.spawn([artifacts.agentCtlPath, "codex-stop"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({});
+  });
+
+  it("detects Codex Bash PR creation payloads", async () => {
+    const gitDir = await mkdtemp(join(tmpdir(), "webmux-agent-runtime-gitdir-"));
+    const worktreePath = await mkdtemp(join(tmpdir(), "webmux-agent-runtime-worktree-"));
+    tempDirs.push(gitDir, worktreePath);
+    let capturedPayload: unknown;
+
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        capturedPayload = await request.json();
+        return Response.json({ ok: true });
+      },
+    });
+
+    try {
+      await ensureWorktreeStorageDirs(gitDir);
+      const artifacts = await ensureAgentRuntimeArtifacts({
+        gitDir,
+        worktreePath,
+      });
+      await writeControlEnv(artifacts.agentCtlPath, `http://127.0.0.1:${server.port}/runtime-events`);
+
+      const process = Bun.spawn([artifacts.agentCtlPath, "codex-post-tool-use"], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      process.stdin.write(JSON.stringify({
+        tool_name: "Bash",
+        tool_input: {
+          command: "gh pr create --fill",
+        },
+        tool_response: {
+          stdout: "Created pull request: https://github.com/windmill-labs/webmux/pull/123",
+        },
+      }));
+      process.stdin.end();
+
+      const [exitCode] = await Promise.all([
+        process.exited,
+        new Response(process.stdout).text(),
+        new Response(process.stderr).text(),
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(capturedPayload).toEqual({
+        type: "pr_opened",
+        worktreeId: "worktree-1",
+        branch: "feature/test",
+        url: "https://github.com/windmill-labs/webmux/pull/123",
+      });
+    } finally {
+      server.stop(true);
+    }
   });
 });

--- a/backend/src/__tests__/agent-runtime.test.ts
+++ b/backend/src/__tests__/agent-runtime.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ensureAgentRuntimeArtifacts } from "../adapters/agent-runtime";
@@ -12,7 +12,7 @@ describe("ensureAgentRuntimeArtifacts", () => {
     await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
-  it("writes agent control helpers and Claude hook settings into worktree-owned paths", async () => {
+  it("writes agent control helpers and agent hook settings into worktree-owned paths", async () => {
     const gitDir = await mkdtemp(join(tmpdir(), "webmux-agent-runtime-gitdir-"));
     const worktreePath = await mkdtemp(join(tmpdir(), "webmux-agent-runtime-worktree-"));
     tempDirs.push(gitDir, worktreePath);
@@ -25,6 +25,7 @@ describe("ensureAgentRuntimeArtifacts", () => {
 
     expect(await Bun.file(artifacts.agentCtlPath).text()).toContain("webmux-agentctl");
     expect(await Bun.file(artifacts.agentCtlPath).text()).toContain("claude-user-prompt-submit");
+    expect(await Bun.file(artifacts.agentCtlPath).text()).toContain("codex-user-prompt-submit");
     expect(await Bun.file(artifacts.agentCtlPath).text()).toContain("agent_status_changed");
 
     const settings = await Bun.file(artifacts.claudeSettingsPath).json() as {
@@ -43,5 +44,84 @@ describe("ensureAgentRuntimeArtifacts", () => {
     expect(settings.hooks?.Stop?.[0]?.hooks?.[0]?.command).toContain("agent-stopped");
     expect(settings.hooks?.PostToolUse?.[0]?.hooks?.[0]?.command).toContain("status-changed --lifecycle running");
     expect(settings.hooks?.PostToolUse?.[1]?.hooks?.[0]?.command).toContain("claude-post-tool-use");
+
+    const codexHooks = await Bun.file(artifacts.codexHooksPath).json() as {
+      hooks?: {
+        SessionStart?: Array<{ matcher?: string; hooks?: Array<{ command?: string; timeout?: number }> }>;
+        UserPromptSubmit?: Array<{ hooks?: Array<{ command?: string; timeout?: number }> }>;
+        PermissionRequest?: Array<{ hooks?: Array<{ command?: string; timeout?: number }> }>;
+        PreToolUse?: Array<{ hooks?: Array<{ command?: string; timeout?: number }> }>;
+        Stop?: Array<{ hooks?: Array<{ command?: string; timeout?: number }> }>;
+        PostToolUse?: Array<{ matcher?: string; hooks?: Array<{ command?: string; timeout?: number }> }>;
+      };
+    };
+
+    expect(codexHooks.hooks?.SessionStart?.[0]?.matcher).toBe("startup|resume|clear");
+    expect(codexHooks.hooks?.SessionStart?.[0]?.hooks?.[0]?.command).toContain("codex-session-start");
+    expect(codexHooks.hooks?.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toContain("codex-user-prompt-submit");
+    expect(codexHooks.hooks?.PermissionRequest?.[0]?.hooks?.[0]?.command).toContain("codex-permission-request");
+    expect(codexHooks.hooks?.PreToolUse?.[0]?.hooks?.[0]?.command).toContain("status-changed --lifecycle running");
+    expect(codexHooks.hooks?.Stop?.[0]?.hooks?.[0]?.command).toContain("codex-stop");
+    expect(codexHooks.hooks?.PostToolUse?.[0]?.hooks?.[0]?.command).toContain("status-changed --lifecycle running");
+    expect(codexHooks.hooks?.PostToolUse?.[1]?.matcher).toBe("Bash");
+    expect(codexHooks.hooks?.PostToolUse?.[1]?.hooks?.[0]?.command).toContain("codex-post-tool-use");
+    expect(codexHooks.hooks?.PostToolUse?.[1]?.hooks?.[0]?.timeout).toBe(30);
+    expect(await Bun.file(join(gitDir, "info", "exclude")).text()).toContain(".codex/hooks.json");
+  });
+
+  it("preserves non-webmux Codex hooks when refreshing generated hooks", async () => {
+    const gitDir = await mkdtemp(join(tmpdir(), "webmux-agent-runtime-gitdir-"));
+    const worktreePath = await mkdtemp(join(tmpdir(), "webmux-agent-runtime-worktree-"));
+    tempDirs.push(gitDir, worktreePath);
+
+    await ensureWorktreeStorageDirs(gitDir);
+    await mkdir(join(worktreePath, ".codex"), { recursive: true });
+    await Bun.write(
+      join(worktreePath, ".codex", "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: "echo keep-me",
+                },
+              ],
+            },
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: "/old/webmux-agentctl codex-user-prompt-submit",
+                },
+              ],
+            },
+          ],
+        },
+      }, null, 2) + "\n",
+    );
+
+    const artifacts = await ensureAgentRuntimeArtifacts({
+      gitDir,
+      worktreePath,
+    });
+    await ensureAgentRuntimeArtifacts({
+      gitDir,
+      worktreePath,
+    });
+
+    const codexHooks = await Bun.file(artifacts.codexHooksPath).json() as {
+      hooks?: {
+        UserPromptSubmit?: Array<{ hooks?: Array<{ command?: string }> }>;
+      };
+    };
+    const commands = codexHooks.hooks?.UserPromptSubmit?.flatMap((group) =>
+      group.hooks?.map((hook) => hook.command ?? "") ?? []
+    ) ?? [];
+
+    expect(commands.filter((command) => command.includes("keep-me"))).toHaveLength(1);
+    expect(commands.filter((command) => command.includes("codex-user-prompt-submit"))).toHaveLength(1);
+    expect(commands.some((command) => command.includes("/old/webmux-agentctl"))).toBe(false);
   });
 });

--- a/backend/src/__tests__/agent-service.test.ts
+++ b/backend/src/__tests__/agent-service.test.ts
@@ -124,7 +124,7 @@ describe("agent-service command builders", () => {
     expect(shell).toContain("docker exec -it -w '/repos/feature' 'wm-feature-container' /bin/sh -c");
     expect(shell).toContain("/bin/zsh");
     expect(shell).toContain('export PATH="$PATH:/root/.local/bin:/usr/local/bin:/root/.bun/bin:/root/.cargo/bin"');
-    expect(agent).toContain("codex --yolo");
+    expect(agent).toContain("codex --enable codex_hooks --yolo");
     expect(agent).toContain("ship the fix");
     expect(agent).toContain('export PATH="$PATH:/root/.local/bin:/usr/local/bin:/root/.bun/bin:/root/.cargo/bin"');
     expect(agent).not.toContain("docker exec");
@@ -168,7 +168,7 @@ describe("agent-service command builders", () => {
       launchMode: "resume",
     });
 
-    expect(command).toContain("codex --yolo resume --last");
+    expect(command).toContain("codex --enable codex_hooks --yolo resume --last");
     expect(command).not.toContain("developer_instructions=");
     expect(command).not.toContain("ship the fix");
     expect(command).not.toContain("stay focused");
@@ -196,6 +196,7 @@ describe("agent-service command builders", () => {
       prompt: "--help",
     });
     expect(codex).toContain("-- '--help'");
+    expect(codex).toContain("codex --enable codex_hooks");
   });
 
   it("omits -- when no prompt is provided", () => {

--- a/backend/src/__tests__/lifecycle-service.test.ts
+++ b/backend/src/__tests__/lifecycle-service.test.ts
@@ -1024,7 +1024,7 @@ describe("LifecycleService", () => {
 
     const agentCommand = tmux.commands.at(-1)?.command;
 
-    expect(agentCommand).toContain("codex --yolo resume --last");
+    expect(agentCommand).toContain("codex --enable codex_hooks --yolo resume --last");
     expect(agentCommand).not.toContain("developer_instructions=");
     expect(agentCommand).not.toContain("Database:");
     expect(agentCommand).not.toContain("ship the fix");

--- a/backend/src/adapters/agent-runtime.ts
+++ b/backend/src/adapters/agent-runtime.ts
@@ -40,6 +40,7 @@ from pathlib import Path
 
 
 CONTROL_ENV_PATH = Path(__file__).resolve().with_name("control.env")
+CONTROL_REQUEST_TIMEOUT_SECONDS = 2
 
 
 def read_control_env():
@@ -69,6 +70,7 @@ def build_parser():
 
     status_changed = subparsers.add_parser("status-changed")
     status_changed.add_argument("--lifecycle", choices=["starting", "running", "idle", "stopped"], required=True)
+    status_changed.add_argument("--best-effort", action="store_true")
 
     pr_opened = subparsers.add_parser("pr-opened")
     pr_opened.add_argument("--url")
@@ -172,7 +174,7 @@ def send_payload(payload, control_env):
     )
 
     try:
-        with urllib.request.urlopen(request, timeout=10) as response:
+        with urllib.request.urlopen(request, timeout=CONTROL_REQUEST_TIMEOUT_SECONDS) as response:
             if response.status < 200 or response.status >= 300:
                 print(f"control endpoint returned HTTP {response.status}", file=sys.stderr)
                 return False
@@ -207,33 +209,39 @@ def main():
         return 1
 
     if parsed.command == "codex-session-start":
-        if not send_payload(build_payload("status-changed", argparse.Namespace(lifecycle="idle"), control_env), control_env):
-            return 1
+        send_payload(build_payload("status-changed", argparse.Namespace(lifecycle="idle"), control_env), control_env)
         return 0
 
-    if parsed.command in ["claude-user-prompt-submit", "codex-user-prompt-submit"]:
+    if parsed.command == "codex-user-prompt-submit":
+        send_payload(build_payload("status-changed", argparse.Namespace(lifecycle="running"), control_env), control_env)
+        return 0
+
+    if parsed.command == "claude-user-prompt-submit":
         if not send_payload(build_payload("status-changed", argparse.Namespace(lifecycle="running"), control_env), control_env):
             return 1
         return 0
 
     if parsed.command == "codex-permission-request":
-        if not send_payload(build_payload("status-changed", argparse.Namespace(lifecycle="idle"), control_env), control_env):
-            return 1
+        send_payload(build_payload("status-changed", argparse.Namespace(lifecycle="idle"), control_env), control_env)
         return 0
 
-    if parsed.command in ["claude-post-tool-use", "codex-post-tool-use"]:
+    if parsed.command == "codex-post-tool-use":
+        hook_payload = read_hook_payload()
+        maybe_send_pr_opened(hook_payload, control_env)
+        return 0
+
+    if parsed.command == "claude-post-tool-use":
         hook_payload = read_hook_payload()
         return 0 if maybe_send_pr_opened(hook_payload, control_env) else 1
 
     if parsed.command == "codex-stop":
-        if not send_payload(build_payload("agent-stopped", parsed, control_env), control_env):
-            return 1
-        print(json.dumps({"continue": True}))
+        send_payload(build_payload("agent-stopped", parsed, control_env), control_env)
+        print(json.dumps({}))
         return 0
 
     payload = build_payload(parsed.command, parsed, control_env)
     if not send_payload(payload, control_env):
-        return 1
+        return 0 if getattr(parsed, "best_effort", False) else 1
 
     return 0
 
@@ -312,7 +320,7 @@ function buildClaudeHookSettings(input: AgentRuntimeArtifacts): HookConfigFile {
 }
 
 function buildCodexHookSettings(input: AgentRuntimeArtifacts): HookConfigFile {
-  const statusCommand = `${shellQuote(input.agentCtlPath)} status-changed --lifecycle running`;
+  const statusCommand = `${shellQuote(input.agentCtlPath)} status-changed --lifecycle running --best-effort`;
   return {
     hooks: {
       SessionStart: [
@@ -361,15 +369,6 @@ function buildCodexHookSettings(input: AgentRuntimeArtifacts): HookConfigFile {
         },
       ],
       PostToolUse: [
-        {
-          hooks: [
-            {
-              type: "command",
-              command: statusCommand,
-              timeout: 30,
-            },
-          ],
-        },
         {
           matcher: "Bash",
           hooks: [
@@ -422,18 +421,28 @@ async function mergeClaudeSettings(
   await Bun.write(settingsPath, JSON.stringify(merged, null, 2) + "\n");
 }
 
-function isWebmuxHookGroup(group: unknown): boolean {
+function commandStartsWithAgentCtl(command: string, agentCtlPath: string): boolean {
+  const trimmedCommand = command.trimStart();
+  const quotedAgentCtlPath = shellQuote(agentCtlPath);
+  return trimmedCommand === agentCtlPath
+    || trimmedCommand.startsWith(`${agentCtlPath} `)
+    || trimmedCommand === quotedAgentCtlPath
+    || trimmedCommand.startsWith(`${quotedAgentCtlPath} `);
+}
+
+function isWebmuxHookGroup(group: unknown, agentCtlPath: string): boolean {
   if (!isRecord(group) || !Array.isArray(group.hooks)) return false;
   return group.hooks.some((hook) =>
     isRecord(hook)
     && typeof hook.command === "string"
-    && hook.command.includes("webmux-agentctl")
+    && commandStartsWithAgentCtl(hook.command, agentCtlPath)
   );
 }
 
 async function mergeCodexHooksFile(
   hooksPath: string,
   hookSettings: HookConfigFile["hooks"],
+  agentCtlPath: string,
 ): Promise<void> {
   let existing: Record<string, unknown> = {};
 
@@ -454,7 +463,7 @@ async function mergeCodexHooksFile(
   for (const [eventName, groups] of Object.entries(hookSettings)) {
     const eventGroups = existingHooks[eventName];
     const preservedGroups = Array.isArray(eventGroups)
-      ? eventGroups.filter((group) => !isWebmuxHookGroup(group))
+      ? eventGroups.filter((group) => !isWebmuxHookGroup(group, agentCtlPath))
       : [];
     mergedHooks[eventName] = [...preservedGroups, ...groups];
   }
@@ -515,7 +524,7 @@ export async function ensureAgentRuntimeArtifacts(input: {
   }
   await mergeClaudeSettings(artifacts.claudeSettingsPath, hooks);
   await ensureGeneratedCodexHooksIgnored(input.gitDir);
-  await mergeCodexHooksFile(artifacts.codexHooksPath, buildCodexHookSettings(artifacts).hooks);
+  await mergeCodexHooksFile(artifacts.codexHooksPath, buildCodexHookSettings(artifacts).hooks, artifacts.agentCtlPath);
 
   return artifacts;
 }

--- a/backend/src/adapters/agent-runtime.ts
+++ b/backend/src/adapters/agent-runtime.ts
@@ -1,6 +1,24 @@
 import { chmod, mkdir } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { getWorktreeStoragePaths } from "./fs";
+
+const GENERATED_CODEX_HOOKS_EXCLUDE = ".codex/hooks.json";
+
+interface CommandHookConfig {
+  type: "command";
+  command: string;
+  async?: boolean;
+  timeout?: number;
+}
+
+interface HookMatcherConfig {
+  matcher?: string;
+  hooks: CommandHookConfig[];
+}
+
+interface HookConfigFile {
+  hooks: Record<string, HookMatcherConfig[]>;
+}
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
@@ -60,6 +78,11 @@ def build_parser():
 
     subparsers.add_parser("claude-user-prompt-submit")
     subparsers.add_parser("claude-post-tool-use")
+    subparsers.add_parser("codex-session-start")
+    subparsers.add_parser("codex-user-prompt-submit")
+    subparsers.add_parser("codex-permission-request")
+    subparsers.add_parser("codex-post-tool-use")
+    subparsers.add_parser("codex-stop")
 
     return parser
 
@@ -100,6 +123,41 @@ def read_hook_payload():
         return {}
 
     return parsed if isinstance(parsed, dict) else {}
+
+
+def iter_string_values(value):
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from iter_string_values(child)
+        return
+    if isinstance(value, list):
+        for child in value:
+            yield from iter_string_values(child)
+
+
+def find_pr_url(value):
+    for text in iter_string_values(value):
+        match = re.search(r"https://github\\.com/[^\\s\\\"]+/pull/\\d+", text)
+        if match:
+            return match.group(0)
+    return None
+
+
+def maybe_send_pr_opened(hook_payload, control_env):
+    tool_name = hook_payload.get("tool_name")
+    tool_input = hook_payload.get("tool_input")
+    if not isinstance(tool_input, dict) or tool_name != "Bash":
+        return True
+
+    command = tool_input.get("command")
+    if not isinstance(command, str) or "gh pr create" not in command:
+        return True
+
+    pr_args = argparse.Namespace(url=find_pr_url(hook_payload.get("tool_response")))
+    return send_payload(build_payload("pr-opened", pr_args, control_env), control_env)
 
 
 def send_payload(payload, control_env):
@@ -148,30 +206,30 @@ def main():
         print(f"missing control env keys: {', '.join(missing)}", file=sys.stderr)
         return 1
 
-    if parsed.command == "claude-user-prompt-submit":
+    if parsed.command == "codex-session-start":
+        if not send_payload(build_payload("status-changed", argparse.Namespace(lifecycle="idle"), control_env), control_env):
+            return 1
+        return 0
+
+    if parsed.command in ["claude-user-prompt-submit", "codex-user-prompt-submit"]:
         if not send_payload(build_payload("status-changed", argparse.Namespace(lifecycle="running"), control_env), control_env):
             return 1
         return 0
 
-    if parsed.command == "claude-post-tool-use":
+    if parsed.command == "codex-permission-request":
+        if not send_payload(build_payload("status-changed", argparse.Namespace(lifecycle="idle"), control_env), control_env):
+            return 1
+        return 0
+
+    if parsed.command in ["claude-post-tool-use", "codex-post-tool-use"]:
         hook_payload = read_hook_payload()
-        tool_name = hook_payload.get("tool_name")
-        tool_input = hook_payload.get("tool_input")
-        if not isinstance(tool_input, dict) or tool_name != "Bash":
-            return 0
+        return 0 if maybe_send_pr_opened(hook_payload, control_env) else 1
 
-        command = tool_input.get("command")
-        if not isinstance(command, str) or "gh pr create" not in command:
-            return 0
-
-        pr_args = argparse.Namespace(url=None)
-        tool_response = hook_payload.get("tool_response")
-        if isinstance(tool_response, str):
-            match = re.search(r"https://github\\.com/[^\\s\\\"]+/pull/\\d+", tool_response)
-            if match:
-                pr_args.url = match.group(0)
-
-        return 0 if send_payload(build_payload("pr-opened", pr_args, control_env), control_env) else 1
+    if parsed.command == "codex-stop":
+        if not send_payload(build_payload("agent-stopped", parsed, control_env), control_env):
+            return 1
+        print(json.dumps({"continue": True}))
+        return 0
 
     payload = build_payload(parsed.command, parsed, control_env)
     if not send_payload(payload, control_env):
@@ -188,9 +246,10 @@ if __name__ == "__main__":
 export interface AgentRuntimeArtifacts {
   agentCtlPath: string;
   claudeSettingsPath: string;
+  codexHooksPath: string;
 }
 
-function buildClaudeHookSettings(input: AgentRuntimeArtifacts): Record<string, unknown> {
+function buildClaudeHookSettings(input: AgentRuntimeArtifacts): HookConfigFile {
   return {
     hooks: {
       UserPromptSubmit: [
@@ -252,9 +311,94 @@ function buildClaudeHookSettings(input: AgentRuntimeArtifacts): Record<string, u
   };
 }
 
+function buildCodexHookSettings(input: AgentRuntimeArtifacts): HookConfigFile {
+  const statusCommand = `${shellQuote(input.agentCtlPath)} status-changed --lifecycle running`;
+  return {
+    hooks: {
+      SessionStart: [
+        {
+          matcher: "startup|resume|clear",
+          hooks: [
+            {
+              type: "command",
+              command: `${shellQuote(input.agentCtlPath)} codex-session-start`,
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+      UserPromptSubmit: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `${shellQuote(input.agentCtlPath)} codex-user-prompt-submit`,
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+      PermissionRequest: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `${shellQuote(input.agentCtlPath)} codex-permission-request`,
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+      PreToolUse: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: statusCommand,
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+      PostToolUse: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: statusCommand,
+              timeout: 30,
+            },
+          ],
+        },
+        {
+          matcher: "Bash",
+          hooks: [
+            {
+              type: "command",
+              command: `${shellQuote(input.agentCtlPath)} codex-post-tool-use`,
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+      Stop: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `${shellQuote(input.agentCtlPath)} codex-stop`,
+              timeout: 30,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
 async function mergeClaudeSettings(
   settingsPath: string,
-  hookSettings: Record<string, unknown>,
+  hookSettings: HookConfigFile["hooks"],
 ): Promise<void> {
   let existing: Record<string, unknown> = {};
 
@@ -278,6 +422,75 @@ async function mergeClaudeSettings(
   await Bun.write(settingsPath, JSON.stringify(merged, null, 2) + "\n");
 }
 
+function isWebmuxHookGroup(group: unknown): boolean {
+  if (!isRecord(group) || !Array.isArray(group.hooks)) return false;
+  return group.hooks.some((hook) =>
+    isRecord(hook)
+    && typeof hook.command === "string"
+    && hook.command.includes("webmux-agentctl")
+  );
+}
+
+async function mergeCodexHooksFile(
+  hooksPath: string,
+  hookSettings: HookConfigFile["hooks"],
+): Promise<void> {
+  let existing: Record<string, unknown> = {};
+
+  try {
+    const file = Bun.file(hooksPath);
+    if (await file.exists()) {
+      const parsed = await file.json();
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        existing = parsed as Record<string, unknown>;
+      }
+    }
+  } catch {
+    existing = {};
+  }
+
+  const existingHooks = isRecord(existing.hooks) ? existing.hooks : {};
+  const mergedHooks: Record<string, unknown> = { ...existingHooks };
+  for (const [eventName, groups] of Object.entries(hookSettings)) {
+    const eventGroups = existingHooks[eventName];
+    const preservedGroups = Array.isArray(eventGroups)
+      ? eventGroups.filter((group) => !isWebmuxHookGroup(group))
+      : [];
+    mergedHooks[eventName] = [...preservedGroups, ...groups];
+  }
+
+  await Bun.write(hooksPath, JSON.stringify({ ...existing, hooks: mergedHooks }, null, 2) + "\n");
+}
+
+async function resolveGitCommonDir(gitDir: string): Promise<string> {
+  try {
+    const commonDir = (await Bun.file(join(gitDir, "commondir")).text()).trim();
+    if (!commonDir) return gitDir;
+    return commonDir.startsWith("/") ? commonDir : resolve(gitDir, commonDir);
+  } catch {
+    return gitDir;
+  }
+}
+
+async function ensureGeneratedCodexHooksIgnored(gitDir: string): Promise<void> {
+  const commonDir = await resolveGitCommonDir(gitDir);
+  const excludePath = join(commonDir, "info", "exclude");
+  let existing = "";
+
+  try {
+    existing = await Bun.file(excludePath).text();
+  } catch {
+    existing = "";
+  }
+
+  const lines = existing.split(/\r?\n/).map((line) => line.trim());
+  if (lines.includes(GENERATED_CODEX_HOOKS_EXCLUDE)) return;
+
+  await mkdir(dirname(excludePath), { recursive: true });
+  const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  await Bun.write(excludePath, `${existing}${separator}${GENERATED_CODEX_HOOKS_EXCLUDE}\n`);
+}
+
 export async function ensureAgentRuntimeArtifacts(input: {
   gitDir: string;
   worktreePath: string;
@@ -286,9 +499,11 @@ export async function ensureAgentRuntimeArtifacts(input: {
   const artifacts: AgentRuntimeArtifacts = {
     agentCtlPath: join(storagePaths.webmuxDir, "webmux-agentctl"),
     claudeSettingsPath: join(input.worktreePath, ".claude", "settings.local.json"),
+    codexHooksPath: join(input.worktreePath, ".codex", "hooks.json"),
   };
 
   await mkdir(dirname(artifacts.claudeSettingsPath), { recursive: true });
+  await mkdir(dirname(artifacts.codexHooksPath), { recursive: true });
 
   await Bun.write(artifacts.agentCtlPath, buildAgentCtlScript());
   await chmod(artifacts.agentCtlPath, 0o755);
@@ -299,6 +514,8 @@ export async function ensureAgentRuntimeArtifacts(input: {
     throw new Error("Invalid Claude hook settings");
   }
   await mergeClaudeSettings(artifacts.claudeSettingsPath, hooks);
+  await ensureGeneratedCodexHooksIgnored(input.gitDir);
+  await mergeCodexHooksFile(artifacts.codexHooksPath, buildCodexHookSettings(artifacts).hooks);
 
   return artifacts;
 }

--- a/backend/src/services/agent-service.ts
+++ b/backend/src/services/agent-service.ts
@@ -33,15 +33,16 @@ function buildBuiltInAgentInvocation(input: {
   launchMode?: AgentLaunchMode;
 }): string {
   if (input.agent === "codex") {
+    const hooksFlag = " --enable codex_hooks";
     const yoloFlag = input.yolo ? " --yolo" : "";
     if (input.launchMode === "resume") {
-      return `codex${yoloFlag} resume --last`;
+      return `codex${hooksFlag}${yoloFlag} resume --last`;
     }
     const promptSuffix = input.prompt ? ` -- ${quoteShell(input.prompt)}` : "";
     if (input.systemPrompt) {
-      return `codex${yoloFlag} -c ${quoteShell(`developer_instructions=${input.systemPrompt}`)}${promptSuffix}`;
+      return `codex${hooksFlag}${yoloFlag} -c ${quoteShell(`developer_instructions=${input.systemPrompt}`)}${promptSuffix}`;
     }
-    return `codex${yoloFlag}${promptSuffix}`;
+    return `codex${hooksFlag}${yoloFlag}${promptSuffix}`;
   }
 
   const yoloFlag = input.yolo ? " --dangerously-skip-permissions" : "";


### PR DESCRIPTION
## Summary
Adds worktree-local Codex hooks so webmux can track Codex agent lifecycle status through the same runtime event path used by Claude.

## Changes
- Generate `.codex/hooks.json` for managed worktrees with Codex lifecycle hooks for session start, prompt submit, permission request, tool use, stop, and PR creation detection.
- Launch Codex panes with `--enable codex_hooks` so generated local hooks can run when the worktree is trusted.
- Preserve non-webmux Codex hook groups while replacing stale webmux-generated groups, and add `.codex/hooks.json` to local git excludes to avoid dirtying worktrees.
- Extend backend tests for generated Codex hooks, command construction, and lifecycle resume behavior.

## Test plan
- [x] `bun test backend/src/__tests__/agent-runtime.test.ts backend/src/__tests__/agent-service.test.ts`
- [x] `bun run --cwd backend check`
- [x] `bun run --cwd backend test`
- [x] Manual: reopened an existing Codex worktree and verified the status hooks work

## Notes
- Codex still requires the user to trust the worktree/project before project-local `.codex/hooks.json` is loaded.
- No UI screenshots: no frontend UI changes.

---
Generated with [Claude Code](https://claude.com/claude-code)