### PR TITLE
feat: add workspace labels

### DIFF
--- a/backend/src/__tests__/agents-ui-service.test.ts
+++ b/backend/src/__tests__/agents-ui-service.test.ts
@@ -5,6 +5,7 @@ describe("buildAgentsUiWorktreeSummary", () => {
   it("maps worktree snapshots into conversation-aware summary data", () => {
     const summary = buildAgentsUiWorktreeSummary({
       branch: "feature/search",
+      label: "Search ranking",
       baseBranch: "main",
       path: "/repo/__worktrees/feature-search",
       dir: "/repo/__worktrees/feature-search",
@@ -87,6 +88,7 @@ describe("buildAgentsUiWorktreeSummary", () => {
   it("defaults missing conversation metadata to null", () => {
     const summary = buildAgentsUiWorktreeSummary({
       branch: "feature/idle",
+      label: null,
       path: "/repo/__worktrees/feature-idle",
       dir: "/repo/__worktrees/feature-idle",
       archived: false,

--- a/backend/src/__tests__/claude-conversation-service.test.ts
+++ b/backend/src/__tests__/claude-conversation-service.test.ts
@@ -46,6 +46,7 @@ function makeMeta(): WorktreeMeta {
 function makeWorktree(): WorktreeSnapshot {
   return {
     branch: "claude-feature",
+    label: null,
     path: "/tmp/worktrees/claude-feature",
     dir: "claude-feature",
     archived: false,

--- a/backend/src/__tests__/lifecycle-service.test.ts
+++ b/backend/src/__tests__/lifecycle-service.test.ts
@@ -1063,6 +1063,29 @@ describe("LifecycleService", () => {
     expect(archiveState.entries[0]?.path).toBe(join(repoRoot, "__worktrees", "feature-archive"));
   });
 
+  it("updates and clears a worktree label in metadata and runtime state", async () => {
+    const repoRoot = await initRepo();
+    const runtime = new ProjectRuntime();
+    const tmux = new FakeTmuxGateway();
+    const lifecycle = makeLifecycleService(repoRoot, tmux, runtime);
+
+    await lifecycle.createWorktree({ branch: "feature-label" });
+    const labeled = await lifecycle.setWorktreeLabel("feature-label", "  Search ranking  ");
+
+    const worktreePath = join(repoRoot, "__worktrees", "feature-label");
+    const gitDir = new BunGitGateway().resolveWorktreeGitDir(worktreePath);
+
+    expect(labeled).toEqual({ label: "Search ranking" });
+    expect((await readWorktreeMeta(gitDir))?.label).toBe("Search ranking");
+    expect(runtime.getWorktreeByBranch("feature-label")?.label).toBe("Search ranking");
+
+    const cleared = await lifecycle.setWorktreeLabel("feature-label", "");
+
+    expect(cleared).toEqual({ label: null });
+    expect((await readWorktreeMeta(gitDir))?.label).toBeUndefined();
+    expect(runtime.getWorktreeByBranch("feature-label")?.label).toBeNull();
+  });
+
   it("creates a managed docker worktree through the container runtime path", async () => {
     const repoRoot = await initRepo();
     const runtime = new ProjectRuntime();

--- a/backend/src/__tests__/lifecycle-service.test.ts
+++ b/backend/src/__tests__/lifecycle-service.test.ts
@@ -1069,21 +1069,58 @@ describe("LifecycleService", () => {
     const tmux = new FakeTmuxGateway();
     const lifecycle = makeLifecycleService(repoRoot, tmux, runtime);
 
-    await lifecycle.createWorktree({ branch: "feature-label" });
-    const labeled = await lifecycle.setWorktreeLabel("feature-label", "  Search ranking  ");
-
     const worktreePath = join(repoRoot, "__worktrees", "feature-label");
+    await lifecycle.createWorktree({ branch: "feature-label" });
     const gitDir = new BunGitGateway().resolveWorktreeGitDir(worktreePath);
+    const paths = getWorktreeStoragePaths(gitDir);
+    await Bun.write(paths.runtimeEnvPath, "runtime-marker\n");
+    await Bun.write(paths.controlEnvPath, "control-marker\n");
+    const allocatedPorts = { ...(await readWorktreeMeta(gitDir))?.allocatedPorts };
+    const labeled = await lifecycle.setWorktreeLabel("feature-label", "  Search ranking  ");
 
     expect(labeled).toEqual({ label: "Search ranking" });
     expect((await readWorktreeMeta(gitDir))?.label).toBe("Search ranking");
     expect(runtime.getWorktreeByBranch("feature-label")?.label).toBe("Search ranking");
+    expect(await Bun.file(paths.runtimeEnvPath).text()).toBe("runtime-marker\n");
+    expect(await Bun.file(paths.controlEnvPath).text()).toBe("control-marker\n");
+    expect((await readWorktreeMeta(gitDir))?.allocatedPorts).toEqual(allocatedPorts);
 
     const cleared = await lifecycle.setWorktreeLabel("feature-label", "");
 
     expect(cleared).toEqual({ label: null });
     expect((await readWorktreeMeta(gitDir))?.label).toBeUndefined();
     expect(runtime.getWorktreeByBranch("feature-label")?.label).toBeNull();
+    expect(await Bun.file(paths.runtimeEnvPath).text()).toBe("runtime-marker\n");
+    expect(await Bun.file(paths.controlEnvPath).text()).toBe("control-marker\n");
+    expect((await readWorktreeMeta(gitDir))?.allocatedPorts).toEqual(allocatedPorts);
+  });
+
+  it("rejects labeling unmanaged worktrees without creating metadata", async () => {
+    const repoRoot = await initRepo();
+    const runtime = new ProjectRuntime();
+    const tmux = new FakeTmuxGateway();
+    const lifecycle = makeLifecycleService(repoRoot, tmux, runtime);
+    const git = new BunGitGateway();
+    const worktreePath = join(repoRoot, "__worktrees", "feature-unmanaged-label");
+
+    git.createWorktree({
+      repoRoot,
+      worktreePath,
+      branch: "feature-unmanaged-label",
+      mode: "new",
+      baseBranch: "main",
+    });
+    const gitDir = git.resolveWorktreeGitDir(worktreePath);
+    const paths = getWorktreeStoragePaths(gitDir);
+
+    await expect(lifecycle.setWorktreeLabel("feature-unmanaged-label", "Search ranking"))
+      .rejects.toMatchObject({
+        status: 409,
+        message: "Worktree feature-unmanaged-label has no managed metadata to label",
+      });
+    expect(await Bun.file(paths.metaPath).exists()).toBe(false);
+    expect(await Bun.file(paths.runtimeEnvPath).exists()).toBe(false);
+    expect(await Bun.file(paths.controlEnvPath).exists()).toBe(false);
   });
 
   it("creates a managed docker worktree through the container runtime path", async () => {

--- a/backend/src/__tests__/native-terminal-service.test.ts
+++ b/backend/src/__tests__/native-terminal-service.test.ts
@@ -6,6 +6,7 @@ function makeState(overrides: Partial<ManagedWorktreeRuntimeState> = {}): Manage
   return {
     worktreeId: "wt_feature_search",
     branch: "feature/search",
+    label: null,
     baseBranch: null,
     path: "/repo/__worktrees/feature-search",
     profile: "default",

--- a/backend/src/__tests__/project-runtime.test.ts
+++ b/backend/src/__tests__/project-runtime.test.ts
@@ -16,6 +16,7 @@ describe("ProjectRuntime", () => {
 
     expect(state.worktreeId).toBe("wt_search");
     expect(state.branch).toBe("feature/search");
+    expect(state.label).toBeNull();
     expect(state.baseBranch).toBe("main");
     expect(state.profile).toBe("default");
     expect(state.agentName).toBe("claude");
@@ -108,5 +109,27 @@ describe("ProjectRuntime", () => {
 
     expect(runtime.getWorktreeByBranch("feature/search")).toBeNull();
     expect(runtime.getWorktreeByBranch("feature/search-v2")?.worktreeId).toBe("wt_search");
+  });
+
+  it("updates label metadata without changing branch lookups", () => {
+    const runtime = new ProjectRuntime();
+    runtime.upsertWorktree({
+      worktreeId: "wt_search",
+      branch: "feature/search",
+      label: "Search UI",
+      path: "/repo/__worktrees/feature-search",
+      runtime: "host",
+    });
+
+    const state = runtime.upsertWorktree({
+      worktreeId: "wt_search",
+      branch: "feature/search",
+      label: "Search ranking",
+      path: "/repo/__worktrees/feature-search",
+      runtime: "host",
+    });
+
+    expect(state.label).toBe("Search ranking");
+    expect(runtime.getWorktreeByBranch("feature/search")?.label).toBe("Search ranking");
   });
 });

--- a/backend/src/__tests__/snapshot-service.test.ts
+++ b/backend/src/__tests__/snapshot-service.test.ts
@@ -9,6 +9,7 @@ describe("buildProjectSnapshot", () => {
     runtime.upsertWorktree({
       worktreeId: "wt_search",
       branch: "feature/search",
+      label: "Search ranking",
       baseBranch: "main",
       path: "/repo/__worktrees/feature-search",
       profile: "default",
@@ -100,6 +101,7 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.worktrees).toEqual([
       {
         branch: "feature/search",
+        label: "Search ranking",
         baseBranch: "main",
         path: "/repo/__worktrees/feature-search",
         dir: "/repo/__worktrees/feature-search",
@@ -219,6 +221,7 @@ describe("buildProjectSnapshot", () => {
     expect(snapshot.worktrees).toEqual([
       {
         branch: "feature/new-flow",
+        label: null,
         baseBranch: "main",
         path: "/repo/__worktrees/feature/new-flow",
         dir: "/repo/__worktrees/feature/new-flow",

--- a/backend/src/__tests__/worktree-conversation-service.test.ts
+++ b/backend/src/__tests__/worktree-conversation-service.test.ts
@@ -162,6 +162,7 @@ function makeCodexConversationMeta(threadId: string, cwd: string, lastSeenAt = "
 function makeWorktree(): WorktreeSnapshot {
   return {
     branch: "codex-feature",
+    label: null,
     path: "/tmp/worktrees/codex-feature",
     dir: "codex-feature",
     archived: false,

--- a/backend/src/__tests__/worktree-storage.test.ts
+++ b/backend/src/__tests__/worktree-storage.test.ts
@@ -13,6 +13,7 @@ import {
   readWorktreeMeta,
   renderEnvFile,
   writeWorktreePrs,
+  writeWorktreeMeta,
 } from "../adapters/fs";
 import type { WorktreeMeta } from "../domain/model";
 import { createManagedWorktree, initializeManagedWorktree } from "../services/worktree-service";
@@ -396,6 +397,17 @@ describe("initializeManagedWorktree", () => {
         lastSeenAt: "2026-04-14T10:00:00.000Z",
       },
     });
+  });
+
+  it("normalizes blank labels out of worktree metadata", async () => {
+    gitDir = await mkdtemp(join(tmpdir(), "webmux-meta-label-"));
+
+    await writeWorktreeMeta(gitDir, {
+      ...makeMeta(),
+      label: "   ",
+    });
+
+    expect((await readWorktreeMeta(gitDir))?.label).toBeUndefined();
   });
 
   it("round-trips PR storage through the worktree webmux dir", async () => {

--- a/backend/src/adapters/fs.ts
+++ b/backend/src/adapters/fs.ts
@@ -223,9 +223,15 @@ function normalizeOptionalString(raw: unknown): string | undefined {
 }
 
 function normalizeWorktreeMeta(meta: WorktreeMeta): WorktreeMeta {
-  const { label, conversation: rawConversation, ...rest } = meta;
-  const conversation = normalizeConversationMeta(rawConversation);
-  const normalizedLabel = normalizeOptionalString(label);
+  const conversation = normalizeConversationMeta(meta.conversation);
+  const normalizedLabel = normalizeOptionalString(meta.label);
+  if (conversation === meta.conversation && normalizedLabel === meta.label) {
+    return meta;
+  }
+
+  const rest: WorktreeMeta = { ...meta };
+  delete rest.label;
+  delete rest.conversation;
   return {
     ...rest,
     ...(normalizedLabel ? { label: normalizedLabel } : {}),

--- a/backend/src/adapters/fs.ts
+++ b/backend/src/adapters/fs.ts
@@ -218,14 +218,19 @@ function normalizeConversationMeta(raw: WorktreeConversationMeta | null | undefi
   return normalized;
 }
 
+function normalizeOptionalString(raw: unknown): string | undefined {
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}
+
 function normalizeWorktreeMeta(meta: WorktreeMeta): WorktreeMeta {
-  const conversation = normalizeConversationMeta(meta.conversation);
-  return conversation === meta.conversation
-    ? meta
-    : {
-        ...meta,
-        conversation,
-      };
+  const { label, conversation: rawConversation, ...rest } = meta;
+  const conversation = normalizeConversationMeta(rawConversation);
+  const normalizedLabel = normalizeOptionalString(label);
+  return {
+    ...rest,
+    ...(normalizedLabel ? { label: normalizedLabel } : {}),
+    ...(conversation !== undefined ? { conversation } : {}),
+  };
 }
 
 function isPrComment(raw: unknown): raw is PrComment {

--- a/backend/src/domain/model.ts
+++ b/backend/src/domain/model.ts
@@ -30,6 +30,7 @@ export interface WorktreeMeta {
   schemaVersion: number;
   worktreeId: string;
   branch: string;
+  label?: string;
   baseBranch?: string;
   createdAt: string;
   profile: string;
@@ -162,6 +163,7 @@ export interface WorktreeCreationSnapshot {
 export interface ManagedWorktreeRuntimeState {
   worktreeId: string;
   branch: string;
+  label: string | null;
   baseBranch: string | null;
   path: string;
   profile: string | null;
@@ -184,6 +186,7 @@ export interface NotificationView {
 
 export interface WorktreeSnapshot {
   branch: string;
+  label: string | null;
   baseBranch?: string;
   path: string;
   dir: string;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -13,6 +13,7 @@ import {
   RunIdParamsSchema,
   SendWorktreePromptRequestSchema,
   SetWorktreeArchivedRequestSchema,
+  SetWorktreeLabelRequestSchema,
   ToggleEnabledRequestSchema,
   UpsertCustomAgentRequestSchema,
   WorktreeNameParamsSchema,
@@ -929,6 +930,18 @@ async function apiSetWorktreeArchived(name: string, req: Request): Promise<Respo
   return jsonResponse({ ok: true, archived: body.archived });
 }
 
+async function apiSetWorktreeLabel(name: string, req: Request): Promise<Response> {
+  ensureBranchNotBusy(name);
+  const parsed = await parseJsonBody(req, SetWorktreeLabelRequestSchema);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.data;
+
+  log.info(`[worktree:label] name=${name} label=${body.label ? JSON.stringify(body.label) : "null"}`);
+  const result = await lifecycleService.setWorktreeLabel(name, body.label);
+  log.debug(`[worktree:label] done name=${name} label=${result.label ? JSON.stringify(result.label) : "null"}`);
+  return jsonResponse({ ok: true, label: result.label });
+}
+
 async function apiSendPrompt(name: string, req: Request): Promise<Response> {
   ensureBranchNotBusy(name);
   const parsed = await parseJsonBody(req, SendWorktreePromptRequestSchema);
@@ -1411,6 +1424,15 @@ Bun.serve({
         if (!parsed.ok) return parsed.response;
         const name = parsed.data;
         return catching(`PUT /api/worktrees/${name}/archive`, () => apiSetWorktreeArchived(name, req));
+      },
+    },
+
+    [apiPaths.setWorktreeLabel]: {
+      PUT: (req) => {
+        const parsed = parseWorktreeNameParam(req.params);
+        if (!parsed.ok) return parsed.response;
+        const name = parsed.data;
+        return catching(`PUT /api/worktrees/${name}/label`, () => apiSetWorktreeLabel(name, req));
       },
     },
 

--- a/backend/src/services/lifecycle-service.ts
+++ b/backend/src/services/lifecycle-service.ts
@@ -359,10 +359,10 @@ export class LifecycleService {
     try {
       const normalizedLabel = normalizeWorktreeLabel(label);
       const resolved = await this.resolveExistingWorktree(branch);
-      const initialized = resolved.meta
-        ? await this.refreshManagedArtifacts(resolved)
-        : await this.initializeUnmanagedWorktree(resolved);
-      const nextMeta = this.withUpdatedLabel(initialized.meta, normalizedLabel);
+      if (!resolved.meta) {
+        throw new LifecycleError(`Worktree ${branch} has no managed metadata to label`, 409);
+      }
+      const nextMeta = this.withUpdatedLabel(resolved.meta, normalizedLabel);
       await writeWorktreeMeta(resolved.gitDir, nextMeta);
       await this.deps.reconciliation.reconcile(this.deps.projectRoot, { force: true });
       return { label: normalizedLabel };

--- a/backend/src/services/lifecycle-service.ts
+++ b/backend/src/services/lifecycle-service.ts
@@ -9,6 +9,7 @@ import {
   getWorktreeStoragePaths,
   loadDotenvLocal,
   readWorktreeMeta,
+  writeWorktreeMeta,
   writeControlEnv,
   writeRuntimeEnv,
 } from "../adapters/fs";
@@ -41,6 +42,7 @@ import { log } from "../lib/log";
 import { generateFallbackBranchName } from "../lib/branch-name";
 
 const DOCKER_CONTROL_HOST = "host.docker.internal";
+const MAX_WORKTREE_LABEL_LENGTH = 80;
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -52,6 +54,15 @@ function stringifyStartupEnvValue(value: string | boolean): string {
 
 function trimTrailingSlashes(value: string): string {
   return value.replace(/\/+$/, "");
+}
+
+function normalizeWorktreeLabel(label: string | null): string | null {
+  const trimmed = label?.trim() ?? "";
+  if (!trimmed) return null;
+  if (trimmed.length > MAX_WORKTREE_LABEL_LENGTH) {
+    throw new LifecycleError(`Worktree label must be ${MAX_WORKTREE_LABEL_LENGTH} characters or fewer`, 400);
+  }
+  return trimmed;
 }
 
 function isLoopbackHostname(hostname: string): boolean {
@@ -344,6 +355,22 @@ export class LifecycleService {
     }
   }
 
+  async setWorktreeLabel(branch: string, label: string | null): Promise<{ label: string | null }> {
+    try {
+      const normalizedLabel = normalizeWorktreeLabel(label);
+      const resolved = await this.resolveExistingWorktree(branch);
+      const initialized = resolved.meta
+        ? await this.refreshManagedArtifacts(resolved)
+        : await this.initializeUnmanagedWorktree(resolved);
+      const nextMeta = this.withUpdatedLabel(initialized.meta, normalizedLabel);
+      await writeWorktreeMeta(resolved.gitDir, nextMeta);
+      await this.deps.reconciliation.reconcile(this.deps.projectRoot, { force: true });
+      return { label: normalizedLabel };
+    } catch (error) {
+      throw this.wrapOperationError(error);
+    }
+  }
+
   listAvailableBranches(options: ListAvailableBranchesOptions = {}): Array<{ name: string }> {
     const localBranches = this.listLocalBranches().filter((branch) => isValidBranchName(branch));
     const remoteBranches = options.includeRemote
@@ -602,6 +629,16 @@ export class LifecycleService {
 
   private async updateWorktreeArchivedState(path: string, archived: boolean): Promise<void> {
     await this.deps.archiveState.setArchived(path, archived);
+  }
+
+  private withUpdatedLabel(meta: WorktreeMeta, label: string | null): WorktreeMeta {
+    const nextMeta: WorktreeMeta = { ...meta };
+    if (label) {
+      nextMeta.label = label;
+    } else {
+      delete nextMeta.label;
+    }
+    return nextMeta;
   }
 
   private async closeBranchWindow(branch: string): Promise<void> {

--- a/backend/src/services/project-runtime.ts
+++ b/backend/src/services/project-runtime.ts
@@ -17,6 +17,7 @@ function isoNow(now?: () => Date): string {
 function makeDefaultState(input: {
   worktreeId: string;
   branch: string;
+  label?: string | null;
   baseBranch?: string | null;
   path: string;
   profile?: string | null;
@@ -26,6 +27,7 @@ function makeDefaultState(input: {
   return {
     worktreeId: input.worktreeId,
     branch: input.branch,
+    label: input.label ?? null,
     baseBranch: input.baseBranch ?? null,
     path: input.path,
     profile: input.profile ?? null,
@@ -70,6 +72,7 @@ export class ProjectRuntime {
   upsertWorktree(input: {
     worktreeId: string;
     branch: string;
+    label?: string | null;
     baseBranch?: string | null;
     path: string;
     profile?: string | null;
@@ -81,6 +84,7 @@ export class ProjectRuntime {
       this.reindexBranch(existing.branch, input.branch, input.worktreeId);
       existing.path = input.path;
       existing.branch = input.branch;
+      if (input.label !== undefined) existing.label = input.label;
       if (input.baseBranch !== undefined) existing.baseBranch = input.baseBranch;
       existing.profile = input.profile ?? existing.profile;
       existing.agentName = input.agentName ?? existing.agentName;

--- a/backend/src/services/reconciliation-service.ts
+++ b/backend/src/services/reconciliation-service.ts
@@ -94,6 +94,7 @@ export interface ReconcileOptions {
 interface ReconciledWorktreeState {
   worktreeId: string;
   branch: string;
+  label: string | null;
   baseBranch: string | null;
   path: string;
   profile: string | null;
@@ -175,6 +176,7 @@ export class ReconciliationService {
       return {
         worktreeId,
         branch,
+        label: meta?.label ?? null,
         baseBranch: meta?.baseBranch ?? null,
         path: entry.path,
         profile: meta?.profile ?? null,
@@ -211,6 +213,7 @@ export class ReconciliationService {
       this.deps.runtime.upsertWorktree({
         worktreeId: state.worktreeId,
         branch: state.branch,
+        label: state.label,
         baseBranch: state.baseBranch,
         path: state.path,
         profile: state.profile,

--- a/backend/src/services/snapshot-service.ts
+++ b/backend/src/services/snapshot-service.ts
@@ -46,6 +46,7 @@ function mapWorktreeSnapshot(
 ): WorktreeSnapshot {
   return {
     branch: state.branch,
+    label: state.label,
     ...(state.baseBranch ? { baseBranch: state.baseBranch } : {}),
     path: state.path,
     dir: state.path,
@@ -74,6 +75,7 @@ function mapCreatingWorktreeSnapshot(
 ): WorktreeSnapshot {
   return {
     branch: creating.branch,
+    label: null,
     ...(creating.baseBranch ? { baseBranch: creating.baseBranch } : {}),
     path: creating.path,
     dir: creating.path,

--- a/bin/src/completions.test.ts
+++ b/bin/src/completions.test.ts
@@ -120,6 +120,7 @@ describe("runCompletionCommand", () => {
     expect(output).toContain("#compdef webmux");
     expect(output).toContain("compdef _webmux webmux");
     expect(output).toContain("archive:Hide a worktree from the default list");
+    expect(output).toContain("label:Set or clear a workspace label");
     expect(output).toContain("prune:Remove all worktrees in the current project");
     expect(output).not.toContain('_webmux "$@"');
     spy.mockRestore();

--- a/bin/src/completions.ts
+++ b/bin/src/completions.ts
@@ -11,7 +11,7 @@ interface ListBranchesDeps {
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
-const BRANCH_SUBCOMMANDS = new Set(["open", "close", "archive", "unarchive", "remove", "merge", "send"]);
+const BRANCH_SUBCOMMANDS = new Set(["open", "close", "archive", "unarchive", "label", "remove", "merge", "send"]);
 
 // ── Pure logic ─────────────────────────────────────────────────────────────
 
@@ -127,6 +127,7 @@ _webmux() {
     'close:Close a worktree session'
     'archive:Hide a worktree from the default list'
     'unarchive:Show an archived worktree again'
+    'label:Set or clear a workspace label'
     'remove:Remove a worktree'
     'merge:Merge a worktree into main'
     'send:Send a prompt to a running worktree agent'
@@ -140,7 +141,7 @@ _webmux() {
   fi
 
   case "\${words[2]}" in
-    open|close|archive|unarchive|remove|merge|send)
+    open|close|archive|unarchive|label|remove|merge|send)
       if (( CURRENT == 3 )); then
         local -a branches
         branches=(\${(f)"$(webmux --completions "\${words[2]}" 2>/dev/null)"})
@@ -180,12 +181,12 @@ const BASH_SCRIPT = `_webmux() {
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
-    COMPREPLY=($(compgen -W "serve init service update add list open close archive unarchive remove merge send prune completion" -- "\${cur}"))
+    COMPREPLY=($(compgen -W "serve init service update add list open close archive unarchive label remove merge send prune completion" -- "\${cur}"))
     return
   fi
 
   case "\${COMP_WORDS[1]}" in
-    open|close|archive|unarchive|remove|merge|send)
+    open|close|archive|unarchive|label|remove|merge|send)
       if [[ \${COMP_CWORD} -eq 2 ]]; then
         local branches
         branches=$(webmux --completions "\${COMP_WORDS[1]}" 2>/dev/null)

--- a/bin/src/webmux.test.ts
+++ b/bin/src/webmux.test.ts
@@ -120,6 +120,18 @@ describe("webmux entrypoint", () => {
     });
   });
 
+  it("parses label as a worktree command", () => {
+    delete process.env.PORT;
+
+    expect(parseRootArgs(["label", "feature/search", "Search", "ranking"])).toEqual({
+      port: 5111,
+      debug: false,
+      app: false,
+      command: "label",
+      commandArgs: ["feature/search", "Search", "ranking"],
+    });
+  });
+
   it("runs worktree commands from a project subdirectory", async () => {
     const repoRoot = await mkdtemp(join(tmpdir(), "webmux-cli-"));
     tempDirs.push(repoRoot);

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -25,6 +25,7 @@ Usage:
   webmux close        Close a worktree session without removing it
   webmux archive      Hide a worktree from the default list
   webmux unarchive    Show an archived worktree again
+  webmux label        Set or clear a workspace label
   webmux remove       Remove a worktree
   webmux merge        Merge a worktree into the main branch and remove it
   webmux send         Send a prompt to a running worktree agent
@@ -43,7 +44,7 @@ Environment:
 `);
 }
 
-type RootCommand = "serve" | "init" | "service" | "update" | "add" | "list" | "open" | "close" | "archive" | "unarchive" | "remove" | "merge" | "send" | "prune" | "completion" | null;
+type RootCommand = "serve" | "init" | "service" | "update" | "add" | "list" | "open" | "close" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "prune" | "completion" | null;
 
 interface ParsedRootArgs {
   port: number;
@@ -64,6 +65,7 @@ function isRootCommand(value: string): value is NonNullable<RootCommand> {
     || value === "close"
     || value === "archive"
     || value === "unarchive"
+    || value === "label"
     || value === "remove"
     || value === "merge"
     || value === "send"
@@ -142,13 +144,14 @@ export function parseRootArgs(args: string[]): ParsedRootArgs {
   };
 }
 
-function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "open" | "close" | "archive" | "unarchive" | "remove" | "merge" | "send" | "prune" {
+function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "open" | "close" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "prune" {
   return command === "add"
     || command === "list"
     || command === "open"
     || command === "close"
     || command === "archive"
     || command === "unarchive"
+    || command === "label"
     || command === "remove"
     || command === "merge"
     || command === "send"

--- a/bin/src/worktree-commands.test.ts
+++ b/bin/src/worktree-commands.test.ts
@@ -251,12 +251,24 @@ describe("parseLabelCommandArgs", () => {
     });
   });
 
+  it("parses --label", () => {
+    expect(parseLabelCommandArgs(["feature/search", "--label", "Search ranking"])).toEqual({
+      branch: "feature/search",
+      label: "Search ranking",
+    });
+  });
+
   it("returns null for help", () => {
     expect(parseLabelCommandArgs(["--help"])).toBeNull();
   });
 
   it("rejects --clear with label text", () => {
     expect(() => parseLabelCommandArgs(["feature/search", "--clear", "Search"])).toThrow("Cannot use --clear with a label");
+  });
+
+  it("rejects --label with positional label text", () => {
+    expect(() => parseLabelCommandArgs(["feature/search", "--label", "Search", "extra"]))
+      .toThrow("Cannot use --label with a positional label");
   });
 });
 

--- a/bin/src/worktree-commands.test.ts
+++ b/bin/src/worktree-commands.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { buildProjectSessionName, buildWorktreeWindowName } from "../../backend/src/adapters/tmux";
 import type { CreateLifecycleWorktreeInput, CreateLifecycleWorktreesInput } from "../../backend/src/services/lifecycle-service";
 import {
   parseAddCommandArgs,
   parseBranchCommandArgs,
+  parseLabelCommandArgs,
   parseListCommandArgs,
   parseSendCommandArgs,
   runWorktreeCommand,
@@ -35,6 +39,10 @@ function stubLifecycleService(calls: Array<{ method: string; value: unknown }>) 
     },
     async setWorktreeArchived(branch: string, archived: boolean): Promise<void> {
       calls.push({ method: "setWorktreeArchived", value: { branch, archived } });
+    },
+    async setWorktreeLabel(branch: string, label: string | null): Promise<{ label: string | null }> {
+      calls.push({ method: "setWorktreeLabel", value: { branch, label } });
+      return { label };
     },
     async removeWorktree(branch: string): Promise<void> {
       calls.push({ method: "removeWorktree", value: branch });
@@ -228,6 +236,30 @@ describe("parseSendCommandArgs", () => {
   });
 });
 
+describe("parseLabelCommandArgs", () => {
+  it("parses branch and label text", () => {
+    expect(parseLabelCommandArgs(["feature/search", "Search", "ranking"])).toEqual({
+      branch: "feature/search",
+      label: "Search ranking",
+    });
+  });
+
+  it("parses --clear", () => {
+    expect(parseLabelCommandArgs(["feature/search", "--clear"])).toEqual({
+      branch: "feature/search",
+      label: null,
+    });
+  });
+
+  it("returns null for help", () => {
+    expect(parseLabelCommandArgs(["--help"])).toBeNull();
+  });
+
+  it("rejects --clear with label text", () => {
+    expect(() => parseLabelCommandArgs(["feature/search", "--clear", "Search"])).toThrow("Cannot use --clear with a label");
+  });
+});
+
 describe("runWorktreeCommand", () => {
   it("dispatches add through the lifecycle service and switches to tmux", async () => {
     const { runtime, calls } = makeRuntime();
@@ -405,6 +437,50 @@ describe("runWorktreeCommand", () => {
     expect(stdout).toEqual(["Archived worktree feature/search"]);
   });
 
+  it("dispatches label updates through the lifecycle service", async () => {
+    const { runtime, calls } = makeRuntime();
+    const stdout: string[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      {
+        command: "label",
+        args: ["feature/search", "Search", "ranking"],
+        projectDir: "/repo",
+        port: 5111,
+      },
+      {
+        createRuntime: () => runtime,
+        stdout: (message) => stdout.push(message),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([{ method: "setWorktreeLabel", value: { branch: "feature/search", label: "Search ranking" } }]);
+    expect(stdout).toEqual(['Labeled worktree feature/search as "Search ranking"']);
+  });
+
+  it("dispatches label clears through the lifecycle service", async () => {
+    const { runtime, calls } = makeRuntime();
+    const stdout: string[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      {
+        command: "label",
+        args: ["feature/search", "--clear"],
+        projectDir: "/repo",
+        port: 5111,
+      },
+      {
+        createRuntime: () => runtime,
+        stdout: (message) => stdout.push(message),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([{ method: "setWorktreeLabel", value: { branch: "feature/search", label: null } }]);
+    expect(stdout).toEqual(["Cleared label for feature/search"]);
+  });
+
   it("prints subcommand help without creating a runtime", async () => {
     let createRuntimeCalled = false;
     const stdout: string[] = [];
@@ -546,6 +622,12 @@ describe("runWorktreeCommand", () => {
             async closeWorktree(): Promise<void> {
               throw new Error("not used");
             },
+            async setWorktreeArchived(): Promise<void> {
+              throw new Error("not used");
+            },
+            async setWorktreeLabel(): Promise<{ label: string | null }> {
+              throw new Error("not used");
+            },
             async removeWorktree(): Promise<void> {
               throw new Error("Worktree has uncommitted changes: feature/search");
             },
@@ -622,6 +704,52 @@ describe("runWorktreeCommand", () => {
     expect(stdout[0]).toContain("closed");
     expect(stdout[1]).toContain("my-feature");
     expect(stdout[1]).toContain("open");
+  });
+
+  it("lists and searches workspace labels", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "webmux-cli-labels-"));
+    try {
+      const projectDir = join(tempDir, "repo");
+      const worktreePath = join(projectDir, ".worktrees", "random-name");
+      const metaDir = join(worktreePath, ".git", "webmux");
+      await mkdir(metaDir, { recursive: true });
+      await Bun.write(join(metaDir, "meta.json"), JSON.stringify({
+        schemaVersion: 1,
+        worktreeId: "wt_random",
+        branch: "random-name",
+        label: "Search ranking",
+        createdAt: "2026-05-12T00:00:00.000Z",
+        profile: "default",
+        agent: "codex",
+        runtime: "host",
+        startupEnvValues: {},
+        allocatedPorts: {},
+      }));
+      const stdout: string[] = [];
+
+      const exitCode = await runWorktreeCommand(
+        { command: "list", args: ["--search", "ranking"], projectDir, port: 5111 },
+        {
+          createRuntime: () => ({
+            projectDir,
+            config: { workspace: { mainBranch: "main" } },
+            git: stubGit([
+              { path: projectDir, branch: "main", bare: false },
+              { path: worktreePath, branch: "random-name", bare: false },
+            ]),
+            tmux: stubTmux(),
+            lifecycleService: stubLifecycleService([]),
+          }),
+          stdout: (msg) => stdout.push(msg),
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toHaveLength(1);
+      expect(stdout[0]).toContain("Search ranking (random-name)");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("prints empty message when no worktrees exist", async () => {

--- a/bin/src/worktree-commands.ts
+++ b/bin/src/worktree-commands.ts
@@ -313,6 +313,7 @@ export interface ParsedListCommand {
 export function parseLabelCommandArgs(args: string[]): ParsedLabelCommand | null {
   let branch: string | null = null;
   let clear = false;
+  let optionLabel: string | null = null;
   const labelParts: string[] = [];
 
   for (let index = 0; index < args.length; index++) {
@@ -329,8 +330,11 @@ export function parseLabelCommandArgs(args: string[]): ParsedLabelCommand | null
     }
 
     if (arg === "--label" || arg.startsWith("--label=")) {
+      if (optionLabel !== null) {
+        throw new CommandUsageError("Cannot use --label more than once");
+      }
       const { value, nextIndex } = readOptionValue(args, index, "--label");
-      labelParts.push(value);
+      optionLabel = value;
       index = nextIndex;
       continue;
     }
@@ -344,6 +348,9 @@ export function parseLabelCommandArgs(args: string[]): ParsedLabelCommand | null
       continue;
     }
 
+    if (optionLabel !== null) {
+      throw new CommandUsageError("Cannot use --label with a positional label");
+    }
     labelParts.push(arg);
   }
 
@@ -355,7 +362,11 @@ export function parseLabelCommandArgs(args: string[]): ParsedLabelCommand | null
     throw new CommandUsageError("Invalid worktree name");
   }
 
-  const label = labelParts.join(" ").trim();
+  if (optionLabel !== null && labelParts.length > 0) {
+    throw new CommandUsageError("Cannot use --label with a positional label");
+  }
+
+  const label = (optionLabel ?? labelParts.join(" ")).trim();
   if (clear && label) {
     throw new CommandUsageError("Cannot use --clear with a label");
   }

--- a/bin/src/worktree-commands.ts
+++ b/bin/src/worktree-commands.ts
@@ -18,7 +18,7 @@ const PHASE_LABELS: Record<WorktreeCreationPhase, string> = {
   reconciling: "Reconciling",
 };
 
-export type WorktreeSubcommand = "add" | "list" | "open" | "close" | "remove" | "merge" | "send" | "prune" | "archive" | "unarchive";
+export type WorktreeSubcommand = "add" | "list" | "open" | "close" | "remove" | "merge" | "send" | "prune" | "archive" | "unarchive" | "label";
 
 type WorktreeListMode = "active" | "all" | "archived";
 
@@ -28,6 +28,7 @@ interface LifecycleServiceLike {
   openWorktree(branch: string): Promise<{ branch: string; worktreeId: string }>;
   closeWorktree(branch: string): Promise<void>;
   setWorktreeArchived(branch: string, archived: boolean): Promise<void>;
+  setWorktreeLabel(branch: string, label: string | null): Promise<{ label: string | null }>;
   removeWorktree(branch: string): Promise<void>;
   mergeWorktree(branch: string): Promise<void>;
   pruneWorktrees(): Promise<PruneWorktreesResult>;
@@ -107,6 +108,17 @@ export function getWorktreeCommandUsage(command: WorktreeSubcommand): string {
       return "Usage:\n  webmux archive <branch>";
     case "unarchive":
       return "Usage:\n  webmux unarchive <branch>";
+    case "label":
+      return [
+        "Usage:",
+        "  webmux label <branch> <label>",
+        "  webmux label <branch> --clear",
+        "",
+        "Options:",
+        "  --clear                  Clear the workspace label",
+        "  --label <text>           Label text",
+        "  --help                   Show this help message",
+      ].join("\n");
     case "remove":
       return "Usage:\n  webmux remove <branch>";
     case "merge":
@@ -288,9 +300,74 @@ export interface ParsedSendCommand {
   preamble?: string;
 }
 
+export interface ParsedLabelCommand {
+  branch: string;
+  label: string | null;
+}
+
 export interface ParsedListCommand {
   mode: WorktreeListMode;
   search: string;
+}
+
+export function parseLabelCommandArgs(args: string[]): ParsedLabelCommand | null {
+  let branch: string | null = null;
+  let clear = false;
+  const labelParts: string[] = [];
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (!arg) continue;
+
+    if (arg === "--help" || arg === "-h") {
+      return null;
+    }
+
+    if (arg === "--clear") {
+      clear = true;
+      continue;
+    }
+
+    if (arg === "--label" || arg.startsWith("--label=")) {
+      const { value, nextIndex } = readOptionValue(args, index, "--label");
+      labelParts.push(value);
+      index = nextIndex;
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      throw new CommandUsageError(`Unknown option: ${arg}`);
+    }
+
+    if (!branch) {
+      branch = arg;
+      continue;
+    }
+
+    labelParts.push(arg);
+  }
+
+  if (!branch) {
+    throw new CommandUsageError("Missing required argument: <branch>");
+  }
+
+  if (!isValidWorktreeName(branch)) {
+    throw new CommandUsageError("Invalid worktree name");
+  }
+
+  const label = labelParts.join(" ").trim();
+  if (clear && label) {
+    throw new CommandUsageError("Cannot use --clear with a label");
+  }
+
+  if (!clear && !label) {
+    throw new CommandUsageError("Missing required argument: <label>");
+  }
+
+  return {
+    branch,
+    label: clear ? null : label,
+  };
 }
 
 export function parseSendCommandArgs(args: string[]): ParsedSendCommand | null {
@@ -459,6 +536,7 @@ function defaultSwitchToTmuxWindow(projectDir: string, branch: string): void {
 
 interface ListedWorktreeRow {
   branch: string;
+  label: string | null;
   isOpen: boolean;
   archived: boolean;
   info: string;
@@ -506,10 +584,12 @@ async function listWorktrees(
     const info = meta ? `${meta.profile} / ${meta.agent}` : "";
     return {
       branch,
+      label: meta?.label ?? null,
       isOpen,
       archived: archivedPaths.has(resolve(entry.path)),
       info,
       searchText: [
+        meta?.label ?? "",
         branch,
         meta?.baseBranch ?? "",
         meta?.profile ?? "",
@@ -547,10 +627,13 @@ async function listWorktrees(
     return;
   }
 
-  const maxBranch = Math.max(...visibleRows.map((row) => row.branch.length));
+  const maxName = Math.max(...visibleRows.map((row) =>
+    (row.label ? `${row.label} (${row.branch})` : row.branch).length
+  ));
   for (const row of visibleRows) {
     const status = `${row.isOpen ? "open" : "closed"}${row.archived ? " archived" : ""}`;
-    stdout(`${row.branch.padEnd(maxBranch + 2)} ${status.padEnd(15)} ${row.info}`.trimEnd());
+    const name = row.label ? `${row.label} (${row.branch})` : row.branch;
+    stdout(`${name.padEnd(maxName + 2)} ${status.padEnd(15)} ${row.info}`.trimEnd());
   }
 
   if (options.mode === "active") {
@@ -679,7 +762,25 @@ export async function runWorktreeCommand(
       return 0;
     }
 
-    const command: Exclude<WorktreeSubcommand, "add" | "list" | "send" | "prune"> = context.command;
+    if (context.command === "label") {
+      const parsed = parseLabelCommandArgs(context.args);
+      if (!parsed) {
+        stdout(getWorktreeCommandUsage("label"));
+        return 0;
+      }
+
+      const runtime = createRuntime({
+        projectDir: context.projectDir,
+        port: context.port,
+      });
+      const result = await runtime.lifecycleService.setWorktreeLabel(parsed.branch, parsed.label);
+      stdout(result.label
+        ? `Labeled worktree ${parsed.branch} as "${result.label}"`
+        : `Cleared label for ${parsed.branch}`);
+      return 0;
+    }
+
+    const command: Exclude<WorktreeSubcommand, "add" | "list" | "send" | "prune" | "label"> = context.command;
     const branch = parseBranchCommandArgs(context.args);
     if (!branch) {
       stdout(getWorktreeCommandUsage(command));

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -13,6 +13,7 @@
   import LinearPanel from "./lib/LinearPanel.svelte";
   import LinearDetailDialog from "./lib/LinearDetailDialog.svelte";
   import MobileChatSurface from "./lib/MobileChatSurface.svelte";
+  import WorktreeLabelDialog from "./lib/WorktreeLabelDialog.svelte";
   import SidebarRepoRow from "./lib/SidebarRepoRow.svelte";
   import Toggle from "./lib/Toggle.svelte";
   import type {
@@ -51,7 +52,7 @@
   import { getTheme } from "./lib/themes";
   import type { ThemeKey } from "./lib/themes";
   import { setToastController } from "./lib/toast-context";
-  import { api, fetchWorktrees, subscribeNotifications } from "./lib/api";
+  import { api, fetchWorktrees, setWorktreeLabel, subscribeNotifications } from "./lib/api";
 
   function createDefaultConfig(): AppConfig {
     return {
@@ -84,6 +85,9 @@
   let hasLoadedWorktrees = $state(false);
   let removeBranch = $state<string | null>(null);
   let mergeBranch = $state<string | null>(null);
+  let labelBranch = $state<string | null>(null);
+  let labelLoading = $state(false);
+  let labelError = $state("");
   let removingBranches = $state<Set<string>>(new Set());
   let showCreateDialog = $state(false);
   let showSettingsDialog = $state(false);
@@ -402,6 +406,9 @@
       ? worktrees.find((w) => w.branch === selectedBranch)
       : undefined,
   );
+  let labelWorktree = $derived(
+    labelBranch ? worktrees.find((w) => w.branch === labelBranch) : undefined,
+  );
   let canConnect = $derived(!!selectedBranch && selectedWorktree?.mux === "✓" && !selectedWorktree?.creating);
   let showMobileChat = $derived(isMobile && canConnect && supportsWorktreeChat(selectedWorktree));
   let isSelectedOpening = $derived(selectedBranch ? openingBranches.has(selectedBranch) : false);
@@ -679,6 +686,35 @@
       removingBranches = new Set(
         [...removingBranches].filter((b) => b !== branch),
       );
+    }
+  }
+
+  function openLabelDialog(): void {
+    if (!selectedWorktree) return;
+    labelBranch = selectedWorktree.branch;
+    labelError = "";
+  }
+
+  function applyWorktreeLabel(branch: string, label: string | null): void {
+    worktrees = worktrees.map((worktree) =>
+      worktree.branch === branch ? { ...worktree, label } : worktree
+    );
+  }
+
+  async function handleLabelChange(label: string | null): Promise<void> {
+    const branch = labelBranch;
+    if (!branch) return;
+
+    labelLoading = true;
+    labelError = "";
+    try {
+      const nextLabel = await setWorktreeLabel(branch, label);
+      applyWorktreeLabel(branch, nextLabel);
+      labelBranch = null;
+    } catch (err) {
+      labelError = errorMessage(err);
+    } finally {
+      labelLoading = false;
     }
   }
 
@@ -1106,6 +1142,7 @@
       onremove={() => {
         if (selectedBranch) removeBranch = selectedBranch;
       }}
+      oneditlabel={openLabelDialog}
       onsettings={() => (showSettingsDialog = true)}
       ondirtyclick={openDiffDialog}
       onCiClick={(pr) => (ciDetailsPr = pr)}
@@ -1133,14 +1170,24 @@
       <div class="flex-1 flex items-center justify-center px-6">
         <div class="flex flex-col items-center gap-3 text-center">
           <span class="spinner" style="width: 24px; height: 24px; border-width: 2px;"></span>
-          <p class="text-sm text-primary font-medium">{selectedWorktree.branch}</p>
+          <div>
+            <p class="text-sm text-primary font-medium">{selectedWorktree.label ?? selectedWorktree.branch}</p>
+            {#if selectedWorktree.label}
+              <p class="text-[10px] text-muted">{selectedWorktree.branch}</p>
+            {/if}
+          </div>
           <p class="text-xs text-muted">{worktreeCreationPhaseLabel(selectedWorktree.creationPhase)}</p>
         </div>
       </div>
     {:else if selectedWorktree}
       <div class="flex-1 flex items-center justify-center px-6">
         <div class="flex flex-col items-center gap-4 text-center">
-          <p class="text-sm text-primary font-medium">{selectedWorktree.branch}</p>
+          <div>
+            <p class="text-sm text-primary font-medium">{selectedWorktree.label ?? selectedWorktree.branch}</p>
+            {#if selectedWorktree.label}
+              <p class="text-[10px] text-muted">{selectedWorktree.branch}</p>
+            {/if}
+          </div>
           <div class="flex flex-col items-center gap-1">
             {#if selectedWorktree.profile}
               <span class="text-xs text-muted">Profile: {selectedWorktree.profile}</span>
@@ -1199,6 +1246,21 @@
     openedFromLinearIssue={assignIssue !== null}
     oncreate={handleCreate}
     oncancel={() => { showCreateDialog = false; assignIssue = null; }}
+  />
+{/if}
+
+{#if labelBranch && labelWorktree}
+  <WorktreeLabelDialog
+    branch={labelWorktree.branch}
+    initialLabel={labelWorktree.label}
+    loading={labelLoading}
+    error={labelError}
+    onconfirm={(label) => { void handleLabelChange(label); }}
+    onclear={() => { void handleLabelChange(null); }}
+    oncancel={() => {
+      labelBranch = null;
+      labelError = "";
+    }}
   />
 {/if}
 

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -21,11 +21,12 @@ vi.mock("./lib/api", () => ({
     sendWorktreePrompt: vi.fn(),
   },
   fetchWorktrees: vi.fn(),
+  setWorktreeLabel: vi.fn(),
   subscribeNotifications: vi.fn(),
 }));
 
 import App from "./App.svelte";
-import { api, fetchWorktrees, subscribeNotifications } from "./lib/api";
+import { api, fetchWorktrees, setWorktreeLabel, subscribeNotifications } from "./lib/api";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -107,6 +108,7 @@ function createWorktree(
 ): WorktreeInfo {
   return {
     branch,
+    label: null,
     archived: false,
     agent: "waiting",
     mux: "",
@@ -244,6 +246,7 @@ describe("App create selection", () => {
     vi.mocked(api.dismissNotification).mockResolvedValue({ ok: true });
     vi.mocked(api.fetchCiLogs).mockResolvedValue({ logs: "" });
     vi.mocked(api.sendWorktreePrompt).mockResolvedValue({ ok: true });
+    vi.mocked(setWorktreeLabel).mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -490,6 +493,25 @@ describe("App create selection", () => {
         body: { archived: true },
       });
     });
+  });
+
+  it("edits the selected worktree label from the header", async () => {
+    vi.mocked(fetchWorktrees).mockResolvedValue([createWorktree("feature/active")]);
+    vi.mocked(setWorktreeLabel).mockResolvedValue("Search ranking");
+
+    render(App);
+
+    await screen.findByTitle("feature/active");
+    await fireEvent.click(screen.getByRole("button", { name: "Edit workspace label" }));
+    await fireEvent.input(screen.getByLabelText("Label"), {
+      target: { value: "Search ranking" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(setWorktreeLabel).toHaveBeenCalledWith("feature/active", "Search ranking");
+    });
+    expect(screen.getAllByText("Search ranking").length).toBeGreaterThan(0);
   });
 
   it("shows a setup message in the Linear panel when LINEAR_API_KEY is missing", async () => {

--- a/frontend/src/lib/MobileChatSurface.test.ts
+++ b/frontend/src/lib/MobileChatSurface.test.ts
@@ -25,6 +25,7 @@ import {
 function createWorktree(overrides: Partial<WorktreeInfo> = {}): WorktreeInfo {
   return {
     branch: "feature/mobile-chat",
+    label: null,
     archived: false,
     agent: "waiting",
     mux: "✓",

--- a/frontend/src/lib/TopBar.svelte
+++ b/frontend/src/lib/TopBar.svelte
@@ -24,6 +24,7 @@
     onarchive,
     onmerge,
     onremove,
+    oneditlabel,
     onsettings,
     onCiClick,
     onReviewsClick,
@@ -44,6 +45,7 @@
     onarchive: () => void;
     onmerge: () => void;
     onremove: () => void;
+    oneditlabel?: () => void;
     onsettings: () => void;
     onCiClick: (pr: PrEntry) => void;
     onReviewsClick: (pr: PrEntry) => void;
@@ -80,7 +82,9 @@
   }
 
   let cursorUrl = $derived(makeCursorUrl(worktree?.dir, sshHost));
-  let displayName = $derived(truncateWorktreeName(name, 30));
+  let headerName = $derived(worktree?.label ?? name);
+  let displayName = $derived(truncateWorktreeName(headerName, 30));
+  let displayBranch = $derived(worktree?.label ? truncateWorktreeName(name, 44) : null);
 
   // Split PRs into main repo vs linked repo groups
   let mainPrs = $derived(
@@ -135,9 +139,40 @@
             </svg>
           </button>
         {/if}
-        <span class="min-w-0 text-sm font-semibold truncate" title={name ?? undefined}
-          >{displayName ?? "Select a worktree"}</span
-        >
+        <span class="min-w-0 flex flex-col leading-tight">
+          <span class="flex items-center gap-1.5 min-w-0">
+            <span class="min-w-0 text-sm font-semibold truncate" title={headerName ?? undefined}
+              >{displayName ?? "Select a worktree"}</span
+            >
+            {#if worktree && oneditlabel}
+              <button
+                type="button"
+                class="shrink-0 p-0.5 rounded text-muted hover:text-primary hover:bg-hover"
+                title="Edit workspace label"
+                aria-label="Edit workspace label"
+                onclick={oneditlabel}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M12 20h9" />
+                  <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                </svg>
+              </button>
+            {/if}
+          </span>
+          {#if displayBranch}
+            <span class="text-[10px] text-muted truncate" title={name ?? undefined}>{displayBranch}</span>
+          {/if}
+        </span>
         {#if worktree?.archived}
           <span class="shrink-0 text-[10px] px-1.5 py-0.5 rounded border border-edge text-muted">Archived</span>
         {/if}

--- a/frontend/src/lib/TopBar.test.ts
+++ b/frontend/src/lib/TopBar.test.ts
@@ -9,6 +9,7 @@ function createWorktree(
 ): WorktreeInfo {
   return {
     branch,
+    label: null,
     archived: false,
     agent: "claude",
     mux: "✓",
@@ -75,6 +76,33 @@ describe("TopBar", () => {
     const header = screen.getByText(branch);
 
     expect(header).toHaveAttribute("title", branch);
+  });
+
+  it("shows workspace labels above the real branch name", () => {
+    const branch = "feature/random-fallback";
+
+    render(TopBar, {
+      props: {
+        name: branch,
+        worktree: createWorktree(branch, { label: "Search ranking" }),
+        sshHost: "",
+        linkedRepos: [],
+        notificationHistory: [],
+        unreadCount: 0,
+        onclose: vi.fn(),
+        onarchive: vi.fn(),
+        onmerge: vi.fn(),
+        onremove: vi.fn(),
+        oneditlabel: vi.fn(),
+        onsettings: vi.fn(),
+        onCiClick: vi.fn(),
+        onReviewsClick: vi.fn(),
+      },
+    });
+
+    expect(screen.getByText("Search ranking")).toBeInTheDocument();
+    expect(screen.getByText(branch)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit workspace label" })).toBeInTheDocument();
   });
 
   it("renders the Linear badge as a link in the header", () => {

--- a/frontend/src/lib/WorktreeConversationPanel.test.ts
+++ b/frontend/src/lib/WorktreeConversationPanel.test.ts
@@ -6,6 +6,7 @@ import type { AgentsUiConversationState, WorktreeInfo } from "./types";
 function createWorktree(overrides: Partial<WorktreeInfo> = {}): WorktreeInfo {
   return {
     branch: "feature/mobile-chat",
+    label: null,
     archived: false,
     agent: "waiting",
     mux: "✓",

--- a/frontend/src/lib/WorktreeLabelDialog.svelte
+++ b/frontend/src/lib/WorktreeLabelDialog.svelte
@@ -20,12 +20,11 @@
     oncancel: () => void;
   } = $props();
 
-  let label = $state("");
+  let currentLabel = $state<string | null>(null);
   let inputEl = $state<HTMLInputElement | null>(null);
-
-  $effect(() => {
-    label = initialLabel ?? "";
-  });
+  let normalizedInitialLabel = $derived((initialLabel ?? "").trim());
+  let normalizedLabel = $derived((currentLabel ?? initialLabel ?? "").trim());
+  let canSave = $derived(!loading && normalizedLabel !== normalizedInitialLabel);
 
   $effect(() => {
     const currentInput = inputEl;
@@ -35,7 +34,7 @@
 </script>
 
 <BaseDialog onclose={oncancel}>
-  <form onsubmit={(event: SubmitEvent) => { event.preventDefault(); onconfirm(label); }}>
+  <form onsubmit={(event: SubmitEvent) => { event.preventDefault(); if (canSave) onconfirm(normalizedLabel); }}>
     <h2 class="text-base mb-4">Workspace label</h2>
     <div class="mb-4">
       <label class="block text-[11px] text-muted mb-1" for="worktree-label-input">Label</label>
@@ -44,7 +43,11 @@
         class="w-full px-3 py-2 rounded-md border border-edge bg-surface text-primary text-sm focus:outline-none focus:border-accent"
         maxlength="80"
         bind:this={inputEl}
-        bind:value={label}
+        value={currentLabel ?? initialLabel ?? ""}
+        oninput={(event: Event) => {
+          const target = event.currentTarget;
+          if (target instanceof HTMLInputElement) currentLabel = target.value;
+        }}
         placeholder={branch}
         disabled={loading}
       />
@@ -54,7 +57,7 @@
       <Btn type="button" onclick={onclear} disabled={loading || !initialLabel}>Clear</Btn>
       <div class="flex justify-end gap-2">
         <Btn type="button" onclick={oncancel} disabled={loading}>Cancel</Btn>
-        <Btn type="submit" variant="cta" class="flex items-center gap-1.5" disabled={loading}
+        <Btn type="submit" variant="cta" class="flex items-center gap-1.5" disabled={!canSave}
           >{#if loading}<span class="spinner"></span>{/if} Save</Btn
         >
       </div>

--- a/frontend/src/lib/WorktreeLabelDialog.svelte
+++ b/frontend/src/lib/WorktreeLabelDialog.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import BaseDialog from "./BaseDialog.svelte";
+  import Btn from "./Btn.svelte";
+
+  let {
+    branch,
+    initialLabel,
+    loading = false,
+    error = "",
+    onconfirm,
+    onclear,
+    oncancel,
+  }: {
+    branch: string;
+    initialLabel: string | null;
+    loading?: boolean;
+    error?: string;
+    onconfirm: (label: string) => void;
+    onclear: () => void;
+    oncancel: () => void;
+  } = $props();
+
+  let label = $state("");
+  let inputEl = $state<HTMLInputElement | null>(null);
+
+  $effect(() => {
+    label = initialLabel ?? "";
+  });
+
+  $effect(() => {
+    const currentInput = inputEl;
+    if (!currentInput) return;
+    queueMicrotask(() => currentInput.focus());
+  });
+</script>
+
+<BaseDialog onclose={oncancel}>
+  <form onsubmit={(event: SubmitEvent) => { event.preventDefault(); onconfirm(label); }}>
+    <h2 class="text-base mb-4">Workspace label</h2>
+    <div class="mb-4">
+      <label class="block text-[11px] text-muted mb-1" for="worktree-label-input">Label</label>
+      <input
+        id="worktree-label-input"
+        class="w-full px-3 py-2 rounded-md border border-edge bg-surface text-primary text-sm focus:outline-none focus:border-accent"
+        maxlength="80"
+        bind:this={inputEl}
+        bind:value={label}
+        placeholder={branch}
+        disabled={loading}
+      />
+    </div>
+    {#if error}<p class="text-[12px] text-danger mb-4 -mt-2 whitespace-pre-wrap">{error}</p>{/if}
+    <div class="flex justify-between gap-2">
+      <Btn type="button" onclick={onclear} disabled={loading || !initialLabel}>Clear</Btn>
+      <div class="flex justify-end gap-2">
+        <Btn type="button" onclick={oncancel} disabled={loading}>Cancel</Btn>
+        <Btn type="submit" variant="cta" class="flex items-center gap-1.5" disabled={loading}
+          >{#if loading}<span class="spinner"></span>{/if} Save</Btn
+        >
+      </div>
+    </div>
+  </form>
+</BaseDialog>

--- a/frontend/src/lib/WorktreeLabelDialog.test.ts
+++ b/frontend/src/lib/WorktreeLabelDialog.test.ts
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WorktreeLabelDialog from "./WorktreeLabelDialog.svelte";
+
+const originalDialogShowModal = HTMLDialogElement.prototype.showModal;
+const originalDialogClose = HTMLDialogElement.prototype.close;
+
+function renderDialog(overrides: {
+  initialLabel?: string | null;
+  onconfirm?: (label: string) => void;
+  onclear?: () => void;
+  oncancel?: () => void;
+} = {}): void {
+  render(WorktreeLabelDialog, {
+    props: {
+      branch: "feature/search",
+      initialLabel: null,
+      loading: false,
+      error: "",
+      onconfirm: overrides.onconfirm ?? vi.fn(),
+      onclear: overrides.onclear ?? vi.fn(),
+      oncancel: overrides.oncancel ?? vi.fn(),
+      ...overrides,
+    },
+  });
+}
+
+describe("WorktreeLabelDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement): void {
+      this.open = true;
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement): void {
+      this.open = false;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    HTMLDialogElement.prototype.showModal = originalDialogShowModal;
+    HTMLDialogElement.prototype.close = originalDialogClose;
+  });
+
+  it("disables clear and save when there is no initial label", () => {
+    renderDialog();
+
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("clears an existing label", async () => {
+    const onclear = vi.fn();
+    renderDialog({ initialLabel: "Search ranking", onclear });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(onclear).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits trimmed changed labels", async () => {
+    const onconfirm = vi.fn();
+    renderDialog({ initialLabel: "Search ranking", onconfirm });
+
+    await fireEvent.input(screen.getByLabelText("Label"), {
+      target: { value: "  Search filters  " },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onconfirm).toHaveBeenCalledWith("Search filters");
+  });
+
+  it("does not submit unchanged labels", async () => {
+    const onconfirm = vi.fn();
+    renderDialog({ initialLabel: "Search ranking", onconfirm });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onconfirm).not.toHaveBeenCalled();
+  });
+
+  it("cancels without saving", async () => {
+    const oncancel = vi.fn();
+    const onconfirm = vi.fn();
+    renderDialog({ initialLabel: "Search ranking", oncancel, onconfirm });
+
+    await fireEvent.input(screen.getByLabelText("Label"), {
+      target: { value: "Search filters" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(oncancel).toHaveBeenCalledTimes(1);
+    expect(onconfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/WorktreeList.svelte
+++ b/frontend/src/lib/WorktreeList.svelte
@@ -83,6 +83,7 @@
     {@const isCreating = wt.creating}
     {@const isArchived = wt.archived}
     {@const isBusy = isRemoving || isInitializing}
+    {@const hasLabel = !!wt.label}
     <li class="mb-0.5 group relative {isBusy ? 'opacity-40 pointer-events-none' : ''}">
       <button
         type="button"
@@ -101,7 +102,12 @@
             {#if row.depth > 0}
               <span class="shrink-0 text-muted/60">↳</span>
             {/if}
-            <span class="font-medium truncate">{wt.branch}</span>
+            <span class="min-w-0 flex flex-col">
+              <span class="font-medium truncate">{wt.label ?? wt.branch}</span>
+              {#if hasLabel}
+                <span class="text-[10px] leading-tight text-muted truncate">{wt.branch}</span>
+              {/if}
+            </span>
             {#if isArchived}
               <span class="shrink-0 text-[10px] px-1.5 py-0.5 rounded border border-edge text-muted">
                 archived

--- a/frontend/src/lib/WorktreeList.test.ts
+++ b/frontend/src/lib/WorktreeList.test.ts
@@ -6,6 +6,7 @@ import type { WorktreeInfo, WorktreeListRow } from "./types";
 function createWorktree(branch: string): WorktreeInfo {
   return {
     branch,
+    label: null,
     archived: false,
     agent: "claude",
     mux: "✓",
@@ -116,6 +117,27 @@ describe("WorktreeList", () => {
 
     await fireEvent.click(screen.getByRole("button", { name: "Archive" }));
     expect(onarchive).toHaveBeenCalledWith("feature/menu-actions");
+  });
+
+  it("renders labels as the primary row name with the branch below", () => {
+    render(WorktreeList, {
+      props: {
+        rows: [createRow({ ...createWorktree("feature/random-fallback"), label: "Search ranking" })],
+        selected: null,
+        removing: new Set<string>(),
+        initializing: new Set<string>(),
+        archiving: new Set<string>(),
+        notifiedBranches: new Set<string>(),
+        onselect: vi.fn(),
+        onclose: vi.fn(),
+        onarchive: vi.fn(),
+        onmerge: vi.fn(),
+        onremove: vi.fn(),
+      },
+    });
+
+    expect(screen.getByText("Search ranking")).toBeInTheDocument();
+    expect(screen.getByText("feature/random-fallback")).toBeInTheDocument();
   });
 
   it("disables the archive action while the row is archiving", async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -37,6 +37,7 @@ function mapAgentStatus(status: string): string {
 function mapWorktree(snapshot: ProjectWorktreeSnapshot): WorktreeInfo {
   return {
     branch: snapshot.branch,
+    label: snapshot.label,
     ...(snapshot.baseBranch ? { baseBranch: snapshot.baseBranch } : {}),
     archived: snapshot.archived,
     agent: mapAgentStatus(snapshot.status),
@@ -62,6 +63,14 @@ function mapWorktree(snapshot: ProjectWorktreeSnapshot): WorktreeInfo {
 export async function fetchWorktrees(): Promise<WorktreeInfo[]> {
   const response = await api.fetchWorktrees();
   return response.worktrees.map((worktree) => mapWorktree(worktree));
+}
+
+export async function setWorktreeLabel(branch: string, label: string | null): Promise<string | null> {
+  const response = await api.setWorktreeLabel({
+    params: { name: branch },
+    body: { label },
+  });
+  return response.label;
 }
 
 export function attachWorktreeConversation(branch: string): Promise<AgentsUiWorktreeConversationResponse> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -50,6 +50,8 @@ export type {
   ServiceStatus,
   SetWorktreeArchivedRequest,
   SetWorktreeArchivedResponse,
+  SetWorktreeLabelRequest,
+  SetWorktreeLabelResponse,
   UnpushedCommit,
   WorktreeCreationPhase,
   WorktreeCreationState,
@@ -71,6 +73,7 @@ export interface DiffDialogProps {
 
 export interface WorktreeInfo {
   branch: string;
+  label: string | null;
   baseBranch?: string;
   archived: boolean;
   agent: string;

--- a/frontend/src/lib/worktree-list.test.ts
+++ b/frontend/src/lib/worktree-list.test.ts
@@ -5,6 +5,7 @@ import type { WorktreeInfo } from "./types";
 function createWorktree(branch: string, overrides: Partial<WorktreeInfo> = {}): WorktreeInfo {
   return {
     branch,
+    label: null,
     archived: false,
     agent: "waiting",
     mux: "",
@@ -66,6 +67,18 @@ describe("buildWorktreeListRows", () => {
     });
 
     expect(worktrees.map((worktree) => worktree.branch)).toEqual(["feature/active"]);
+  });
+
+  it("matches label text when searching worktrees", () => {
+    const worktrees = filterWorktrees([
+      createWorktree("feature/random-fallback", { label: "Search ranking" }),
+      createWorktree("feature/other"),
+    ], {
+      query: "ranking",
+      showArchived: false,
+    });
+
+    expect(worktrees.map((worktree) => worktree.branch)).toEqual(["feature/random-fallback"]);
   });
 
   it("counts archived matches separately from visible rows", () => {

--- a/frontend/src/lib/worktree-list.ts
+++ b/frontend/src/lib/worktree-list.ts
@@ -19,6 +19,7 @@ export function matchesWorktreeSearch(worktree: WorktreeInfo, query: string): bo
   if (!trimmedQuery) return true;
 
   return [
+    worktree.label ?? "",
     worktree.branch,
     worktree.baseBranch ?? "",
     worktree.profile ?? "",

--- a/packages/api-contract/src/contract.ts
+++ b/packages/api-contract/src/contract.ts
@@ -25,6 +25,8 @@ import {
   SendWorktreePromptRequestSchema,
   SetWorktreeArchivedRequestSchema,
   SetWorktreeArchivedResponseSchema,
+  SetWorktreeLabelRequestSchema,
+  SetWorktreeLabelResponseSchema,
   ToggleEnabledRequestSchema,
   WorktreeDiffResponseSchema,
   WorktreeListResponseSchema,
@@ -56,6 +58,7 @@ export const apiPaths = {
   openWorktree: "/api/worktrees/:name/open",
   closeWorktree: "/api/worktrees/:name/close",
   setWorktreeArchived: "/api/worktrees/:name/archive",
+  setWorktreeLabel: "/api/worktrees/:name/label",
   sendWorktreePrompt: "/api/worktrees/:name/send",
   mergeWorktree: "/api/worktrees/:name/merge",
   fetchWorktreeDiff: "/api/worktrees/:name/diff",
@@ -258,6 +261,16 @@ export const apiContract = c.router({
     body: SetWorktreeArchivedRequestSchema,
     responses: {
       200: SetWorktreeArchivedResponseSchema,
+      ...commonErrorResponses,
+    },
+  },
+  setWorktreeLabel: {
+    method: "PUT",
+    path: apiPaths.setWorktreeLabel,
+    pathParams: WorktreeNameParamsSchema,
+    body: SetWorktreeLabelRequestSchema,
+    responses: {
+      200: SetWorktreeLabelResponseSchema,
       ...commonErrorResponses,
     },
   },

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -118,6 +118,15 @@ export const SetWorktreeArchivedResponseSchema = z.object({
   archived: z.boolean(),
 });
 
+export const SetWorktreeLabelRequestSchema = z.object({
+  label: z.string().trim().max(80).nullable(),
+});
+
+export const SetWorktreeLabelResponseSchema = z.object({
+  ok: z.literal(true),
+  label: z.string().nullable(),
+});
+
 export const ToggleEnabledRequestSchema = z.object({
   enabled: z.boolean(),
 });
@@ -245,6 +254,7 @@ export const AppNotificationSchema = z.object({
 
 export const ProjectWorktreeSnapshotSchema = z.object({
   branch: z.string(),
+  label: z.string().nullable(),
   baseBranch: z.string().optional(),
   path: z.string(),
   dir: z.string(),
@@ -465,6 +475,8 @@ export type CreateWorktreeRequest = z.infer<typeof CreateWorktreeRequestSchema>;
 export type CreateWorktreeResponse = z.infer<typeof CreateWorktreeResponseSchema>;
 export type SetWorktreeArchivedRequest = z.infer<typeof SetWorktreeArchivedRequestSchema>;
 export type SetWorktreeArchivedResponse = z.infer<typeof SetWorktreeArchivedResponseSchema>;
+export type SetWorktreeLabelRequest = z.infer<typeof SetWorktreeLabelRequestSchema>;
+export type SetWorktreeLabelResponse = z.infer<typeof SetWorktreeLabelResponseSchema>;
 export type ToggleEnabledRequest = z.infer<typeof ToggleEnabledRequestSchema>;
 export type SendWorktreePromptRequest = z.infer<typeof SendWorktreePromptRequestSchema>;
 export type AgentsSendMessageRequest = z.infer<typeof AgentsSendMessageRequestSchema>;


### PR DESCRIPTION
## Summary
Add editable workspace labels so users can give worktrees a human-readable name when auto-generated branch names are unclear. Labels are metadata only: branch names, paths, tmux windows, and command identifiers remain unchanged.

## Changes
- Add a typed `PUT /api/worktrees/:name/label` API and persist labels in existing worktree metadata.
- Include labels in backend snapshots, frontend shared types, API mapping, sidebar search, and selected-worktree display.
- Add a pencil action in the worktree header that opens a label dialog; labeled worktrees show the label first and the real branch in small text below.
- Add CLI parity with `webmux label <branch> <label>` and `webmux label <branch> --clear`, plus label-aware `webmux list` output/search and completions.
- Add backend, frontend, API-contract, and CLI tests for label persistence, rendering, search, and command parsing/dispatch.

## Test plan
- [x] `bun run --cwd backend check`
- [x] `bun run --cwd frontend check`
- [x] `bash scripts/run-with-isolated-tmux.sh bun run --cwd backend test`
- [x] `bun run --cwd frontend test`
- [x] `bun test packages/api-contract/src`
- [x] `bun test bin/src`
- [x] `git diff --check`
- [x] Browser smoke check: opened the label dialog from the worktree header and verified no console errors

---
Generated with [Claude Code](https://claude.com/claude-code)