### PR TITLE
fix: move worktree badges below names

### DIFF
--- a/frontend/src/lib/WorktreeList.svelte
+++ b/frontend/src/lib/WorktreeList.svelte
@@ -84,6 +84,7 @@
     {@const isArchived = wt.archived}
     {@const isBusy = isRemoving || isInitializing}
     {@const hasLabel = !!wt.label}
+    {@const hasBadgeRow = isArchived || isCreating || isInitializing || isClosed || wt.prs.length > 0 || !!wt.linearIssue}
     <li class="mb-0.5 group relative {isBusy ? 'opacity-40 pointer-events-none' : ''}">
       <button
         type="button"
@@ -97,44 +98,51 @@
           onselect(wt.branch);
         }}
       >
-        <span class="flex items-center gap-1.5 pr-5 flex-wrap">
-          <div class="flex items-center gap-2 max-w-[90%] min-w-0">
-            {#if row.depth > 0}
-              <span class="shrink-0 text-muted/60">↳</span>
-            {/if}
-            <span class="min-w-0 flex flex-col">
-              <span class="font-medium truncate">{wt.label ?? wt.branch}</span>
-              {#if hasLabel}
-                <span class="text-[10px] leading-tight text-muted truncate">{wt.branch}</span>
+        <span class="flex min-w-0 items-start gap-2 pr-5">
+          {#if row.depth > 0}
+            <span class="shrink-0 text-muted/60">↳</span>
+          {/if}
+          <span class="min-w-0 flex flex-1 flex-col gap-1">
+            <span class="flex min-w-0 items-center gap-1.5" data-worktree-name-row>
+              <span class="min-w-0 flex flex-1 flex-col">
+                <span class="font-medium truncate">{wt.label ?? wt.branch}</span>
+                {#if hasLabel}
+                  <span class="text-[10px] leading-tight text-muted truncate">{wt.branch}</span>
+                {/if}
+              </span>
+              {#if !isCreating && !isInitializing && !isClosed}
+                <span class="shrink-0"><AgentStatusIcon status={wt.agent} size={14} /></span>
+              {/if}
+              {#if notifiedBranches.has(wt.branch)}
+                <span class="shrink-0 w-2 h-2 rounded-full bg-accent"></span>
               {/if}
             </span>
-            {#if isArchived}
-              <span class="shrink-0 text-[10px] px-1.5 py-0.5 rounded border border-edge text-muted">
-                archived
+            {#if hasBadgeRow}
+              <span class="flex min-w-0 flex-wrap items-center gap-1.5" data-worktree-badge-row>
+                {#if isArchived}
+                  <span class="shrink-0 text-[10px] px-1.5 py-0.5 rounded border border-edge text-muted">
+                    archived
+                  </span>
+                {/if}
+                {#if isCreating}
+                  <span class="shrink-0 inline-flex items-center gap-1 text-[10px] text-muted">
+                    <span class="spinner"></span>
+                    {worktreeCreationPhaseLabel(wt.creationPhase)}...
+                  </span>
+                {:else if isInitializing}
+                  <span class="shrink-0 text-[10px] text-muted">opening...</span>
+                {:else if isClosed}
+                  <span class="shrink-0 text-[10px] text-muted">closed</span>
+                {/if}
+                {#each wt.prs as pr (pr.repo)}
+                  <PrBadge {pr} />
+                {/each}
+                {#if wt.linearIssue}
+                  <LinearBadge issue={wt.linearIssue} clickable={false} />
+                {/if}
               </span>
             {/if}
-            {#if isCreating}
-              <span class="shrink-0 inline-flex items-center gap-1 text-[10px] text-muted">
-                <span class="spinner"></span>
-                {worktreeCreationPhaseLabel(wt.creationPhase)}...
-              </span>
-            {:else if isInitializing}
-              <span class="shrink-0 text-[10px] text-muted">opening...</span>
-            {:else if isClosed}
-              <span class="shrink-0 text-[10px] text-muted">closed</span>
-            {:else}
-              <span class="shrink-0"><AgentStatusIcon status={wt.agent} size={14} /></span>
-            {/if}
-            {#if notifiedBranches.has(wt.branch)}
-              <span class="shrink-0 w-2 h-2 rounded-full bg-accent"></span>
-            {/if}
-          </div>
-          {#each wt.prs as pr (pr.repo)}
-            <PrBadge {pr} />
-          {/each}
-          {#if wt.linearIssue}
-            <LinearBadge issue={wt.linearIssue} clickable={false} />
-          {/if}
+          </span>
         </span>
         <span class="flex gap-2 text-[11px] text-muted items-center flex-wrap">
           {#if wt.agentLabel ?? wt.agentName}

--- a/frontend/src/lib/WorktreeList.test.ts
+++ b/frontend/src/lib/WorktreeList.test.ts
@@ -140,6 +140,44 @@ describe("WorktreeList", () => {
     expect(screen.getByText("feature/random-fallback")).toBeInTheDocument();
   });
 
+  it("places archived and closed row badges below the worktree name", () => {
+    render(WorktreeList, {
+      props: {
+        rows: [
+          createRow({
+            ...createWorktree("feature/very-long-archived-closed-name"),
+            archived: true,
+            mux: "",
+          }),
+        ],
+        selected: null,
+        removing: new Set<string>(),
+        initializing: new Set<string>(),
+        archiving: new Set<string>(),
+        notifiedBranches: new Set<string>(),
+        onselect: vi.fn(),
+        onclose: vi.fn(),
+        onarchive: vi.fn(),
+        onmerge: vi.fn(),
+        onremove: vi.fn(),
+      },
+    });
+
+    const name = screen.getByText("feature/very-long-archived-closed-name");
+    const archived = screen.getByText("archived");
+    const closed = screen.getByText("closed");
+    const nameRow = name.closest("[data-worktree-name-row]");
+    const badgeRow = archived.closest("[data-worktree-badge-row]");
+
+    if (!nameRow || !badgeRow) {
+      throw new Error("Expected separate name and badge rows");
+    }
+
+    expect(nameRow).not.toContainElement(archived);
+    expect(badgeRow).toContainElement(archived);
+    expect(badgeRow).toContainElement(closed);
+  });
+
   it("disables the archive action while the row is archiving", async () => {
     render(WorktreeList, {
       props: {


### PR DESCRIPTION
## Summary
Move archived, closed/opening/creating, PR, and Linear badges onto a separate row in the worktree sidebar so long worktree names keep their available width.

## Changes
- Split the worktree list item header into a name row and a wrapping badge row.
- Keep the agent status and notification indicator beside the worktree name.
- Add a regression test for archived and closed badges rendering below the name.

## Test plan
- [x] bun run test -- src/lib/WorktreeList.test.ts
- [x] bun run check
- [x] bun run test

---
Generated with [Claude Code](https://claude.com/claude-code)