### PR TITLE
fix: decouple linear auto-create from dashboard

### DIFF
--- a/backend/src/__tests__/linear-auto-create-service.test.ts
+++ b/backend/src/__tests__/linear-auto-create-service.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { CreateLifecycleWorktreeInput } from "../services/lifecycle-service";
+import type { LinearIssue } from "../services/linear-service";
+import {
+  filterAutoCreateIssues,
+  LINEAR_AUTO_CREATE_POLL_INTERVAL_MS,
+  resetProcessedIssues,
+  startLinearAutoCreateMonitor,
+  type LinearAutoCreateDependencies,
+} from "../services/linear-auto-create-service";
+
+function createIssue(overrides: Partial<LinearIssue> = {}): LinearIssue {
+  const issue: LinearIssue = {
+    id: "issue-1",
+    identifier: "ENG-123",
+    title: "Auto create this",
+    description: "Details",
+    priority: 0,
+    priorityLabel: "No priority",
+    url: "https://linear.app/acme/issue/ENG-123",
+    branchName: "eng-123-auto-create",
+    dueDate: null,
+    updatedAt: "2026-05-13T10:00:00.000Z",
+    state: {
+      name: "Todo",
+      color: "#999999",
+      type: "unstarted",
+    },
+    team: {
+      name: "Engineering",
+      key: "ENG",
+    },
+    labels: [
+      {
+        name: "webmux",
+        color: "#2563eb",
+      },
+    ],
+    project: null,
+  };
+
+  return {
+    ...issue,
+    ...overrides,
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function createDeps(input: {
+  issues?: LinearIssue[];
+  existingBranches?: string[];
+} = {}): {
+  deps: LinearAutoCreateDependencies;
+  created: CreateLifecycleWorktreeInput[];
+  fetchOptions: Array<{ skipCache?: boolean } | undefined>;
+} {
+  const created: CreateLifecycleWorktreeInput[] = [];
+  const fetchOptions: Array<{ skipCache?: boolean } | undefined> = [];
+  const issues = input.issues ?? [];
+  const existingBranches = input.existingBranches ?? [];
+
+  return {
+    created,
+    fetchOptions,
+    deps: {
+      lifecycleService: {
+        async createWorktree(worktreeInput): Promise<{ branch: string; worktreeId: string }> {
+          created.push(worktreeInput);
+          return {
+            branch: worktreeInput.branch ?? "generated-branch",
+            worktreeId: `wt-${created.length}`,
+          };
+        },
+      },
+      git: {
+        listWorktrees: () =>
+          existingBranches.map((branch) => ({
+            path: `/repo/__worktrees/${branch}`,
+            branch,
+            head: "abc123",
+            detached: false,
+            bare: false,
+          })),
+      },
+      projectRoot: "/repo",
+      fetchIssues: async (options) => {
+        fetchOptions.push(options);
+        return {
+          ok: true,
+          data: issues,
+        };
+      },
+    },
+  };
+}
+
+describe("filterAutoCreateIssues", () => {
+  beforeEach(() => {
+    resetProcessedIssues();
+  });
+
+  it("keeps Todo issues with the webmux label that do not already have a worktree", () => {
+    const issue = createIssue();
+    const inProgress = createIssue({
+      id: "issue-2",
+      identifier: "ENG-124",
+      branchName: "eng-124-started",
+      state: {
+        name: "In Progress",
+        color: "#f59e0b",
+        type: "started",
+      },
+    });
+    const missingLabel = createIssue({
+      id: "issue-3",
+      identifier: "ENG-125",
+      branchName: "eng-125-no-label",
+      labels: [],
+    });
+    const existing = createIssue({
+      id: "issue-4",
+      identifier: "ENG-126",
+      branchName: "eng-126-existing",
+    });
+
+    expect(filterAutoCreateIssues([issue, inProgress, missingLabel, existing], ["eng-126-existing"])).toEqual([issue]);
+  });
+});
+
+describe("startLinearAutoCreateMonitor", () => {
+  beforeEach(() => {
+    resetProcessedIssues();
+  });
+
+  it("uses a 30 second poll interval", async () => {
+    let scheduledInterval: number | null = null;
+    const { deps } = createDeps();
+
+    const stop = startLinearAutoCreateMonitor(deps, {
+      intervalDeps: {
+        scheduleEvery: (_handler, intervalMs) => {
+          scheduledInterval = intervalMs;
+          return 1;
+        },
+        cancelSchedule: () => {},
+      },
+    });
+
+    await flushPromises();
+    stop();
+
+    expect(scheduledInterval).toBe(LINEAR_AUTO_CREATE_POLL_INTERVAL_MS);
+    expect(scheduledInterval).toBe(30_000);
+  });
+
+  it("creates worktrees without requiring dashboard activity", async () => {
+    const issue = createIssue();
+    const { deps, created, fetchOptions } = createDeps({ issues: [issue] });
+
+    const stop = startLinearAutoCreateMonitor(deps, {
+      intervalDeps: {
+        scheduleEvery: () => 1,
+        cancelSchedule: () => {},
+      },
+    });
+
+    await flushPromises();
+    stop();
+
+    expect(fetchOptions).toEqual([{ skipCache: true }]);
+    expect(created).toEqual([
+      {
+        mode: "new",
+        branch: issue.branchName,
+        prompt: `${issue.title}\n\n${issue.description}`,
+      },
+    ]);
+  });
+});

--- a/backend/src/__tests__/linear-auto-create-service.test.ts
+++ b/backend/src/__tests__/linear-auto-create-service.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import type { CreateLifecycleWorktreeInput } from "../services/lifecycle-service";
-import type { LinearIssue } from "../services/linear-service";
+import type { FetchIssuesResult, LinearIssue } from "../services/linear-service";
 import {
   filterAutoCreateIssues,
   LINEAR_AUTO_CREATE_POLL_INTERVAL_MS,
   resetProcessedIssues,
+  runLinearAutoCreateOnce,
   startLinearAutoCreateMonitor,
   type LinearAutoCreateDependencies,
 } from "../services/linear-auto-create-service";
@@ -45,15 +46,31 @@ function createIssue(overrides: Partial<LinearIssue> = {}): LinearIssue {
   };
 }
 
-async function flushPromises(): Promise<void> {
-  for (let i = 0; i < 5; i += 1) {
-    await Promise.resolve();
-  }
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveDeferred: ((value: T) => void) | null = null;
+  const promise = new Promise<T>((resolve) => {
+    resolveDeferred = resolve;
+  });
+
+  return {
+    promise,
+    resolve(value) {
+      if (!resolveDeferred) throw new Error("deferred resolver not initialized");
+      resolveDeferred(value);
+    },
+  };
 }
 
 function createDeps(input: {
   issues?: LinearIssue[];
   existingBranches?: string[];
+  fetchResult?: FetchIssuesResult;
+  onFetch?: (options: { skipCache?: boolean } | undefined) => void;
 } = {}): {
   deps: LinearAutoCreateDependencies;
   created: CreateLifecycleWorktreeInput[];
@@ -90,7 +107,8 @@ function createDeps(input: {
       projectRoot: "/repo",
       fetchIssues: async (options) => {
         fetchOptions.push(options);
-        return {
+        input.onFetch?.(options);
+        return input.fetchResult ?? {
           ok: true,
           data: issues,
         };
@@ -132,14 +150,70 @@ describe("filterAutoCreateIssues", () => {
   });
 });
 
+describe("runLinearAutoCreateOnce", () => {
+  beforeEach(() => {
+    resetProcessedIssues();
+  });
+
+  it("creates worktrees without requiring dashboard activity", async () => {
+    const issue = createIssue();
+    const { deps, created, fetchOptions } = createDeps({ issues: [issue] });
+
+    await runLinearAutoCreateOnce(deps);
+
+    expect(fetchOptions).toEqual([{ skipCache: true }]);
+    expect(created).toEqual([
+      {
+        mode: "new",
+        branch: issue.branchName,
+        prompt: `${issue.title}\n\n${issue.description}`,
+      },
+    ]);
+  });
+
+  it("does not create duplicate worktrees for processed issues", async () => {
+    const issue = createIssue();
+    const { deps, created, fetchOptions } = createDeps({ issues: [issue] });
+
+    await runLinearAutoCreateOnce(deps);
+    await runLinearAutoCreateOnce(deps);
+
+    expect(fetchOptions).toEqual([{ skipCache: true }, { skipCache: true }]);
+    expect(created).toEqual([
+      {
+        mode: "new",
+        branch: issue.branchName,
+        prompt: `${issue.title}\n\n${issue.description}`,
+      },
+    ]);
+  });
+
+  it("does not create worktrees when the Linear fetch fails", async () => {
+    const { deps, created, fetchOptions } = createDeps({
+      fetchResult: {
+        ok: false,
+        error: "Linear API 401: Unauthorized",
+      },
+    });
+
+    await runLinearAutoCreateOnce(deps);
+
+    expect(fetchOptions).toEqual([{ skipCache: true }]);
+    expect(created).toEqual([]);
+  });
+});
+
 describe("startLinearAutoCreateMonitor", () => {
   beforeEach(() => {
     resetProcessedIssues();
   });
 
-  it("uses a 30 second poll interval", async () => {
-    let scheduledInterval: number | null = null;
-    const { deps } = createDeps();
+  it("uses a 60 second poll interval", async () => {
+    let scheduledInterval = -1;
+    const fetchStarted = createDeferred<void>();
+    const { deps } = createDeps({
+      onFetch: () => fetchStarted.resolve(undefined),
+    });
 
     const stop = startLinearAutoCreateMonitor(deps, {
       intervalDeps: {
@@ -151,34 +225,10 @@ describe("startLinearAutoCreateMonitor", () => {
       },
     });
 
-    await flushPromises();
+    await fetchStarted.promise;
     stop();
 
     expect(scheduledInterval).toBe(LINEAR_AUTO_CREATE_POLL_INTERVAL_MS);
-    expect(scheduledInterval).toBe(30_000);
-  });
-
-  it("creates worktrees without requiring dashboard activity", async () => {
-    const issue = createIssue();
-    const { deps, created, fetchOptions } = createDeps({ issues: [issue] });
-
-    const stop = startLinearAutoCreateMonitor(deps, {
-      intervalDeps: {
-        scheduleEvery: () => 1,
-        cancelSchedule: () => {},
-      },
-    });
-
-    await flushPromises();
-    stop();
-
-    expect(fetchOptions).toEqual([{ skipCache: true }]);
-    expect(created).toEqual([
-      {
-        mode: "new",
-        branch: issue.branchName,
-        prompt: `${issue.title}\n\n${issue.description}`,
-      },
-    ]);
+    expect(scheduledInterval).toBe(60_000);
   });
 });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -122,7 +122,6 @@ function startLinearAutoCreate(): void {
     lifecycleService,
     git,
     projectRoot: PROJECT_DIR,
-    isActive: hasRecentDashboardActivity,
   });
 }
 

--- a/backend/src/services/linear-auto-create-service.ts
+++ b/backend/src/services/linear-auto-create-service.ts
@@ -1,16 +1,28 @@
-import { startSerializedInterval } from "../lib/async";
+import { startSerializedInterval, type SerializedIntervalDependencies } from "../lib/async";
 import { log } from "../lib/log";
 import { branchMatchesIssue, fetchAssignedIssues, type LinearIssue } from "./linear-service";
-import type { LifecycleService } from "./lifecycle-service";
+import type { CreateLifecycleWorktreeInput } from "./lifecycle-service";
 import type { GitGateway } from "../adapters/git";
 
-const POLL_INTERVAL_MS = 15_000;
+export const LINEAR_AUTO_CREATE_POLL_INTERVAL_MS = 30_000;
+
+export interface LinearAutoCreateLifecycleService {
+  createWorktree(input: CreateLifecycleWorktreeInput): Promise<{
+    branch: string;
+    worktreeId: string;
+  }>;
+}
 
 export interface LinearAutoCreateDependencies {
-  lifecycleService: LifecycleService;
-  git: GitGateway;
+  lifecycleService: LinearAutoCreateLifecycleService;
+  git: Pick<GitGateway, "listWorktrees">;
   projectRoot: string;
-  isActive: () => boolean;
+  fetchIssues?: typeof fetchAssignedIssues;
+}
+
+export interface LinearAutoCreateMonitorOptions<THandle = ReturnType<typeof setInterval>> {
+  intervalMs?: number;
+  intervalDeps?: SerializedIntervalDependencies<THandle>;
 }
 
 /** Issue IDs for which worktrees have been successfully created.
@@ -33,12 +45,8 @@ export function filterAutoCreateIssues(
 }
 
 async function runAutoCreate(deps: LinearAutoCreateDependencies): Promise<void> {
-  if (!deps.isActive()) {
-    log.debug("[linear-auto-create] skipping: no active clients");
-    return;
-  }
-
-  const result = await fetchAssignedIssues({ skipCache: true });
+  const fetchIssues = deps.fetchIssues ?? fetchAssignedIssues;
+  const result = await fetchIssues({ skipCache: true });
   if (!result.ok) {
     log.error(`[linear-auto-create] failed to fetch issues: ${result.error}`);
     return;
@@ -77,13 +85,16 @@ async function runAutoCreate(deps: LinearAutoCreateDependencies): Promise<void> 
 
 /** Start periodic polling for new Linear Todo issues and auto-create worktrees.
  *  Returns a cleanup function that stops the monitor. */
-export function startLinearAutoCreateMonitor(
+export function startLinearAutoCreateMonitor<THandle = ReturnType<typeof setInterval>>(
   deps: LinearAutoCreateDependencies,
+  options: LinearAutoCreateMonitorOptions<THandle> = {},
 ): () => void {
-  log.info("[linear-auto-create] monitor started");
+  const intervalMs = options.intervalMs ?? LINEAR_AUTO_CREATE_POLL_INTERVAL_MS;
+  log.info(`[linear-auto-create] monitor started (interval: ${intervalMs}ms)`);
   return startSerializedInterval(
     () => runAutoCreate(deps),
-    POLL_INTERVAL_MS,
+    intervalMs,
+    options.intervalDeps,
   );
 }
 

--- a/backend/src/services/linear-auto-create-service.ts
+++ b/backend/src/services/linear-auto-create-service.ts
@@ -4,7 +4,7 @@ import { branchMatchesIssue, fetchAssignedIssues, type LinearIssue } from "./lin
 import type { CreateLifecycleWorktreeInput } from "./lifecycle-service";
 import type { GitGateway } from "../adapters/git";
 
-export const LINEAR_AUTO_CREATE_POLL_INTERVAL_MS = 30_000;
+export const LINEAR_AUTO_CREATE_POLL_INTERVAL_MS = 60_000;
 
 export interface LinearAutoCreateLifecycleService {
   createWorktree(input: CreateLifecycleWorktreeInput): Promise<{
@@ -20,9 +20,8 @@ export interface LinearAutoCreateDependencies {
   fetchIssues?: typeof fetchAssignedIssues;
 }
 
-export interface LinearAutoCreateMonitorOptions<THandle = ReturnType<typeof setInterval>> {
-  intervalMs?: number;
-  intervalDeps?: SerializedIntervalDependencies<THandle>;
+export interface LinearAutoCreateMonitorOptions {
+  intervalDeps?: SerializedIntervalDependencies<unknown>;
 }
 
 /** Issue IDs for which worktrees have been successfully created.
@@ -44,7 +43,7 @@ export function filterAutoCreateIssues(
   });
 }
 
-async function runAutoCreate(deps: LinearAutoCreateDependencies): Promise<void> {
+export async function runLinearAutoCreateOnce(deps: LinearAutoCreateDependencies): Promise<void> {
   const fetchIssues = deps.fetchIssues ?? fetchAssignedIssues;
   const result = await fetchIssues({ skipCache: true });
   if (!result.ok) {
@@ -85,15 +84,14 @@ async function runAutoCreate(deps: LinearAutoCreateDependencies): Promise<void> 
 
 /** Start periodic polling for new Linear Todo issues and auto-create worktrees.
  *  Returns a cleanup function that stops the monitor. */
-export function startLinearAutoCreateMonitor<THandle = ReturnType<typeof setInterval>>(
+export function startLinearAutoCreateMonitor(
   deps: LinearAutoCreateDependencies,
-  options: LinearAutoCreateMonitorOptions<THandle> = {},
+  options: LinearAutoCreateMonitorOptions = {},
 ): () => void {
-  const intervalMs = options.intervalMs ?? LINEAR_AUTO_CREATE_POLL_INTERVAL_MS;
-  log.info(`[linear-auto-create] monitor started (interval: ${intervalMs}ms)`);
-  return startSerializedInterval(
-    () => runAutoCreate(deps),
-    intervalMs,
+  log.info(`[linear-auto-create] monitor started (interval: ${LINEAR_AUTO_CREATE_POLL_INTERVAL_MS}ms)`);
+  return startSerializedInterval<unknown>(
+    () => runLinearAutoCreateOnce(deps),
+    LINEAR_AUTO_CREATE_POLL_INTERVAL_MS,
     options.intervalDeps,
   );
 }


### PR DESCRIPTION
## Summary
Make Linear auto-create worktrees run as backend automation while `webmux serve` is running, regardless of whether the dashboard UI is open or active. The poll interval is now 60 seconds.

## Changes
- Remove the dashboard activity gate from the Linear auto-create monitor wiring.
- Change the Linear auto-create poll interval from 15 seconds to 60 seconds.
- Keep the monitor options minimal by removing the unused interval override and generic scheduler handle type.
- Add focused backend tests for filtering, interval selection, UI-independent creation, duplicate prevention, and Linear fetch failures.

## Test plan
- [x] `bun install`
- [x] `bun run --cwd backend check`
- [x] `bun test backend/src/__tests__/linear-auto-create-service.test.ts backend/src/__tests__/linear-service.test.ts`
- [x] `bash scripts/run-with-isolated-tmux.sh bun run --cwd backend test`
- [x] `git diff --check`

---
Generated with [Claude Code](https://claude.com/claude-code)