### PR TITLE
feat: redirect /<prefix> across symmetric webmux instances

### DIFF
--- a/backend/src/__tests__/domain-policies.test.ts
+++ b/backend/src/__tests__/domain-policies.test.ts
@@ -74,6 +74,12 @@ describe("isValidInstancePrefix", () => {
     expect(isValidInstancePrefix("has space")).toBe(false);
     expect(isValidInstancePrefix("")).toBe(false);
   });
+
+  it("rejects reserved path segments owned by the route map", () => {
+    expect(isValidInstancePrefix("api")).toBe(false);
+    expect(isValidInstancePrefix("ws")).toBe(false);
+    expect(isValidInstancePrefix("assets")).toBe(false);
+  });
 });
 
 describe("deriveInstancePrefix", () => {
@@ -93,5 +99,11 @@ describe("deriveInstancePrefix", () => {
 
   it("sanitizes weird basenames", () => {
     expect(deriveInstancePrefix("/projects/My Cool App!", [])).toBe("my-cool-app");
+  });
+
+  it("never returns a reserved prefix even when the basename matches one", () => {
+    expect(deriveInstancePrefix("/srv/api", [])).toBe("api-2");
+    expect(deriveInstancePrefix("/srv/ws", [])).toBe("ws-2");
+    expect(deriveInstancePrefix("/srv/assets", [])).toBe("assets-2");
   });
 });

--- a/backend/src/__tests__/domain-policies.test.ts
+++ b/backend/src/__tests__/domain-policies.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { allocateServicePorts } from "../domain/policies";
+import {
+  allocateServicePorts,
+  deriveInstancePrefix,
+  isValidInstancePrefix,
+  sanitizeInstancePrefix,
+} from "../domain/policies";
 
 describe("allocateServicePorts", () => {
   it("allocates the first free slot across existing worktree metadata", () => {
@@ -38,5 +43,55 @@ describe("allocateServicePorts", () => {
       FRONTEND_PORT: 3020,
       PORT: 5121,
     });
+  });
+});
+
+describe("sanitizeInstancePrefix", () => {
+  it("lowercases and replaces non-alphanumerics with hyphens", () => {
+    expect(sanitizeInstancePrefix("My Project")).toBe("my-project");
+    expect(sanitizeInstancePrefix("Some_Repo.v2")).toBe("some-repo-v2");
+  });
+
+  it("collapses runs of hyphens and trims edges", () => {
+    expect(sanitizeInstancePrefix("--__foo bar__--")).toBe("foo-bar");
+  });
+
+  it("returns an empty string when nothing usable remains", () => {
+    expect(sanitizeInstancePrefix("***")).toBe("");
+  });
+});
+
+describe("isValidInstancePrefix", () => {
+  it("accepts lowercase alphanumeric and hyphens", () => {
+    expect(isValidInstancePrefix("webmux")).toBe(true);
+    expect(isValidInstancePrefix("webmux-2")).toBe(true);
+    expect(isValidInstancePrefix("ab12-cd")).toBe(true);
+  });
+
+  it("rejects uppercase, leading hyphen, or invalid chars", () => {
+    expect(isValidInstancePrefix("Webmux")).toBe(false);
+    expect(isValidInstancePrefix("-bad")).toBe(false);
+    expect(isValidInstancePrefix("has space")).toBe(false);
+    expect(isValidInstancePrefix("")).toBe(false);
+  });
+});
+
+describe("deriveInstancePrefix", () => {
+  it("returns the basename when no collision", () => {
+    expect(deriveInstancePrefix("/home/me/projects/webmux", [])).toBe("webmux");
+    expect(deriveInstancePrefix("/srv/widgets/", [])).toBe("widgets");
+  });
+
+  it("falls back to a default when the basename has no alphanumerics", () => {
+    expect(deriveInstancePrefix("/repo/...", [])).toBe("webmux");
+  });
+
+  it("appends -2, -3, ... to avoid collisions", () => {
+    expect(deriveInstancePrefix("/a/webmux", ["webmux"])).toBe("webmux-2");
+    expect(deriveInstancePrefix("/a/webmux", ["webmux", "webmux-2"])).toBe("webmux-3");
+  });
+
+  it("sanitizes weird basenames", () => {
+    expect(deriveInstancePrefix("/projects/My Cool App!", [])).toBe("my-cool-app");
   });
 });

--- a/backend/src/__tests__/instance-registry.test.ts
+++ b/backend/src/__tests__/instance-registry.test.ts
@@ -72,6 +72,37 @@ describe("instance-registry", () => {
     expect(registry.listLive().map((e) => e.port)).toEqual([5111]);
   });
 
+  it("rejects entries whose prefix is not a valid instance prefix", async () => {
+    const { dir, registry } = await freshRegistry();
+    registry.register(makeEntry({ port: 5111, prefix: "good" }));
+    // Forge an entry with a bad prefix (uppercase, reserved, etc.)
+    writeFileSync(join(dir, "5112.json"), JSON.stringify({
+      prefix: "BadPrefix",
+      port: 5112,
+      projectDir: "/x",
+      pid: process.pid,
+      startedAt: 1,
+    }));
+    writeFileSync(join(dir, "5113.json"), JSON.stringify({
+      prefix: "api",
+      port: 5113,
+      projectDir: "/x",
+      pid: process.pid,
+      startedAt: 1,
+    }));
+
+    expect(registry.listLive().map((e) => e.port)).toEqual([5111]);
+  });
+
+  it("deregister with a mismatched expectedPid leaves the entry alone", async () => {
+    const { registry } = await freshRegistry();
+    registry.register(makeEntry({ port: 5111, pid: 1234 }));
+    registry.deregister(5111, 9999);
+    expect(registry.listLive()).toHaveLength(1);
+    registry.deregister(5111, 1234);
+    expect(registry.listLive()).toEqual([]);
+  });
+
   it("deregister is a no-op when the file is missing", async () => {
     const { registry } = await freshRegistry();
     expect(() => registry.deregister(9999)).not.toThrow();

--- a/backend/src/__tests__/instance-registry.test.ts
+++ b/backend/src/__tests__/instance-registry.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFileSync } from "node:fs";
+import { createInstanceRegistry, type InstanceEntry } from "../adapters/instance-registry";
+
+describe("instance-registry", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function freshRegistry(): Promise<{ dir: string; registry: ReturnType<typeof createInstanceRegistry> }> {
+    const dir = await mkdtemp(join(tmpdir(), "webmux-instance-registry-"));
+    tempDirs.push(dir);
+    return { dir, registry: createInstanceRegistry(dir) };
+  }
+
+  function makeEntry(overrides: Partial<InstanceEntry> = {}): InstanceEntry {
+    return {
+      prefix: "demo",
+      port: 5111,
+      projectDir: "/repo/demo",
+      pid: process.pid,
+      startedAt: Date.now(),
+      ...overrides,
+    };
+  }
+
+  it("registers, lists, and deregisters an entry", async () => {
+    const { registry } = await freshRegistry();
+    const entry = makeEntry();
+
+    registry.register(entry);
+    expect(registry.listLive()).toEqual([entry]);
+
+    registry.deregister(entry.port);
+    expect(registry.listLive()).toEqual([]);
+  });
+
+  it("returns an empty list when the registry directory does not exist", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "webmux-instance-registry-"));
+    await rm(dir, { recursive: true, force: true });
+    const registry = createInstanceRegistry(dir);
+    expect(registry.listLive()).toEqual([]);
+  });
+
+  it("evicts entries whose PID is no longer alive", async () => {
+    const { dir, registry } = await freshRegistry();
+    const live = makeEntry({ port: 5111 });
+    const dead = makeEntry({ port: 5112, pid: 1 << 30 });
+
+    registry.register(live);
+    registry.register(dead);
+
+    const result = registry.listLive();
+    expect(result.map((e) => e.port)).toEqual([live.port]);
+
+    // The dead entry's file should be cleaned up on read.
+    const remaining = createInstanceRegistry(dir).listLive();
+    expect(remaining).toEqual([live]);
+  });
+
+  it("ignores malformed json files", async () => {
+    const { dir, registry } = await freshRegistry();
+    registry.register(makeEntry({ port: 5111 }));
+    writeFileSync(join(dir, "5112.json"), "not json");
+    writeFileSync(join(dir, "5113.json"), JSON.stringify({ prefix: 1 }));
+
+    expect(registry.listLive().map((e) => e.port)).toEqual([5111]);
+  });
+
+  it("deregister is a no-op when the file is missing", async () => {
+    const { registry } = await freshRegistry();
+    expect(() => registry.deregister(9999)).not.toThrow();
+  });
+
+  it("overwrites an existing entry when registering the same port twice", async () => {
+    const { registry } = await freshRegistry();
+    registry.register(makeEntry({ port: 5111, prefix: "alpha" }));
+    registry.register(makeEntry({ port: 5111, prefix: "beta" }));
+
+    const entries = registry.listLive();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.prefix).toBe("beta");
+  });
+});

--- a/backend/src/__tests__/peer-routing-integration.test.ts
+++ b/backend/src/__tests__/peer-routing-integration.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { resolvePeerRedirect } from "../domain/peer-routing";
+import type { InstanceEntry } from "../adapters/instance-registry";
+
+/** Spin a tiny Bun.serve mirroring the production wiring: peer-redirect
+ *  check → fallback to a 200 "ok" SPA stub. Exercises the actual HTTP
+ *  surface (status codes, Location header shape, query preservation). */
+function startTestServer(peers: InstanceEntry[], selfPort: number): {
+  port: number;
+  stop: () => void;
+} {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      const redirect = resolvePeerRedirect(url, peers, selfPort);
+      if (redirect) return redirect;
+      // SPA fallback stub.
+      return new Response(`ok ${url.pathname}`, { headers: { "Content-Type": "text/plain" } });
+    },
+  });
+  return {
+    port: server.port ?? 0,
+    stop: () => { void server.stop(true); },
+  };
+}
+
+function peer(overrides: Partial<InstanceEntry> = {}): InstanceEntry {
+  return {
+    prefix: "demo",
+    port: 5111,
+    projectDir: "/repo/demo",
+    pid: process.pid,
+    startedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("peer-routing HTTP integration", () => {
+  const teardown: Array<() => void> = [];
+  afterEach(() => {
+    while (teardown.length > 0) teardown.pop()?.();
+  });
+
+  it("returns a 302 with Location pointing to the peer port", async () => {
+    const PEER_PORT = 12000;
+    const { port, stop } = startTestServer([peer({ prefix: "alpha", port: PEER_PORT })], 5111);
+    teardown.push(stop);
+
+    const res = await fetch(`http://127.0.0.1:${port}/alpha/foo/bar?x=1&y=2`, { redirect: "manual" });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(`http://127.0.0.1:${PEER_PORT}/foo/bar?x=1&y=2`);
+  });
+
+  it("redirects to the request hostname, not 127.0.0.1, when accessed via a name", async () => {
+    const { port, stop } = startTestServer([peer({ prefix: "beta", port: 12001 })], 5111);
+    teardown.push(stop);
+
+    const res = await fetch(`http://localhost:${port}/beta`, { redirect: "manual" });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(`http://localhost:12001/`);
+  });
+
+  it("rewrites same-instance prefix and serves the SPA fallback", async () => {
+    const { port, stop } = startTestServer([peer({ prefix: "self", port: 0 })], 0);
+    teardown.push(stop);
+
+    const res = await fetch(`http://127.0.0.1:${port}/self/deep/link`, { redirect: "manual" });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok /deep/link");
+  });
+
+  it("passes unknown prefixes through to the SPA fallback (no 404 spam)", async () => {
+    const { port, stop } = startTestServer([peer({ prefix: "alpha", port: 12000 })], 5111);
+    teardown.push(stop);
+
+    const res = await fetch(`http://127.0.0.1:${port}/unknownproject`, { redirect: "manual" });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok /unknownproject");
+  });
+
+  it("does not redirect for reserved segments even if a peer registers one", async () => {
+    const { port, stop } = startTestServer([peer({ prefix: "api", port: 99999 })], 5111);
+    teardown.push(stop);
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/config`, { redirect: "manual" });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok /api/config");
+  });
+});

--- a/backend/src/__tests__/peer-routing.test.ts
+++ b/backend/src/__tests__/peer-routing.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { decidePeerRouting } from "../domain/peer-routing";
+import type { InstanceEntry } from "../adapters/instance-registry";
+
+function peer(overrides: Partial<InstanceEntry> = {}): InstanceEntry {
+  return {
+    prefix: "demo",
+    port: 5111,
+    projectDir: "/repo/demo",
+    pid: 123,
+    startedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("decidePeerRouting", () => {
+  it("passes through when there is no recognizable prefix segment", () => {
+    expect(decidePeerRouting("/", [peer()], 9999).kind).toBe("passthrough");
+    expect(decidePeerRouting("", [peer()], 9999).kind).toBe("passthrough");
+    expect(decidePeerRouting("/Some-Caps", [peer()], 9999).kind).toBe("passthrough");
+  });
+
+  it("passes through reserved segments", () => {
+    expect(decidePeerRouting("/api/config", [peer({ prefix: "api" })], 9999).kind).toBe("passthrough");
+    expect(decidePeerRouting("/ws/anything", [peer({ prefix: "ws" })], 9999).kind).toBe("passthrough");
+    expect(decidePeerRouting("/assets/foo.js", [peer({ prefix: "assets" })], 9999).kind).toBe("passthrough");
+  });
+
+  it("passes through when the prefix is not in the registry", () => {
+    const peers = [peer({ prefix: "alpha", port: 5111 })];
+    expect(decidePeerRouting("/beta", peers, 5111).kind).toBe("passthrough");
+    expect(decidePeerRouting("/beta/whatever", peers, 5111).kind).toBe("passthrough");
+  });
+
+  it("redirects to the peer's port when the prefix matches a different instance", () => {
+    const peers = [peer({ prefix: "windmill", port: 5112 })];
+    expect(decidePeerRouting("/windmill", peers, 5111)).toEqual({
+      kind: "redirect",
+      port: 5112,
+      path: "/",
+    });
+    expect(decidePeerRouting("/windmill/foo/bar", peers, 5111)).toEqual({
+      kind: "redirect",
+      port: 5112,
+      path: "/foo/bar",
+    });
+  });
+
+  it("rewrites in place when the matching peer is this instance", () => {
+    const peers = [peer({ prefix: "webmux", port: 5111 })];
+    expect(decidePeerRouting("/webmux", peers, 5111)).toEqual({
+      kind: "rewrite",
+      path: "/",
+    });
+    expect(decidePeerRouting("/webmux/deep/link", peers, 5111)).toEqual({
+      kind: "rewrite",
+      path: "/deep/link",
+    });
+  });
+
+  it("preserves trailing path segments and ignores query (caller appends it)", () => {
+    const peers = [peer({ prefix: "wm", port: 5113 })];
+    expect(decidePeerRouting("/wm/x/y/z", peers, 5111)).toEqual({
+      kind: "redirect",
+      port: 5113,
+      path: "/x/y/z",
+    });
+  });
+});

--- a/backend/src/adapters/instance-registry.ts
+++ b/backend/src/adapters/instance-registry.ts
@@ -1,6 +1,10 @@
+// Sync Node fs APIs on purpose: register/deregister run from synchronous startup
+// and `process.on("exit")` paths where async (Bun.write) would not flush in time.
 import { mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { log } from "../lib/log";
+import { isValidInstancePrefix } from "../domain/policies";
 
 export interface InstanceEntry {
   prefix: string;
@@ -12,21 +16,27 @@ export interface InstanceEntry {
 
 export interface InstanceRegistry {
   register(entry: InstanceEntry): void;
-  deregister(port: number): void;
+  /** Delete the entry at `port`. When `expectedPid` is provided, the entry is
+   *  only deleted if its `pid` matches — guards against a late shutdown handler
+   *  clobbering a successor process that has reused the same port. */
+  deregister(port: number, expectedPid?: number): void;
   listLive(): InstanceEntry[];
 }
 
 function defaultRegistryDir(): string {
-  const home = Bun.env.HOME ?? "/root";
-  return join(home, ".webmux", "instances");
+  return join(homedir(), ".webmux", "instances");
 }
 
+/** A live PID is one we can signal. `ESRCH` means "no such process" — that's
+ *  the only signal we treat as "dead". Other errors (notably `EPERM` for a PID
+ *  we don't own, e.g. a `sudo`-started peer) mean the process exists but we
+ *  can't touch it — still alive from the registry's perspective. */
 function isAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (err: unknown) {
+    return (err as { code?: string } | null)?.code !== "ESRCH";
   }
 }
 
@@ -34,6 +44,7 @@ function isInstanceEntry(value: unknown): value is InstanceEntry {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
   return typeof v.prefix === "string"
+    && isValidInstancePrefix(v.prefix)
     && typeof v.port === "number"
     && typeof v.projectDir === "string"
     && typeof v.pid === "number"
@@ -69,7 +80,16 @@ export function createInstanceRegistry(dir: string = defaultRegistryDir()): Inst
       renameSync(tmpPath, finalPath);
     },
 
-    deregister(port: number): void {
+    deregister(port: number, expectedPid?: number): void {
+      if (expectedPid !== undefined) {
+        const filename = `${port}.json`;
+        const entry = readEntry(filename);
+        if (entry && entry.pid !== expectedPid) {
+          // The entry belongs to a successor process that reused our port.
+          // Leave it alone.
+          return;
+        }
+      }
       try {
         unlinkSync(entryPath(port));
       } catch (err: unknown) {

--- a/backend/src/adapters/instance-registry.ts
+++ b/backend/src/adapters/instance-registry.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { log } from "../lib/log";
+
+export interface InstanceEntry {
+  prefix: string;
+  port: number;
+  projectDir: string;
+  pid: number;
+  startedAt: number;
+}
+
+export interface InstanceRegistry {
+  register(entry: InstanceEntry): void;
+  deregister(port: number): void;
+  listLive(): InstanceEntry[];
+}
+
+function defaultRegistryDir(): string {
+  const home = Bun.env.HOME ?? "/root";
+  return join(home, ".webmux", "instances");
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isInstanceEntry(value: unknown): value is InstanceEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.prefix === "string"
+    && typeof v.port === "number"
+    && typeof v.projectDir === "string"
+    && typeof v.pid === "number"
+    && typeof v.startedAt === "number";
+}
+
+export function createInstanceRegistry(dir: string = defaultRegistryDir()): InstanceRegistry {
+  function ensureDir(): void {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  function entryPath(port: number): string {
+    return join(dir, `${port}.json`);
+  }
+
+  function readEntry(filename: string): InstanceEntry | null {
+    try {
+      const raw = readFileSync(join(dir, filename), "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      return isInstanceEntry(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return {
+    register(entry: InstanceEntry): void {
+      ensureDir();
+      const finalPath = entryPath(entry.port);
+      const tmpPath = `${finalPath}.${process.pid}.${Date.now()}.tmp`;
+      const text = `${JSON.stringify(entry, null, 2)}\n`;
+      writeFileSync(tmpPath, text);
+      renameSync(tmpPath, finalPath);
+    },
+
+    deregister(port: number): void {
+      try {
+        unlinkSync(entryPath(port));
+      } catch (err: unknown) {
+        const code = (err as { code?: string } | null)?.code;
+        if (code !== "ENOENT") {
+          log.debug(`[instance-registry] deregister(${port}) failed: ${String(err)}`);
+        }
+      }
+    },
+
+    listLive(): InstanceEntry[] {
+      let filenames: string[];
+      try {
+        filenames = readdirSync(dir).filter((name) => name.endsWith(".json"));
+      } catch {
+        return [];
+      }
+
+      const live: InstanceEntry[] = [];
+      for (const filename of filenames) {
+        const entry = readEntry(filename);
+        if (!entry) continue;
+        if (!isAlive(entry.pid)) {
+          try {
+            unlinkSync(join(dir, filename));
+          } catch {
+            // best effort — another process may have cleaned it already
+          }
+          continue;
+        }
+        live.push(entry);
+      }
+      return live;
+    },
+  };
+}

--- a/backend/src/domain/peer-routing.ts
+++ b/backend/src/domain/peer-routing.ts
@@ -1,0 +1,35 @@
+import type { InstanceEntry } from "../adapters/instance-registry";
+import { isValidInstancePrefix } from "./policies";
+
+export type PeerRouting =
+  | { kind: "passthrough" }
+  | { kind: "rewrite"; path: string }
+  | { kind: "redirect"; port: number; path: string };
+
+/** Pure decision: given a request pathname and the live peer list, decide
+ *  whether to redirect to a peer, rewrite the URL in place (when the prefix
+ *  matches this instance), or let the request pass through to the SPA handler. */
+export function decidePeerRouting(
+  pathname: string,
+  peers: InstanceEntry[],
+  selfPort: number,
+): PeerRouting {
+  const firstSegment = pathname.split("/")[1];
+  if (!firstSegment || !isValidInstancePrefix(firstSegment)) {
+    return { kind: "passthrough" };
+  }
+  // Defense-in-depth: paths handled by the route map above never reach this code,
+  // but if a peer ever picked a colliding prefix we'd refuse to shadow them.
+  if (firstSegment === "api" || firstSegment === "ws" || firstSegment === "assets") {
+    return { kind: "passthrough" };
+  }
+
+  const peer = peers.find((entry) => entry.prefix === firstSegment);
+  if (!peer) return { kind: "passthrough" };
+
+  const remaining = pathname.slice(firstSegment.length + 1) || "/";
+  if (peer.port === selfPort) {
+    return { kind: "rewrite", path: remaining };
+  }
+  return { kind: "redirect", port: peer.port, path: remaining };
+}

--- a/backend/src/domain/peer-routing.ts
+++ b/backend/src/domain/peer-routing.ts
@@ -1,5 +1,5 @@
 import type { InstanceEntry } from "../adapters/instance-registry";
-import { isValidInstancePrefix } from "./policies";
+import { isValidInstancePrefix, RESERVED_INSTANCE_PREFIXES } from "./policies";
 
 export type PeerRouting =
   | { kind: "passthrough" }
@@ -19,8 +19,9 @@ export function decidePeerRouting(
     return { kind: "passthrough" };
   }
   // Defense-in-depth: paths handled by the route map above never reach this code,
-  // but if a peer ever picked a colliding prefix we'd refuse to shadow them.
-  if (firstSegment === "api" || firstSegment === "ws" || firstSegment === "assets") {
+  // and `deriveInstancePrefix` refuses to mint these prefixes, but if a peer ever
+  // managed to register one we'd refuse to shadow the server's own routes.
+  if (RESERVED_INSTANCE_PREFIXES.has(firstSegment)) {
     return { kind: "passthrough" };
   }
 
@@ -32,4 +33,23 @@ export function decidePeerRouting(
     return { kind: "rewrite", path: remaining };
   }
   return { kind: "redirect", port: peer.port, path: remaining };
+}
+
+/** Apply `decidePeerRouting` to a parsed request URL, returning either a 302
+ *  Response or `null` (with `url.pathname` possibly rewritten for same-instance
+ *  prefixes). The redirect Location pins to `url.hostname`, never the Host
+ *  header — the URL constructor has already sanitized it. */
+export function resolvePeerRedirect(
+  url: URL,
+  peers: InstanceEntry[],
+  selfPort: number,
+): Response | null {
+  const decision = decidePeerRouting(url.pathname, peers, selfPort);
+  if (decision.kind === "passthrough") return null;
+  if (decision.kind === "rewrite") {
+    url.pathname = decision.path;
+    return null;
+  }
+  const location = `${url.protocol}//${url.hostname}:${decision.port}${decision.path}${url.search}`;
+  return new Response(null, { status: 302, headers: { Location: location } });
 }

--- a/backend/src/domain/policies.ts
+++ b/backend/src/domain/policies.ts
@@ -4,6 +4,7 @@ import type { WorktreeMeta } from "./model";
 const INVALID_BRANCH_CHARS_RE = /[~^:?*\[\]\\]+/g;
 const UNSAFE_ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const VALID_WORKTREE_NAME_RE = /^[a-z0-9][a-z0-9\-_./]*$/;
+const VALID_INSTANCE_PREFIX_RE = /^[a-z0-9][a-z0-9\-]*$/;
 
 export function sanitizeBranchName(raw: string): string {
   return raw
@@ -28,6 +29,36 @@ export function isValidWorktreeName(name: string): boolean {
 
 export function isValidEnvKey(key: string): boolean {
   return UNSAFE_ENV_KEY_RE.test(key);
+}
+
+/** Sanitize a string into a URL-path-friendly prefix: lowercase, hyphenated,
+ *  alphanumeric only. Returns empty if nothing usable remains. */
+export function sanitizeInstancePrefix(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+export function isValidInstancePrefix(value: string): boolean {
+  return VALID_INSTANCE_PREFIX_RE.test(value);
+}
+
+/** Derive a webmux instance prefix from a project directory basename.
+ *  Adds `-2`, `-3`, … suffixes to avoid collisions with already-taken prefixes. */
+export function deriveInstancePrefix(projectDir: string, takenPrefixes: Iterable<string>): string {
+  const basename = projectDir.replace(/\/+$/, "").split("/").pop() ?? "webmux";
+  const base = sanitizeInstancePrefix(basename) || "webmux";
+
+  const taken = new Set(takenPrefixes);
+  if (!taken.has(base)) return base;
+
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${base}-${Date.now()}`;
 }
 
 export function allocateServicePorts(

--- a/backend/src/domain/policies.ts
+++ b/backend/src/domain/policies.ts
@@ -31,6 +31,11 @@ export function isValidEnvKey(key: string): boolean {
   return UNSAFE_ENV_KEY_RE.test(key);
 }
 
+/** Path segments that the server's route map already owns. A derived instance
+ *  prefix must never collide with these or `/<prefix>` would be shadowed and
+ *  cross-instance redirects to that project would silently fail. */
+export const RESERVED_INSTANCE_PREFIXES: ReadonlySet<string> = new Set(["api", "ws", "assets"]);
+
 /** Sanitize a string into a URL-path-friendly prefix: lowercase, hyphenated,
  *  alphanumeric only. Returns empty if nothing usable remains. */
 export function sanitizeInstancePrefix(raw: string): string {
@@ -42,16 +47,17 @@ export function sanitizeInstancePrefix(raw: string): string {
 }
 
 export function isValidInstancePrefix(value: string): boolean {
-  return VALID_INSTANCE_PREFIX_RE.test(value);
+  return VALID_INSTANCE_PREFIX_RE.test(value) && !RESERVED_INSTANCE_PREFIXES.has(value);
 }
 
 /** Derive a webmux instance prefix from a project directory basename.
- *  Adds `-2`, `-3`, … suffixes to avoid collisions with already-taken prefixes. */
+ *  Adds `-2`, `-3`, … suffixes to avoid collisions with already-taken prefixes
+ *  and with reserved path segments owned by the server's route map. */
 export function deriveInstancePrefix(projectDir: string, takenPrefixes: Iterable<string>): string {
   const basename = projectDir.replace(/\/+$/, "").split("/").pop() ?? "webmux";
   const base = sanitizeInstancePrefix(basename) || "webmux";
 
-  const taken = new Set(takenPrefixes);
+  const taken = new Set<string>([...takenPrefixes, ...RESERVED_INSTANCE_PREFIXES]);
   if (!taken.has(base)) return base;
 
   for (let n = 2; n < 1000; n++) {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -96,8 +96,10 @@ import { WorktreeConversationService } from "./services/worktree-conversation-se
 import { parseRuntimeEvent } from "./domain/events";
 import type { AgentsUiConversationEvent, AgentsUiWorktreeConversationResponse } from "./domain/agents-ui";
 import type { OneshotMeta, ProjectSnapshot, WorktreeSnapshot } from "./domain/model";
-import { isValidBranchName, isValidWorktreeName } from "./domain/policies";
+import { deriveInstancePrefix, isValidBranchName, isValidInstancePrefix, isValidWorktreeName } from "./domain/policies";
 import { createWebmuxRuntime } from "./runtime";
+import { createInstanceRegistry, type InstanceEntry } from "./adapters/instance-registry";
+import { decidePeerRouting } from "./domain/peer-routing";
 
 const PORT = parseInt(Bun.env.PORT || "5111", 10);
 const STATIC_DIR = Bun.env.WEBMUX_STATIC_DIR || "";
@@ -1483,8 +1485,9 @@ function parseAgentIdParam(params: Record<string, string>):
 
 // --- Server ---
 
-Bun.serve({
-  port: PORT,
+function startServer(port: number): ReturnType<typeof Bun.serve> {
+  return Bun.serve({
+  port,
   idleTimeout: 255, // seconds; worktree removal can take >10s
 
   routes: {
@@ -1738,10 +1741,27 @@ Bun.serve({
         return jsonResponse({ ok: true });
       },
     },
+
+    [apiPaths.fetchInstances]: {
+      GET: () => jsonResponse({
+        instances: instanceRegistry.listLive()
+          .filter((entry) => entry.port !== BOUND_PORT)
+          .map((entry) => ({
+            prefix: entry.prefix,
+            port: entry.port,
+            projectDir: entry.projectDir,
+            startedAt: entry.startedAt,
+          })),
+      }),
+    },
   },
 
   async fetch(req) {
     const url = new URL(req.url);
+
+    const peerRedirect = resolvePeerRedirect(url, req.headers.get("host"));
+    if (peerRedirect) return peerRedirect;
+
     // Static frontend files in production mode (fallback for unmatched routes)
     if (STATIC_DIR) {
       const rawPath = url.pathname === "/" ? "index.html" : url.pathname;
@@ -1893,7 +1913,77 @@ Bun.serve({
       }
     },
   },
-});
+  });
+}
+
+function actualPort(server: ReturnType<typeof Bun.serve>, requested: number): number {
+  return server.port ?? requested;
+}
+
+function bindServer(): number {
+  try {
+    return actualPort(startServer(PORT), PORT);
+  } catch (err: unknown) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code !== "EADDRINUSE") throw err;
+    log.info(`[serve] port ${PORT} in use; binding to a free port`);
+    return actualPort(startServer(0), 0);
+  }
+}
+
+const BOUND_PORT = bindServer();
+
+const instanceRegistry = createInstanceRegistry();
+const explicitPrefix = Bun.env.WEBMUX_PREFIX?.trim();
+const livePeers = instanceRegistry.listLive();
+const takenPrefixes = livePeers.map((peer) => peer.prefix);
+const INSTANCE_PREFIX = explicitPrefix && isValidInstancePrefix(explicitPrefix)
+  ? explicitPrefix
+  : deriveInstancePrefix(PROJECT_DIR, takenPrefixes);
+
+const selfEntry: InstanceEntry = {
+  prefix: INSTANCE_PREFIX,
+  port: BOUND_PORT,
+  projectDir: PROJECT_DIR,
+  pid: process.pid,
+  startedAt: Date.now(),
+};
+instanceRegistry.register(selfEntry);
+log.info(`[serve] registered instance prefix=${INSTANCE_PREFIX} port=${BOUND_PORT}`);
+
+function deregisterSelf(): void {
+  try {
+    instanceRegistry.deregister(BOUND_PORT);
+  } catch {
+    // best effort
+  }
+}
+process.on("SIGINT", () => { deregisterSelf(); process.exit(0); });
+process.on("SIGTERM", () => { deregisterSelf(); process.exit(0); });
+process.on("exit", deregisterSelf);
+
+function safeHostname(rawHost: string | null): string {
+  if (!rawHost) return "127.0.0.1";
+  // Strip any CR/LF and trailing port, keep only the hostname or bracketed IPv6.
+  const sanitized = rawHost.replace(/[\r\n\0]/g, "").trim();
+  if (!sanitized) return "127.0.0.1";
+  const ipv6 = sanitized.match(/^(\[[^\]]+\])(?::\d+)?$/);
+  if (ipv6) return ipv6[1] ?? "127.0.0.1";
+  const hostAndPort = sanitized.match(/^([^:]+)(?::\d+)?$/);
+  return hostAndPort?.[1] ?? "127.0.0.1";
+}
+
+function resolvePeerRedirect(url: URL, hostHeader: string | null): Response | null {
+  const decision = decidePeerRouting(url.pathname, instanceRegistry.listLive(), BOUND_PORT);
+  if (decision.kind === "passthrough") return null;
+  if (decision.kind === "rewrite") {
+    url.pathname = decision.path;
+    return null;
+  }
+  const hostname = safeHostname(hostHeader);
+  const location = `${url.protocol}//${hostname}:${decision.port}${decision.path}${url.search}`;
+  return new Response(null, { status: 302, headers: { Location: location } });
+}
 
 
 // Ensure tmux server is running (needs at least one session to persist)
@@ -1927,12 +2017,12 @@ if (config.workspace.autoPull.enabled) {
   );
 }
 
-log.info(`Dev Dashboard API running at http://localhost:${PORT}`);
+log.info(`Dev Dashboard API running at http://localhost:${BOUND_PORT}`);
 const nets = networkInterfaces();
 for (const addrs of Object.values(nets)) {
   for (const a of addrs ?? []) {
     if (a.family === "IPv4" && !a.internal) {
-      log.info(`  Network: http://${a.address}:${PORT}`);
+      log.info(`  Network: http://${a.address}:${BOUND_PORT}`);
     }
   }
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -99,7 +99,7 @@ import type { OneshotMeta, ProjectSnapshot, WorktreeSnapshot } from "./domain/mo
 import { deriveInstancePrefix, isValidBranchName, isValidInstancePrefix, isValidWorktreeName } from "./domain/policies";
 import { createWebmuxRuntime } from "./runtime";
 import { createInstanceRegistry, type InstanceEntry } from "./adapters/instance-registry";
-import { decidePeerRouting } from "./domain/peer-routing";
+import { resolvePeerRedirect } from "./domain/peer-routing";
 
 const PORT = parseInt(Bun.env.PORT || "5111", 10);
 const STATIC_DIR = Bun.env.WEBMUX_STATIC_DIR || "";
@@ -1759,7 +1759,7 @@ function startServer(port: number): ReturnType<typeof Bun.serve> {
   async fetch(req) {
     const url = new URL(req.url);
 
-    const peerRedirect = resolvePeerRedirect(url, req.headers.get("host"));
+    const peerRedirect = resolvePeerRedirect(url, instanceRegistry.listLive(), BOUND_PORT);
     if (peerRedirect) return peerRedirect;
 
     // Static frontend files in production mode (fallback for unmatched routes)
@@ -1953,7 +1953,7 @@ log.info(`[serve] registered instance prefix=${INSTANCE_PREFIX} port=${BOUND_POR
 
 function deregisterSelf(): void {
   try {
-    instanceRegistry.deregister(BOUND_PORT);
+    instanceRegistry.deregister(BOUND_PORT, process.pid);
   } catch {
     // best effort
   }
@@ -1961,29 +1961,6 @@ function deregisterSelf(): void {
 process.on("SIGINT", () => { deregisterSelf(); process.exit(0); });
 process.on("SIGTERM", () => { deregisterSelf(); process.exit(0); });
 process.on("exit", deregisterSelf);
-
-function safeHostname(rawHost: string | null): string {
-  if (!rawHost) return "127.0.0.1";
-  // Strip any CR/LF and trailing port, keep only the hostname or bracketed IPv6.
-  const sanitized = rawHost.replace(/[\r\n\0]/g, "").trim();
-  if (!sanitized) return "127.0.0.1";
-  const ipv6 = sanitized.match(/^(\[[^\]]+\])(?::\d+)?$/);
-  if (ipv6) return ipv6[1] ?? "127.0.0.1";
-  const hostAndPort = sanitized.match(/^([^:]+)(?::\d+)?$/);
-  return hostAndPort?.[1] ?? "127.0.0.1";
-}
-
-function resolvePeerRedirect(url: URL, hostHeader: string | null): Response | null {
-  const decision = decidePeerRouting(url.pathname, instanceRegistry.listLive(), BOUND_PORT);
-  if (decision.kind === "passthrough") return null;
-  if (decision.kind === "rewrite") {
-    url.pathname = decision.path;
-    return null;
-  }
-  const hostname = safeHostname(hostHeader);
-  const location = `${url.protocol}//${hostname}:${decision.port}${decision.path}${url.search}`;
-  return new Response(null, { status: 302, headers: { Location: location } });
-}
 
 
 // Ensure tmux server is running (needs at least one session to persist)

--- a/bin/src/webmux.test.ts
+++ b/bin/src/webmux.test.ts
@@ -62,11 +62,13 @@ describe("webmux entrypoint", () => {
 
   it("parses serve flags after the subcommand", () => {
     delete process.env.PORT;
+    delete process.env.WEBMUX_PREFIX;
 
     expect(parseRootArgs(["serve", "--port", "8080", "--debug"])).toEqual({
       port: 8080,
       debug: true,
       app: false,
+      prefix: null,
       command: "serve",
       commandArgs: [],
     });
@@ -74,23 +76,58 @@ describe("webmux entrypoint", () => {
 
   it("parses --app flag", () => {
     delete process.env.PORT;
+    delete process.env.WEBMUX_PREFIX;
 
     expect(parseRootArgs(["serve", "--app"])).toEqual({
       port: 5111,
       debug: false,
       app: true,
+      prefix: null,
       command: "serve",
       commandArgs: [],
     });
   });
 
+  it("parses --prefix flag", () => {
+    delete process.env.PORT;
+    delete process.env.WEBMUX_PREFIX;
+
+    expect(parseRootArgs(["serve", "--prefix", "myproj"])).toEqual({
+      port: 5111,
+      debug: false,
+      app: false,
+      prefix: "myproj",
+      command: "serve",
+      commandArgs: [],
+    });
+  });
+
+  it("reads WEBMUX_PREFIX from env", () => {
+    delete process.env.PORT;
+    process.env.WEBMUX_PREFIX = "envproj";
+    try {
+      expect(parseRootArgs(["serve"])).toEqual({
+        port: 5111,
+        debug: false,
+        app: false,
+        prefix: "envproj",
+        command: "serve",
+        commandArgs: [],
+      });
+    } finally {
+      delete process.env.WEBMUX_PREFIX;
+    }
+  });
+
   it("leaves service subcommand flags untouched", () => {
     delete process.env.PORT;
+    delete process.env.WEBMUX_PREFIX;
 
     expect(parseRootArgs(["service", "install", "--port", "8080"])).toEqual({
       port: 5111,
       debug: false,
       app: false,
+      prefix: null,
       command: "service",
       commandArgs: ["install", "--port", "8080"],
     });
@@ -98,11 +135,13 @@ describe("webmux entrypoint", () => {
 
   it("parses prune as a worktree command", () => {
     delete process.env.PORT;
+    delete process.env.WEBMUX_PREFIX;
 
     expect(parseRootArgs(["prune"])).toEqual({
       port: 5111,
       debug: false,
       app: false,
+      prefix: null,
       command: "prune",
       commandArgs: [],
     });
@@ -110,11 +149,13 @@ describe("webmux entrypoint", () => {
 
   it("parses archive as a worktree command", () => {
     delete process.env.PORT;
+    delete process.env.WEBMUX_PREFIX;
 
     expect(parseRootArgs(["archive", "feature/search"])).toEqual({
       port: 5111,
       debug: false,
       app: false,
+      prefix: null,
       command: "archive",
       commandArgs: ["feature/search"],
     });
@@ -122,11 +163,13 @@ describe("webmux entrypoint", () => {
 
   it("parses label as a worktree command", () => {
     delete process.env.PORT;
+    delete process.env.WEBMUX_PREFIX;
 
     expect(parseRootArgs(["label", "feature/search", "Search", "ranking"])).toEqual({
       port: 5111,
       debug: false,
       app: false,
+      prefix: null,
       command: "label",
       commandArgs: ["feature/search", "Search", "ranking"],
     });

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -243,7 +243,7 @@ function openAppMode(url: string): void {
 function pipeWithPrefix(
   stream: ReadableStream<Uint8Array>,
   prefix: string,
-  onTrigger?: { text: string; callback: () => void },
+  onTrigger?: { text: string; callback: (line: string) => void },
 ): void {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
@@ -261,7 +261,7 @@ function pipeWithPrefix(
         console.log(`${prefix} ${line}`);
         if (onTrigger && !fired && line.includes(onTrigger.text)) {
           fired = true;
-          onTrigger.callback();
+          onTrigger.callback(line);
         }
       }
     }
@@ -391,7 +391,7 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
     process.exit(1);
   }
 
-  console.log(`Starting webmux on port ${parsed.port}...`);
+  console.log(`Starting webmux on port ${parsed.port} (falls back to a free port if taken)...`);
 
   const be = Bun.spawn(["bun", backendEntry], {
     env: { ...baseEnv, WEBMUX_STATIC_DIR: staticDir },
@@ -403,7 +403,12 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
   if (parsed.app) {
     pipeWithPrefix(be.stdout, "[BE]", {
       text: "Dev Dashboard API running at",
-      callback: () => openAppMode(`http://localhost:${parsed.port}`),
+      callback: (line) => {
+        // Backend logs the actual bound port (which may differ from parsed.port
+        // when the requested port was taken and we fell back to a free one).
+        const match = line.match(/https?:\/\/[^\s]+/);
+        openAppMode(match?.[0] ?? `http://localhost:${parsed.port}`);
+      },
     });
   } else {
     pipeWithPrefix(be.stdout, "[BE]");

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -35,7 +35,9 @@ Usage:
   webmux completion   Generate shell completion script (bash, zsh)
 
 Options:
-  --port N            Set port (default: 5111)
+  --port N            Set port (default: 5111). Falls back to a free port when taken.
+  --prefix NAME       URL prefix this instance registers under (default: project dir basename).
+                      Other webmux instances on this machine will redirect /<NAME> to this port.
   --app               Open dashboard in browser app mode (minimal window)
   --debug             Show debug-level logs
   --version           Show version number
@@ -43,6 +45,7 @@ Options:
 
 Environment:
   PORT             Same as --port (flag takes precedence)
+  WEBMUX_PREFIX    Same as --prefix
 `);
 }
 
@@ -52,6 +55,7 @@ interface ParsedRootArgs {
   port: number;
   debug: boolean;
   app: boolean;
+  prefix: string | null;
   command: RootCommand;
   commandArgs: string[];
 }
@@ -79,6 +83,7 @@ function isRootCommand(value: string): value is NonNullable<RootCommand> {
 
 function isServeRootOption(value: string): boolean {
   return value === "--port"
+    || value === "--prefix"
     || value === "--app"
     || value === "--debug"
     || value === "--help"
@@ -91,6 +96,7 @@ export function parseRootArgs(args: string[]): ParsedRootArgs {
   let port = parseInt(process.env.PORT || "5111", 10);
   let debug = false;
   let app = false;
+  let prefix: string | null = process.env.WEBMUX_PREFIX?.trim() || null;
   let command: RootCommand = null;
   const commandArgs: string[] = [];
 
@@ -113,6 +119,15 @@ export function parseRootArgs(args: string[]): ParsedRootArgs {
         if (Number.isNaN(port)) {
           throw new Error("Error: --port requires a numeric value");
         }
+        index += 1;
+        break;
+      }
+      case "--prefix": {
+        const value = args[index + 1];
+        if (!value) {
+          throw new Error("Error: --prefix requires a value");
+        }
+        prefix = value.trim();
         index += 1;
         break;
       }
@@ -143,6 +158,7 @@ export function parseRootArgs(args: string[]): ParsedRootArgs {
     port,
     debug,
     app,
+    prefix,
     command,
     commandArgs,
   };
@@ -339,6 +355,7 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
     ...process.env,
     PORT: String(parsed.port),
     WEBMUX_PROJECT_DIR: process.cwd(),
+    ...(parsed.prefix ? { WEBMUX_PREFIX: parsed.prefix } : {}),
     ...(parsed.debug ? { WEBMUX_DEBUG: "1" } : {}),
   };
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1033,9 +1033,9 @@
     >
       <div class="p-4 border-b border-edge">
         <div class="flex items-center justify-between">
-          <div class="flex items-center gap-2 min-w-0">
+          <div class="flex items-center gap-1 min-w-0">
             <h1 class="text-base font-semibold truncate">{config.name ?? "Dashboard"}</h1>
-            <InstanceSwitcher />
+            <InstanceSwitcher selfName={config.name ?? "Dashboard"} />
           </div>
           <div class="flex items-center gap-2">
             <button

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -16,6 +16,7 @@
   import MobileChatSurface from "./lib/MobileChatSurface.svelte";
   import WorktreeLabelDialog from "./lib/WorktreeLabelDialog.svelte";
   import SidebarRepoRow from "./lib/SidebarRepoRow.svelte";
+  import InstanceSwitcher from "./lib/InstanceSwitcher.svelte";
   import Toggle from "./lib/Toggle.svelte";
   import type {
     AvailableBranch,
@@ -1032,7 +1033,10 @@
     >
       <div class="p-4 border-b border-edge">
         <div class="flex items-center justify-between">
-          <h1 class="text-base font-semibold">{config.name ?? "Dashboard"}</h1>
+          <div class="flex items-center gap-2 min-w-0">
+            <h1 class="text-base font-semibold truncate">{config.name ?? "Dashboard"}</h1>
+            <InstanceSwitcher />
+          </div>
           <div class="flex items-center gap-2">
             <button
               class="h-8 px-2 gap-1.5 rounded-md border border-edge bg-surface text-accent text-xs flex items-center justify-center cursor-pointer hover:bg-hover disabled:opacity-50 disabled:cursor-not-allowed"

--- a/frontend/src/lib/InstanceSwitcher.svelte
+++ b/frontend/src/lib/InstanceSwitcher.svelte
@@ -3,9 +3,13 @@
   import { fetchInstances } from "./api";
   import type { InstanceSummary } from "./types";
 
+  let { selfName }: { selfName: string } = $props();
+
   let instances = $state<InstanceSummary[]>([]);
   let open = $state(false);
-  let containerEl: HTMLDivElement | undefined = $state();
+  let triggerEl: HTMLButtonElement | undefined = $state();
+  let menuEl: HTMLDivElement | undefined = $state();
+  let menuRect = $state<{ top: number; left: number; width: number }>({ top: 0, left: 0, width: 0 });
 
   onMount(() => {
     void load();
@@ -19,56 +23,82 @@
     }
   }
 
+  function positionMenu(): void {
+    if (!triggerEl) return;
+    const rect = triggerEl.getBoundingClientRect();
+    const width = Math.max(rect.width + 80, 240);
+    const left = Math.max(8, Math.min(rect.left, window.innerWidth - width - 8));
+    menuRect = { top: rect.bottom + 4, left, width };
+  }
+
   function toggle(): void {
     if (open) {
       open = false;
       return;
     }
     void load();
+    positionMenu();
     open = true;
   }
 
   function handleDocumentClick(event: MouseEvent): void {
     if (!open) return;
-    if (!containerEl) return;
-    if (event.target instanceof Node && containerEl.contains(event.target)) return;
+    const target = event.target;
+    if (!(target instanceof Node)) return;
+    if (triggerEl?.contains(target)) return;
+    if (menuEl?.contains(target)) return;
     open = false;
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (open && event.key === "Escape") {
+      open = false;
+      triggerEl?.focus();
+    }
   }
 </script>
 
-<svelte:window onclick={handleDocumentClick} />
+<svelte:window onclick={handleDocumentClick} onkeydown={handleKeydown} onresize={() => open && positionMenu()} onscroll={() => open && positionMenu()} />
 
 {#if instances.length > 0}
-  <div bind:this={containerEl} class="relative">
-    <button
-      type="button"
-      class="h-7 px-2 rounded-md border border-edge bg-surface text-muted text-[11px] flex items-center gap-1 hover:bg-hover hover:text-primary"
-      title="Switch project"
-      onclick={toggle}
-      aria-haspopup="listbox"
-      aria-expanded={open}
+  <button
+    bind:this={triggerEl}
+    type="button"
+    class="shrink-0 h-6 w-6 inline-flex items-center justify-center rounded-md text-muted hover:bg-hover hover:text-primary"
+    title="Switch project"
+    aria-haspopup="menu"
+    aria-expanded={open}
+    onclick={toggle}
+  >
+    <svg viewBox="0 0 12 12" width="10" height="10" aria-hidden="true">
+      <path d="M2 4 L6 8 L10 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  </button>
+
+  {#if open}
+    <div
+      bind:this={menuEl}
+      role="menu"
+      class="fixed z-50 rounded-md border border-edge bg-surface shadow-lg overflow-hidden"
+      style="top: {menuRect.top}px; left: {menuRect.left}px; width: {menuRect.width}px;"
     >
-      <span>{instances.length} other{instances.length === 1 ? "" : "s"}</span>
-      <span class="text-[9px]">▾</span>
-    </button>
-    {#if open}
-      <div
-        role="listbox"
-        class="absolute z-40 right-0 mt-1 min-w-[220px] max-w-[320px] rounded-md border border-edge bg-surface shadow-lg overflow-hidden"
-      >
-        {#each instances as instance (instance.port)}
-          <a
-            href={`/${instance.prefix}`}
-            class="block px-3 py-2 text-[12px] hover:bg-hover"
-            role="option"
-            aria-selected="false"
-          >
-            <div class="text-primary font-medium truncate">{instance.prefix}</div>
-            <div class="text-muted text-[11px] truncate">{instance.projectDir}</div>
-            <div class="text-muted text-[10px]">:{instance.port}</div>
-          </a>
-        {/each}
+      <div class="px-3 py-2 text-[11px] text-muted uppercase tracking-wide border-b border-edge">
+        Projects
       </div>
-    {/if}
-  </div>
+      <div class="px-3 py-2 bg-hover/50">
+        <div class="text-primary font-medium text-[12px] truncate">{selfName}</div>
+        <div class="text-muted text-[10px]">current</div>
+      </div>
+      {#each instances as instance (instance.port)}
+        <a
+          href={`/${instance.prefix}`}
+          class="block px-3 py-2 text-[12px] hover:bg-hover border-t border-edge"
+          role="menuitem"
+        >
+          <div class="text-primary font-medium truncate">{instance.prefix}</div>
+          <div class="text-muted text-[11px] truncate">{instance.projectDir}</div>
+        </a>
+      {/each}
+    </div>
+  {/if}
 {/if}

--- a/frontend/src/lib/InstanceSwitcher.svelte
+++ b/frontend/src/lib/InstanceSwitcher.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { fetchInstances } from "./api";
+  import type { InstanceSummary } from "./types";
+
+  let instances = $state<InstanceSummary[]>([]);
+  let open = $state(false);
+  let containerEl: HTMLDivElement | undefined = $state();
+
+  onMount(() => {
+    void load();
+  });
+
+  async function load(): Promise<void> {
+    try {
+      instances = await fetchInstances();
+    } catch {
+      instances = [];
+    }
+  }
+
+  function toggle(): void {
+    if (open) {
+      open = false;
+      return;
+    }
+    void load();
+    open = true;
+  }
+
+  function handleDocumentClick(event: MouseEvent): void {
+    if (!open) return;
+    if (!containerEl) return;
+    if (event.target instanceof Node && containerEl.contains(event.target)) return;
+    open = false;
+  }
+</script>
+
+<svelte:window onclick={handleDocumentClick} />
+
+{#if instances.length > 0}
+  <div bind:this={containerEl} class="relative">
+    <button
+      type="button"
+      class="h-7 px-2 rounded-md border border-edge bg-surface text-muted text-[11px] flex items-center gap-1 hover:bg-hover hover:text-primary"
+      title="Switch project"
+      onclick={toggle}
+      aria-haspopup="listbox"
+      aria-expanded={open}
+    >
+      <span>{instances.length} other{instances.length === 1 ? "" : "s"}</span>
+      <span class="text-[9px]">▾</span>
+    </button>
+    {#if open}
+      <div
+        role="listbox"
+        class="absolute z-40 right-0 mt-1 min-w-[220px] max-w-[320px] rounded-md border border-edge bg-surface shadow-lg overflow-hidden"
+      >
+        {#each instances as instance (instance.port)}
+          <a
+            href={`/${instance.prefix}`}
+            class="block px-3 py-2 text-[12px] hover:bg-hover"
+            role="option"
+            aria-selected="false"
+          >
+            <div class="text-primary font-medium truncate">{instance.prefix}</div>
+            <div class="text-muted text-[11px] truncate">{instance.projectDir}</div>
+            <div class="text-muted text-[10px]">:{instance.port}</div>
+          </a>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   AgentsUiWorktreeConversationResponse,
   AppNotification,
   FileUploadResult,
+  InstanceSummary,
   PostWorktreeToLinearResponse,
   PostWorktreeToLinearTarget,
   ProjectWorktreeSnapshot,
@@ -177,6 +178,11 @@ export function deleteAgent(id: string): Promise<void> {
 
 export function validateAgent(body: UpsertCustomAgentRequest): Promise<ValidateCustomAgentResponse> {
   return api.validateAgent({ body });
+}
+
+export async function fetchInstances(): Promise<InstanceSummary[]> {
+  const response = await api.fetchInstances();
+  return response.instances;
 }
 
 export function subscribeNotifications(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -46,6 +46,7 @@ export type {
   PostWorktreeToLinearResponse,
   PostWorktreeToLinearTarget,
   FromLinearInput,
+  InstanceSummary,
   PrComment,
   PrEntry,
   ProfileConfig,

--- a/packages/api-contract/src/contract.ts
+++ b/packages/api-contract/src/contract.ts
@@ -37,6 +37,7 @@ import {
   WorktreeNameParamsSchema,
   NotificationIdParamsSchema,
   LinearIssuesResponseSchema,
+  InstancesResponseSchema,
 } from "./schemas";
 
 const c = initContract();
@@ -74,6 +75,7 @@ export const apiPaths = {
   pullMain: "/api/pull-main",
   fetchCiLogs: "/api/ci-logs/:runId",
   dismissNotification: "/api/notifications/:id/dismiss",
+  fetchInstances: "/api/instances",
 } as const;
 
 const commonErrorResponses = {
@@ -383,6 +385,14 @@ export const apiContract = c.router({
       200: OkResponseSchema,
       400: ErrorResponseSchema,
       404: ErrorResponseSchema,
+    },
+  },
+  fetchInstances: {
+    method: "GET",
+    path: apiPaths.fetchInstances,
+    responses: {
+      200: InstancesResponseSchema,
+      500: ErrorResponseSchema,
     },
   },
 }, {

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -519,6 +519,20 @@ export const RunIdParamsSchema = z.object({
   runId: NumberLikePathParamSchema,
 });
 
+export const InstanceSummarySchema = z.object({
+  prefix: z.string(),
+  port: z.number(),
+  projectDir: z.string(),
+  startedAt: z.number(),
+});
+
+export const InstancesResponseSchema = z.object({
+  instances: z.array(InstanceSummarySchema),
+});
+
+export type InstanceSummary = z.infer<typeof InstanceSummarySchema>;
+export type InstancesResponse = z.infer<typeof InstancesResponseSchema>;
+
 export type BuiltInAgentId = z.infer<typeof BuiltInAgentIdSchema>;
 export type AgentId = z.infer<typeof AgentIdSchema>;
 export type AgentKind = z.infer<typeof AgentKindSchema>;


### PR DESCRIPTION
## Summary

Make running multiple webmux instances on the same machine seamless: typing `localhost:<any-webmux-port>/<project-prefix>` jumps to that project's webmux, no matter which instance is answering, no matter which port it's actually on. No new daemon, no proxy plumbing — peers register themselves in a shared registry and 302-redirect requests to one another.

## Changes

- **Shared registry**: every `webmux serve` writes `~/.webmux/instances/<port>.json` (atomic write via temp+rename) and deletes it on `SIGINT`/`SIGTERM`/`exit`. `listLive()` filters out entries whose PID is no longer alive and self-evicts them.
- **Port fallback**: if the requested PORT is in use, `Bun.serve({ port: 0 })` picks a free one. The actual bound port is logged.
- **Prefix derivation**: basename of the project dir, sanitized, with `-2`, `-3`, … on collision. Overridable via `--prefix` flag or `WEBMUX_PREFIX` env.
- **Redirect handler**: a new pure decider (`backend/src/domain/peer-routing.ts`) decides between `passthrough`, `rewrite` (same-instance prefix → strip and serve normally), or `redirect` (peer-instance prefix → 302). Wired into the SPA `fetch` fallback after the route map, so `/api/*` and `/ws/*` literal routes still match first. Path + query string preserved. `Host` header sanitized.
- **`GET /api/instances`**: returns the live peer list minus self. Added to the api-contract.
- **UI**: a small `InstanceSwitcher.svelte` dropdown next to the project name in the sidebar header. Hidden when no peers exist (single-instance users see no change). Each entry links to `/<prefix>` which the backend redirects.

## Test plan

- [x] `bun run --cwd backend check` and `bun run --cwd frontend check` — clean.
- [x] `bun test` — backend 327, packages 5, bin 109, frontend 73 all passing.
- [x] New unit tests:
  - `backend/src/__tests__/instance-registry.test.ts` — register / list / deregister / dead-pid eviction / malformed-file tolerance / overwrite-on-same-port.
  - `backend/src/__tests__/peer-routing.test.ts` — passthrough, redirect, rewrite, reserved-segment guard, path preservation.
  - `backend/src/__tests__/domain-policies.test.ts` — `sanitizeInstancePrefix`, `isValidInstancePrefix`, `deriveInstancePrefix` (basename + collision suffix).
  - `bin/src/webmux.test.ts` — `--prefix` flag and `WEBMUX_PREFIX` env.
- [x] Manual end-to-end with two real `bun bin/webmux.js serve` instances:
  - First instance grabs port 5311 and registers as `webmux`.
  - Second instance (different project dir) finds port in use, falls back to OS-picked free port, registers under its own prefix.
  - `localhost:5311/<other-prefix>` → 302 → second instance's port.
  - `localhost:5311/webmux` → 200 (same-instance rewrite).
  - `localhost:5311/doesnotexist` → 200 (SPA passthrough; no 404 noise).
  - Path + query string preserved through redirects.
  - SIGTERM on either instance deletes its registry file.
  - Forged stale entry (alive-looking JSON, unused PID) is evicted automatically on the next `listLive()`.

## Out of scope (deliberate)

- Reverse proxying (HTTP or WS). Redirect-only by user request.
- SPA path-prefix awareness (`<base href>`, relative URLs) — not needed without proxying.
- Cross-instance Linear watcher dedup. Separable.
- TLS / auth between peers. Localhost only.

---
Generated with [Claude Code](https://claude.com/claude-code)