### PR TITLE
feat: auto-pick a free port in webmux service install

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1932,15 +1932,28 @@ function actualPort(server: ReturnType<typeof Bun.serve>, requested: number): nu
   return server.port ?? requested;
 }
 
+const MAX_INCREMENTAL_BIND_ATTEMPTS = 100;
+
+/** Bind the HTTP server, walking PORT, PORT+1, … up to a sane cap on
+ *  `EADDRINUSE`. Predictable nearby ports (5111 → 5112 → 5113) match the
+ *  install-time port picker and keep instances easy to spot in `lsof`. If
+ *  the whole window is taken (extremely unlikely), fall back to an OS-picked
+ *  ephemeral port so the process never crashes on startup. */
 function bindServer(): number {
-  try {
-    return actualPort(startServer(PORT), PORT);
-  } catch (err: unknown) {
-    const code = (err as { code?: string } | null)?.code;
-    if (code !== "EADDRINUSE") throw err;
-    log.info(`[serve] port ${PORT} in use; binding to a free port`);
-    return actualPort(startServer(0), 0);
+  let candidate = PORT;
+  for (let attempt = 0; attempt < MAX_INCREMENTAL_BIND_ATTEMPTS; attempt++) {
+    try {
+      const server = startServer(candidate);
+      if (attempt > 0) log.info(`[serve] port ${PORT} in use; bound to ${actualPort(server, candidate)}`);
+      return actualPort(server, candidate);
+    } catch (err: unknown) {
+      const code = (err as { code?: string } | null)?.code;
+      if (code !== "EADDRINUSE") throw err;
+      candidate += 1;
+    }
   }
+  log.info(`[serve] ports ${PORT}..${PORT + MAX_INCREMENTAL_BIND_ATTEMPTS - 1} all in use; falling back to an OS-picked port`);
+  return actualPort(startServer(0), 0);
 }
 
 const BOUND_PORT = bindServer();

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1933,13 +1933,30 @@ function actualPort(server: ReturnType<typeof Bun.serve>, requested: number): nu
 }
 
 const MAX_INCREMENTAL_BIND_ATTEMPTS = 100;
+const PORT_STRICT = Bun.env.WEBMUX_PORT_STRICT === "1";
 
-/** Bind the HTTP server, walking PORT, PORT+1, … up to a sane cap on
- *  `EADDRINUSE`. Predictable nearby ports (5111 → 5112 → 5113) match the
- *  install-time port picker and keep instances easy to spot in `lsof`. If
- *  the whole window is taken (extremely unlikely), fall back to an OS-picked
- *  ephemeral port so the process never crashes on startup. */
+/** Bind the HTTP server.
+ *  - In strict mode (`WEBMUX_PORT_STRICT=1`, set by the CLI when `--port` or
+ *    `PORT` was supplied explicitly): bind exactly `PORT` and fail loudly on
+ *    `EADDRINUSE` — the user pinned that port, surfacing the conflict beats
+ *    silently landing somewhere else.
+ *  - Otherwise (default 5111): walk PORT, PORT+1, … up to a sane cap. Nearby
+ *    ports match the install-time picker and stay easy to spot in `lsof`. If
+ *    the whole window is taken, fall back to an OS-picked ephemeral port so
+ *    the process never crashes on startup. */
 function bindServer(): number {
+  if (PORT_STRICT) {
+    try {
+      return actualPort(startServer(PORT), PORT);
+    } catch (err: unknown) {
+      const code = (err as { code?: string } | null)?.code;
+      if (code === "EADDRINUSE") {
+        log.error(`[serve] port ${PORT} is in use and was set explicitly; drop --port / PORT to let webmux pick a free port`);
+      }
+      throw err;
+    }
+  }
+
   let candidate = PORT;
   for (let attempt = 0; attempt < MAX_INCREMENTAL_BIND_ATTEMPTS; attempt++) {
     try {

--- a/bin/src/install-ports.test.ts
+++ b/bin/src/install-ports.test.ts
@@ -87,6 +87,63 @@ describe("readPortFromUnit", () => {
   it("returns null for a missing file", () => {
     expect(readPortFromUnit("/no/such/path.service")).toBeNull();
   });
+
+  // Round-trips against the exact strings `service.ts` emits, so a future
+  // re-indent or wrapping change in `generateLaunchdPlist` / `generateSystemdUnit`
+  // surfaces as a failing test rather than a silent regression to "auto-pick".
+  it("round-trips against the systemd unit format service.ts writes", async () => {
+    const dir = await makeTempDir();
+    const filePath = join(dir, "webmux-roundtrip.service");
+    const content = [
+      "[Unit]",
+      "Description=webmux dashboard — roundtrip",
+      "",
+      "[Service]",
+      "Type=simple",
+      "ExecStart=/usr/local/bin/webmux serve --port 5117",
+      "WorkingDirectory=/home/x/proj",
+      "Restart=on-failure",
+      "RestartSec=5",
+      "Environment=PORT=5117",
+      "Environment=WEBMUX_PROJECT_DIR=/home/x/proj",
+      "Environment=PATH=/usr/local/bin",
+      "",
+      "[Install]",
+      "WantedBy=default.target",
+      "",
+    ].join("\n");
+    await writeFile(filePath, content);
+
+    expect(readPortFromUnit(filePath)).toBe(5117);
+  });
+
+  it("round-trips against the launchd plist format service.ts writes", async () => {
+    const dir = await makeTempDir();
+    const filePath = join(dir, "com.webmux.roundtrip.plist");
+    const content = [
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+      "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
+      "<plist version=\"1.0\">",
+      "<dict>",
+      "  <key>Label</key>",
+      "  <string>com.webmux.roundtrip</string>",
+      "  <key>ProgramArguments</key>",
+      "  <array>",
+      "    <string>/usr/local/bin/webmux</string>",
+      "    <string>serve</string>",
+      "    <string>--port</string>",
+      "    <string>5222</string>",
+      "  </array>",
+      "  <key>WorkingDirectory</key>",
+      "  <string>/Users/x/proj</string>",
+      "</dict>",
+      "</plist>",
+      "",
+    ].join("\n");
+    await writeFile(filePath, content);
+
+    expect(readPortFromUnit(filePath)).toBe(5222);
+  });
 });
 
 describe("readInstalledServicePorts", () => {

--- a/bin/src/install-ports.test.ts
+++ b/bin/src/install-ports.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  discoverTakenPorts,
+  pickFreePort,
+  readInstalledServicePorts,
+  readPortFromUnit,
+} from "./install-ports.ts";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const fn = cleanups.pop();
+    if (fn) await fn();
+  }
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "webmux-install-ports-"));
+  cleanups.push(async () => rm(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+describe("pickFreePort", () => {
+  it("returns start when nothing is taken", () => {
+    expect(pickFreePort(5111, [])).toBe(5111);
+  });
+
+  it("returns the lowest free port at or above start", () => {
+    expect(pickFreePort(5111, [5111, 5112, 5114])).toBe(5113);
+  });
+
+  it("ignores taken ports below start", () => {
+    expect(pickFreePort(5111, [5000, 5001, 5111])).toBe(5112);
+  });
+});
+
+describe("readPortFromUnit", () => {
+  it("parses --port out of a systemd unit", async () => {
+    const dir = await makeTempDir();
+    const filePath = join(dir, "webmux-foo.service");
+    await writeFile(
+      filePath,
+      [
+        "[Service]",
+        "Type=simple",
+        "ExecStart=/usr/local/bin/webmux serve --port 5117",
+        "WorkingDirectory=/home/x/proj",
+      ].join("\n"),
+    );
+
+    expect(readPortFromUnit(filePath)).toBe(5117);
+  });
+
+  it("parses --port out of a launchd plist", async () => {
+    const dir = await makeTempDir();
+    const filePath = join(dir, "com.webmux.foo.plist");
+    await writeFile(
+      filePath,
+      [
+        "<plist version=\"1.0\"><dict>",
+        "  <key>ProgramArguments</key>",
+        "  <array>",
+        "    <string>/usr/local/bin/webmux</string>",
+        "    <string>serve</string>",
+        "    <string>--port</string>",
+        "    <string>5222</string>",
+        "  </array>",
+        "</dict></plist>",
+      ].join("\n"),
+    );
+
+    expect(readPortFromUnit(filePath)).toBe(5222);
+  });
+
+  it("returns null for a unit file without --port", async () => {
+    const dir = await makeTempDir();
+    const filePath = join(dir, "other.service");
+    await writeFile(filePath, "ExecStart=/usr/bin/something else\n");
+
+    expect(readPortFromUnit(filePath)).toBeNull();
+  });
+
+  it("returns null for a missing file", () => {
+    expect(readPortFromUnit("/no/such/path.service")).toBeNull();
+  });
+});
+
+describe("readInstalledServicePorts", () => {
+  it("picks up webmux systemd units and ignores unrelated files", async () => {
+    const systemdDir = await makeTempDir();
+    await writeFile(
+      join(systemdDir, "webmux-alpha.service"),
+      "ExecStart=/usr/local/bin/webmux serve --port 5111\n",
+    );
+    await writeFile(
+      join(systemdDir, "webmux-beta.service"),
+      "ExecStart=/usr/local/bin/webmux serve --port 5112\n",
+    );
+    await writeFile(
+      join(systemdDir, "other-app.service"),
+      "ExecStart=/usr/bin/other --port 9999\n",
+    );
+
+    const ports = readInstalledServicePorts({
+      systemdDir,
+      launchdDir: "/no/such/dir",
+    }).sort();
+    expect(ports).toEqual([5111, 5112]);
+  });
+
+  it("picks up webmux launchd plists", async () => {
+    const launchdDir = await makeTempDir();
+    await writeFile(
+      join(launchdDir, "com.webmux.alpha.plist"),
+      [
+        "<plist><dict><array>",
+        "<string>--port</string><string>5300</string>",
+        "</array></dict></plist>",
+      ].join("\n"),
+    );
+
+    const ports = readInstalledServicePorts({
+      systemdDir: "/no/such/dir",
+      launchdDir,
+    });
+    expect(ports).toEqual([5300]);
+  });
+
+  it("excludes the unit file being replaced", async () => {
+    const systemdDir = await makeTempDir();
+    const target = join(systemdDir, "webmux-alpha.service");
+    await writeFile(target, "ExecStart=/usr/local/bin/webmux serve --port 5111\n");
+    await writeFile(
+      join(systemdDir, "webmux-beta.service"),
+      "ExecStart=/usr/local/bin/webmux serve --port 5112\n",
+    );
+
+    const ports = readInstalledServicePorts({
+      systemdDir,
+      launchdDir: "/no/such/dir",
+      excludePath: target,
+    });
+    expect(ports).toEqual([5112]);
+  });
+});
+
+describe("discoverTakenPorts", () => {
+  it("merges live registry ports with installed-unit ports", async () => {
+    const registryDir = await makeTempDir();
+    const systemdDir = await makeTempDir();
+
+    await writeFile(
+      join(registryDir, "5400.json"),
+      JSON.stringify({
+        prefix: "live-one",
+        port: 5400,
+        projectDir: "/tmp/x",
+        pid: process.pid,
+        startedAt: Date.now(),
+      }),
+    );
+    await writeFile(
+      join(systemdDir, "webmux-other.service"),
+      "ExecStart=/usr/local/bin/webmux serve --port 5401\n",
+    );
+
+    const taken = discoverTakenPorts({
+      registryDir,
+      systemdDir,
+      launchdDir: "/no/such/dir",
+    });
+    expect(taken.has(5400)).toBe(true);
+    expect(taken.has(5401)).toBe(true);
+  });
+
+  it("excludes the unit being replaced so reinstall can keep its port", async () => {
+    const registryDir = await makeTempDir();
+    const systemdDir = await makeTempDir();
+    const target = join(systemdDir, "webmux-self.service");
+    await writeFile(target, "ExecStart=/usr/local/bin/webmux serve --port 5500\n");
+
+    const taken = discoverTakenPorts({
+      registryDir,
+      systemdDir,
+      launchdDir: "/no/such/dir",
+      excludeUnitPath: target,
+    });
+    expect(taken.has(5500)).toBe(false);
+  });
+});

--- a/bin/src/install-ports.ts
+++ b/bin/src/install-ports.ts
@@ -6,7 +6,8 @@ import { createInstanceRegistry } from "../../backend/src/adapters/instance-regi
 export const DEFAULT_SYSTEMD_DIR = join(homedir(), ".config", "systemd", "user");
 export const DEFAULT_LAUNCHD_DIR = join(homedir(), "Library", "LaunchAgents");
 
-const UNIT_PORT_RE = /--port[\s\S]{0,40}?(\d{2,5})/;
+const SYSTEMD_PORT_RE = /--port\s+(\d+)/;
+const LAUNCHD_PORT_RE = /<string>--port<\/string>\s*<string>(\d+)<\/string>/;
 
 /** Lowest port `>= start` not in `taken`. */
 export function pickFreePort(start: number, taken: Iterable<number>): number {
@@ -51,10 +52,12 @@ export function readInstalledServicePorts(opts: {
   return ports;
 }
 
-/** Parse a `--port N` value out of a service unit file. Tolerates the gap
- *  between the flag and value being whitespace (systemd) or whitespace +
- *  XML wrapping (launchd plist). Returns null when no port is declared or
- *  the file is unreadable. */
+/** Parse a `--port N` value out of a service unit file. Dispatches on file
+ *  extension so each format gets a tight regex (`--port 5111` for systemd vs
+ *  `<string>--port</string>\s*<string>5111</string>` for launchd plists) —
+ *  no shared char-window assumption that breaks if either generator's
+ *  indentation changes. Returns null when no port is declared or the file
+ *  is unreadable. */
 export function readPortFromUnit(filePath: string): number | null {
   let text: string;
   try {
@@ -62,10 +65,9 @@ export function readPortFromUnit(filePath: string): number | null {
   } catch {
     return null;
   }
-  const match = UNIT_PORT_RE.exec(text);
-  if (!match) return null;
-  const port = parseInt(match[1], 10);
-  return Number.isNaN(port) ? null : port;
+  const regex = filePath.endsWith(".plist") ? LAUNCHD_PORT_RE : SYSTEMD_PORT_RE;
+  const match = regex.exec(text);
+  return match ? parseInt(match[1], 10) : null;
 }
 
 /** Combine live-registry ports and installed-unit ports into a single set

--- a/bin/src/install-ports.ts
+++ b/bin/src/install-ports.ts
@@ -1,0 +1,87 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createInstanceRegistry } from "../../backend/src/adapters/instance-registry";
+
+export const DEFAULT_SYSTEMD_DIR = join(homedir(), ".config", "systemd", "user");
+export const DEFAULT_LAUNCHD_DIR = join(homedir(), "Library", "LaunchAgents");
+
+const UNIT_PORT_RE = /--port[\s\S]{0,40}?(\d{2,5})/;
+
+/** Lowest port `>= start` not in `taken`. */
+export function pickFreePort(start: number, taken: Iterable<number>): number {
+  const set = new Set(taken);
+  let port = start;
+  while (set.has(port)) port += 1;
+  return port;
+}
+
+/** Ports claimed by other webmux service units already installed on this
+ *  machine — systemd unit files on Linux and launchd plists on macOS.
+ *  Scanning the unit files (rather than only live processes) means an installed
+ *  but currently stopped service still reserves its port. */
+export function readInstalledServicePorts(opts: {
+  systemdDir?: string;
+  launchdDir?: string;
+  excludePath?: string;
+} = {}): number[] {
+  const systemdDir = opts.systemdDir ?? DEFAULT_SYSTEMD_DIR;
+  const launchdDir = opts.launchdDir ?? DEFAULT_LAUNCHD_DIR;
+  const ports: number[] = [];
+
+  function collect(dir: string, namePredicate: (n: string) => boolean): void {
+    if (!existsSync(dir)) return;
+    let names: string[];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of names) {
+      if (!namePredicate(name)) continue;
+      const full = join(dir, name);
+      if (opts.excludePath && full === opts.excludePath) continue;
+      const port = readPortFromUnit(full);
+      if (port !== null) ports.push(port);
+    }
+  }
+
+  collect(systemdDir, (n) => n.startsWith("webmux-") && n.endsWith(".service"));
+  collect(launchdDir, (n) => n.startsWith("com.webmux.") && n.endsWith(".plist"));
+  return ports;
+}
+
+/** Parse a `--port N` value out of a service unit file. Tolerates the gap
+ *  between the flag and value being whitespace (systemd) or whitespace +
+ *  XML wrapping (launchd plist). Returns null when no port is declared or
+ *  the file is unreadable. */
+export function readPortFromUnit(filePath: string): number | null {
+  let text: string;
+  try {
+    text = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  const match = UNIT_PORT_RE.exec(text);
+  if (!match) return null;
+  const port = parseInt(match[1], 10);
+  return Number.isNaN(port) ? null : port;
+}
+
+/** Combine live-registry ports and installed-unit ports into a single set
+ *  to skip when picking a port for a fresh `service install`. */
+export function discoverTakenPorts(opts: {
+  registryDir?: string;
+  systemdDir?: string;
+  launchdDir?: string;
+  excludeUnitPath?: string;
+} = {}): Set<number> {
+  const registry = createInstanceRegistry(opts.registryDir);
+  const live = registry.listLive().map((entry) => entry.port);
+  const installed = readInstalledServicePorts({
+    systemdDir: opts.systemdDir,
+    launchdDir: opts.launchdDir,
+    excludePath: opts.excludeUnitPath,
+  });
+  return new Set([...live, ...installed]);
+}

--- a/bin/src/service-restart.test.ts
+++ b/bin/src/service-restart.test.ts
@@ -2,8 +2,41 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { listInstalledServices, restartCommand, type InstalledService } from "./service-restart.ts";
+import {
+  listInstalledServices,
+  restartCommand,
+  updateInstalledService,
+  type InstalledService,
+  type ServiceRunner,
+} from "./service-restart.ts";
 import { generateServiceFile, parseInstalledServiceConfig, type ServiceConfig } from "./service.ts";
+import type { RunResult } from "./shared.ts";
+
+interface RecordedCall {
+  bin: string;
+  args: string[];
+}
+
+function makeRecorder(behaviour: (call: RecordedCall) => RunResult): {
+  runner: ServiceRunner;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const runner: ServiceRunner = {
+    run(bin, args) {
+      const call = { bin, args };
+      calls.push(call);
+      return behaviour(call);
+    },
+  };
+  return { runner, calls };
+}
+
+const okResult: RunResult = {
+  success: true,
+  stdout: Buffer.from(""),
+  stderr: Buffer.from(""),
+};
 
 const cleanups: Array<() => Promise<void>> = [];
 
@@ -138,6 +171,136 @@ describe("generateServiceFile → parseInstalledServiceConfig → generateServic
 
     // Round-trip should produce identical content when webmuxPath is unchanged.
     expect(generateServiceFile(parsed)).toBe(originalContent);
+  });
+});
+
+describe("updateInstalledService", () => {
+  async function setupSystemdService(): Promise<{ service: InstalledService; dir: string; originalContent: string }> {
+    const dir = await makeTempDir();
+    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "orch" }));
+    const filePath = join(dir, "webmux-orch.service");
+    const original: ServiceConfig = {
+      platform: "linux",
+      projectName: "orch",
+      serviceName: "webmux-orch",
+      webmuxPath: "/old/path/webmux",
+      projectDir: dir,
+      port: 5500,
+    };
+    const originalContent = generateServiceFile(original);
+    await writeFile(filePath, originalContent);
+    return {
+      service: { name: "webmux-orch", filePath, platform: "linux" },
+      dir,
+      originalContent,
+    };
+  }
+
+  it("skips regeneration entirely when webmuxPath is empty", async () => {
+    const { service, originalContent } = await setupSystemdService();
+    const { runner, calls } = makeRecorder(() => okResult);
+
+    const outcome = await updateInstalledService(service, "", runner);
+
+    expect(outcome.regenerated).toBe(false);
+    expect(outcome.restarted).toBe(true);
+    // The unit file must be untouched — a stale `which webmux` failure must
+    // never corrupt ExecStart.
+    expect(await Bun.file(service.filePath).text()).toBe(originalContent);
+    // Only the restart should fire — no daemon-reload.
+    expect(calls).toEqual([
+      { bin: "systemctl", args: ["--user", "restart", "webmux-orch"] },
+    ]);
+  });
+
+  it("skips reload when regenerated content matches existing", async () => {
+    const { service } = await setupSystemdService();
+    const { runner, calls } = makeRecorder(() => okResult);
+
+    // Same path → generated content identical → no rewrite, no daemon-reload.
+    const outcome = await updateInstalledService(service, "/old/path/webmux", runner);
+
+    expect(outcome.regenerated).toBe(false);
+    expect(outcome.restarted).toBe(true);
+    expect(calls).toEqual([
+      { bin: "systemctl", args: ["--user", "restart", "webmux-orch"] },
+    ]);
+  });
+
+  it("regenerates + reloads + restarts when webmuxPath changes", async () => {
+    const { service } = await setupSystemdService();
+    const { runner, calls } = makeRecorder(() => okResult);
+
+    const outcome = await updateInstalledService(service, "/new/path/webmux", runner);
+
+    expect(outcome.regenerated).toBe(true);
+    expect(outcome.restarted).toBe(true);
+    expect(calls).toEqual([
+      { bin: "systemctl", args: ["--user", "daemon-reload"] },
+      { bin: "systemctl", args: ["--user", "restart", "webmux-orch"] },
+    ]);
+    expect(await Bun.file(service.filePath).text()).toContain("/new/path/webmux");
+  });
+
+  it("does not attempt a restart when daemon-reload fails", async () => {
+    const { service } = await setupSystemdService();
+    const { runner, calls } = makeRecorder((call) => {
+      if (call.args.includes("daemon-reload")) {
+        return {
+          success: false,
+          stdout: Buffer.from(""),
+          stderr: Buffer.from("reload broke"),
+        };
+      }
+      return okResult;
+    });
+
+    const outcome = await updateInstalledService(service, "/new/path/webmux", runner);
+
+    expect(outcome.regenerated).toBe(true);
+    expect(outcome.restarted).toBe(false);
+    expect(outcome.error).toContain("reload broke");
+    expect(calls).toEqual([
+      { bin: "systemctl", args: ["--user", "daemon-reload"] },
+    ]);
+  });
+
+  it("surfaces a launchctl load recovery hint when reload fails", async () => {
+    const dir = await makeTempDir();
+    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "darwin-orch" }));
+    const filePath = join(dir, "com.webmux.webmux-darwin-orch.plist");
+    const original: ServiceConfig = {
+      platform: "darwin",
+      projectName: "darwin-orch",
+      serviceName: "webmux-darwin-orch",
+      webmuxPath: "/old/path/webmux",
+      projectDir: dir,
+      port: 5600,
+    };
+    await writeFile(filePath, generateServiceFile(original));
+    const service: InstalledService = {
+      name: "com.webmux.webmux-darwin-orch",
+      filePath,
+      platform: "darwin",
+    };
+
+    const { runner } = makeRecorder((call) => {
+      if (call.args[0] === "load") {
+        return {
+          success: false,
+          stdout: Buffer.from(""),
+          stderr: Buffer.from("plist load failed"),
+        };
+      }
+      return okResult;
+    });
+
+    const outcome = await updateInstalledService(service, "/new/path/webmux", runner);
+
+    expect(outcome.regenerated).toBe(true);
+    expect(outcome.restarted).toBe(false);
+    expect(outcome.error).toContain("plist load failed");
+    expect(outcome.error).toContain("launchctl load -w");
   });
 });
 

--- a/bin/src/service-restart.test.ts
+++ b/bin/src/service-restart.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listInstalledServices, restartCommand, type InstalledService } from "./service-restart.ts";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    const fn = cleanups.pop();
+    if (fn) await fn();
+  }
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "webmux-service-restart-"));
+  cleanups.push(async () => rm(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+describe("listInstalledServices", () => {
+  it("picks up systemd units and strips the .service suffix", async () => {
+    const systemdDir = await makeTempDir();
+    await writeFile(join(systemdDir, "webmux-alpha.service"), "[Service]\nExecStart=/bin/x\n");
+    await writeFile(join(systemdDir, "webmux-beta.service"), "[Service]\nExecStart=/bin/x\n");
+    await writeFile(join(systemdDir, "unrelated.service"), "[Service]\nExecStart=/bin/x\n");
+
+    const services = listInstalledServices({
+      systemdDir,
+      launchdDir: "/no/such/dir",
+    });
+
+    expect(services.map((s) => s.name).sort()).toEqual(["webmux-alpha", "webmux-beta"]);
+    for (const svc of services) expect(svc.platform).toBe("linux");
+  });
+
+  it("picks up launchd plists and keeps the full label", async () => {
+    const launchdDir = await makeTempDir();
+    await writeFile(join(launchdDir, "com.webmux.alpha.plist"), "<plist></plist>");
+    await writeFile(join(launchdDir, "com.other.thing.plist"), "<plist></plist>");
+
+    const services = listInstalledServices({
+      systemdDir: "/no/such/dir",
+      launchdDir,
+    });
+
+    expect(services.map((s) => s.name)).toEqual(["com.webmux.alpha"]);
+    expect(services[0].platform).toBe("darwin");
+  });
+
+  it("returns empty when neither directory exists", () => {
+    const services = listInstalledServices({
+      systemdDir: "/no/such/systemd",
+      launchdDir: "/no/such/launchd",
+    });
+    expect(services).toEqual([]);
+  });
+});
+
+describe("restartCommand", () => {
+  it("builds the systemctl --user restart command for linux", () => {
+    const svc: InstalledService = {
+      name: "webmux-foo",
+      filePath: "/x/webmux-foo.service",
+      platform: "linux",
+    };
+    expect(restartCommand(svc, 1000)).toEqual({
+      bin: "systemctl",
+      args: ["--user", "restart", "webmux-foo"],
+    });
+  });
+
+  it("builds the launchctl kickstart command for darwin", () => {
+    const svc: InstalledService = {
+      name: "com.webmux.foo",
+      filePath: "/x/com.webmux.foo.plist",
+      platform: "darwin",
+    };
+    expect(restartCommand(svc, 501)).toEqual({
+      bin: "launchctl",
+      args: ["kickstart", "-k", "gui/501/com.webmux.foo"],
+    });
+  });
+});

--- a/bin/src/service-restart.test.ts
+++ b/bin/src/service-restart.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { listInstalledServices, restartCommand, type InstalledService } from "./service-restart.ts";
+import { generateServiceFile, parseInstalledServiceConfig, type ServiceConfig } from "./service.ts";
 
 const cleanups: Array<() => Promise<void>> = [];
 
@@ -55,6 +56,88 @@ describe("listInstalledServices", () => {
       launchdDir: "/no/such/launchd",
     });
     expect(services).toEqual([]);
+  });
+});
+
+describe("parseInstalledServiceConfig", () => {
+  it("reconstructs a ServiceConfig from a systemd unit written by generateServiceFile", async () => {
+    const dir = await makeTempDir();
+    const filePath = join(dir, "webmux-roundtrip.service");
+    const original: ServiceConfig = {
+      platform: "linux",
+      projectName: "roundtrip",
+      serviceName: "webmux-roundtrip",
+      webmuxPath: "/usr/local/bin/webmux",
+      projectDir: dir,
+      port: 5117,
+    };
+    await writeFile(filePath, generateServiceFile(original));
+
+    const parsed = parseInstalledServiceConfig(filePath, "linux", "/new/path/webmux");
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.port).toBe(5117);
+    expect(parsed?.projectDir).toBe(dir);
+    expect(parsed?.serviceName).toBe("webmux-roundtrip");
+    // webmuxPath comes from the caller (post-upgrade `which webmux`), not the unit.
+    expect(parsed?.webmuxPath).toBe("/new/path/webmux");
+  });
+
+  it("reconstructs a ServiceConfig from a launchd plist written by generateServiceFile", async () => {
+    const dir = await makeTempDir();
+    const filePath = join(dir, "com.webmux.webmux-roundtrip.plist");
+    const original: ServiceConfig = {
+      platform: "darwin",
+      projectName: "roundtrip",
+      serviceName: "webmux-roundtrip",
+      webmuxPath: "/usr/local/bin/webmux",
+      projectDir: dir,
+      port: 5222,
+    };
+    await writeFile(filePath, generateServiceFile(original));
+
+    const parsed = parseInstalledServiceConfig(filePath, "darwin", "/new/path/webmux");
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.port).toBe(5222);
+    expect(parsed?.projectDir).toBe(dir);
+    expect(parsed?.serviceName).toBe("webmux-roundtrip");
+  });
+
+  it("returns null when the unit file lacks --port", async () => {
+    const dir = await makeTempDir();
+    const filePath = join(dir, "broken.service");
+    await writeFile(filePath, "[Service]\nWorkingDirectory=/x\n");
+    expect(parseInstalledServiceConfig(filePath, "linux", "/path/webmux")).toBeNull();
+  });
+});
+
+describe("generateServiceFile → parseInstalledServiceConfig → generateServiceFile is idempotent", () => {
+  it("regenerated content matches the original for systemd units", async () => {
+    const dir = await makeTempDir();
+    // `detectProjectName` reads package.json's `name` first, so seeding one
+    // with a stable name guarantees the re-derived `projectName` matches the
+    // original — otherwise it would fall back to the random temp-dir basename
+    // and the round-trip would diverge on the `Description=` line.
+    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "idempotent" }));
+    const filePath = join(dir, "webmux-idempotent.service");
+    const original: ServiceConfig = {
+      platform: "linux",
+      projectName: "idempotent",
+      serviceName: "webmux-idempotent",
+      webmuxPath: "/usr/local/bin/webmux",
+      projectDir: dir,
+      port: 5333,
+    };
+    const originalContent = generateServiceFile(original);
+    await writeFile(filePath, originalContent);
+
+    const parsed = parseInstalledServiceConfig(filePath, "linux", "/usr/local/bin/webmux");
+    expect(parsed).not.toBeNull();
+    if (!parsed) throw new Error("parse failed");
+
+    // Round-trip should produce identical content when webmuxPath is unchanged.
+    expect(generateServiceFile(parsed)).toBe(originalContent);
   });
 });
 

--- a/bin/src/service-restart.ts
+++ b/bin/src/service-restart.ts
@@ -1,0 +1,92 @@
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { run, type RunResult } from "./shared.ts";
+
+export type ServicePlatform = "linux" | "darwin";
+
+export interface InstalledService {
+  /** Full unit name. systemd: "webmux-foo" (no .service suffix). launchd: the
+   *  plist Label, e.g. "com.webmux.foo". */
+  name: string;
+  filePath: string;
+  platform: ServicePlatform;
+}
+
+const DEFAULT_SYSTEMD_DIR = join(homedir(), ".config", "systemd", "user");
+const DEFAULT_LAUNCHD_DIR = join(homedir(), "Library", "LaunchAgents");
+
+/** Enumerate webmux service units installed for the current user, across both
+ *  platforms (one platform's dir is typically absent). Best-effort: unreadable
+ *  directories return nothing rather than throwing. */
+export function listInstalledServices(opts: {
+  systemdDir?: string;
+  launchdDir?: string;
+} = {}): InstalledService[] {
+  const out: InstalledService[] = [];
+  const systemdDir = opts.systemdDir ?? DEFAULT_SYSTEMD_DIR;
+  const launchdDir = opts.launchdDir ?? DEFAULT_LAUNCHD_DIR;
+
+  if (existsSync(systemdDir)) {
+    try {
+      for (const name of readdirSync(systemdDir)) {
+        if (!name.startsWith("webmux-") || !name.endsWith(".service")) continue;
+        out.push({
+          name: name.slice(0, -".service".length),
+          filePath: join(systemdDir, name),
+          platform: "linux",
+        });
+      }
+    } catch {
+      // unreadable dir — skip
+    }
+  }
+
+  if (existsSync(launchdDir)) {
+    try {
+      for (const name of readdirSync(launchdDir)) {
+        if (!name.startsWith("com.webmux.") || !name.endsWith(".plist")) continue;
+        out.push({
+          name: name.slice(0, -".plist".length),
+          filePath: join(launchdDir, name),
+          platform: "darwin",
+        });
+      }
+    } catch {
+      // unreadable dir — skip
+    }
+  }
+
+  return out;
+}
+
+/** Pure command builder for restarting a service. Kept separate from the
+ *  I/O call so it can be unit-tested without spawning processes. */
+export function restartCommand(service: InstalledService, uid: number): { bin: string; args: string[] } {
+  if (service.platform === "linux") {
+    return { bin: "systemctl", args: ["--user", "restart", service.name] };
+  }
+  return { bin: "launchctl", args: ["kickstart", "-k", `gui/${uid}/${service.name}`] };
+}
+
+export interface RestartOutcome {
+  service: InstalledService;
+  ok: boolean;
+  error?: string;
+}
+
+/** Restart a single installed service. Best-effort: a failure (service not
+ *  loaded, masked, etc.) is reported back rather than thrown. */
+export function restartInstalledService(service: InstalledService): RestartOutcome {
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  const { bin, args } = restartCommand(service, uid);
+  const result: RunResult = run(bin, args);
+  if (!result.success) {
+    return {
+      service,
+      ok: false,
+      error: result.stderr.toString().trim() || `${bin} ${args.join(" ")} failed`,
+    };
+  }
+  return { service, ok: true };
+}

--- a/bin/src/service-restart.ts
+++ b/bin/src/service-restart.ts
@@ -1,9 +1,10 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { run, type RunResult } from "./shared.ts";
+import { generateServiceFile, parseInstalledServiceConfig, type Platform } from "./service.ts";
 
-export type ServicePlatform = "linux" | "darwin";
+export type ServicePlatform = Platform;
 
 export interface InstalledService {
   /** Full unit name. systemd: "webmux-foo" (no .service suffix). launchd: the
@@ -89,4 +90,86 @@ export function restartInstalledService(service: InstalledService): RestartOutco
     };
   }
   return { service, ok: true };
+}
+
+export interface UpdateOutcome {
+  service: InstalledService;
+  regenerated: boolean;
+  restarted: boolean;
+  error?: string;
+}
+
+function reloadAfterRegenerate(service: InstalledService): RunResult | null {
+  if (service.platform === "linux") {
+    return run("systemctl", ["--user", "daemon-reload"]);
+  }
+  // launchd: kickstart -k doesn't re-read the plist. Force unload + load so
+  // the new content takes effect. unload may fail when the service isn't
+  // currently loaded — that's expected during the first refresh, treat as
+  // non-fatal and let `load` decide success.
+  run("launchctl", ["unload", service.filePath]);
+  return run("launchctl", ["load", "-w", service.filePath]);
+}
+
+/** Bring an installed unit file in sync with the current `generateServiceFile`
+ *  template (preserving the user's port and project), reload the service
+ *  manager so the change takes effect, and restart so the running process
+ *  picks up both the new binary and any unit-file changes. Falls back to a
+ *  plain restart when the unit can't be parsed — that still gets the new
+ *  binary loaded even if regeneration is skipped. */
+export function updateInstalledService(
+  service: InstalledService,
+  webmuxPath: string,
+): UpdateOutcome {
+  const config = parseInstalledServiceConfig(service.filePath, service.platform, webmuxPath);
+  let regenerated = false;
+
+  if (config !== null) {
+    let currentContent = "";
+    try {
+      currentContent = readFileSync(service.filePath, "utf8");
+    } catch {
+      // unreadable — fall through to plain restart
+    }
+    const expected = generateServiceFile(config);
+    if (currentContent !== expected) {
+      try {
+        writeFileSync(service.filePath, expected);
+        regenerated = true;
+      } catch (err: unknown) {
+        return {
+          service,
+          regenerated: false,
+          restarted: false,
+          error: `could not rewrite ${service.filePath}: ${String(err)}`,
+        };
+      }
+    }
+  }
+
+  if (regenerated) {
+    const reload = reloadAfterRegenerate(service);
+    if (reload && !reload.success) {
+      return {
+        service,
+        regenerated,
+        restarted: false,
+        error: reload.stderr.toString().trim() || "reload failed",
+      };
+    }
+    // On launchd the load step already (re)started the service. systemd
+    // still needs an explicit restart so an already-running process picks
+    // up the new ExecStart.
+    if (service.platform === "darwin") {
+      return { service, regenerated, restarted: true };
+    }
+  }
+
+  const outcome = restartInstalledService(service);
+  return {
+    service,
+    regenerated,
+    restarted: outcome.ok,
+    error: outcome.error,
+  };
 }

--- a/bin/src/service-restart.ts
+++ b/bin/src/service-restart.ts
@@ -1,10 +1,18 @@
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { run, type RunResult } from "./shared.ts";
 import { generateServiceFile, parseInstalledServiceConfig, type Platform } from "./service.ts";
 
 export type ServicePlatform = Platform;
+
+/** Indirection over `run` so tests can inject a stub recorder without
+ *  spawning real systemctl/launchctl. Production code uses the default. */
+export interface ServiceRunner {
+  run(bin: string, args: string[]): RunResult;
+}
+
+const defaultRunner: ServiceRunner = { run };
 
 export interface InstalledService {
   /** Full unit name. systemd: "webmux-foo" (no .service suffix). launchd: the
@@ -78,10 +86,13 @@ export interface RestartOutcome {
 
 /** Restart a single installed service. Best-effort: a failure (service not
  *  loaded, masked, etc.) is reported back rather than thrown. */
-export function restartInstalledService(service: InstalledService): RestartOutcome {
+export function restartInstalledService(
+  service: InstalledService,
+  runner: ServiceRunner = defaultRunner,
+): RestartOutcome {
   const uid = typeof process.getuid === "function" ? process.getuid() : 0;
   const { bin, args } = restartCommand(service, uid);
-  const result: RunResult = run(bin, args);
+  const result = runner.run(bin, args);
   if (!result.success) {
     return {
       service,
@@ -99,29 +110,53 @@ export interface UpdateOutcome {
   error?: string;
 }
 
-function reloadAfterRegenerate(service: InstalledService): RunResult | null {
+function reloadAfterRegenerate(
+  service: InstalledService,
+  runner: ServiceRunner,
+): { ok: boolean; error?: string } {
   if (service.platform === "linux") {
-    return run("systemctl", ["--user", "daemon-reload"]);
+    const result = runner.run("systemctl", ["--user", "daemon-reload"]);
+    return result.success
+      ? { ok: true }
+      : { ok: false, error: result.stderr.toString().trim() || "daemon-reload failed" };
   }
   // launchd: kickstart -k doesn't re-read the plist. Force unload + load so
   // the new content takes effect. unload may fail when the service isn't
   // currently loaded — that's expected during the first refresh, treat as
   // non-fatal and let `load` decide success.
-  run("launchctl", ["unload", service.filePath]);
-  return run("launchctl", ["load", "-w", service.filePath]);
+  runner.run("launchctl", ["unload", service.filePath]);
+  const loadResult = runner.run("launchctl", ["load", "-w", service.filePath]);
+  if (loadResult.success) return { ok: true };
+  // If load fails after we unloaded, the service is now offline. Surface a
+  // recovery command rather than just the raw stderr so the user can fix it
+  // without digging through launchd docs.
+  const stderr = loadResult.stderr.toString().trim() || "load failed";
+  return {
+    ok: false,
+    error: `${stderr}\n  service is now unloaded — recover with: launchctl load -w "${service.filePath}"`,
+  };
 }
 
 /** Bring an installed unit file in sync with the current `generateServiceFile`
  *  template (preserving the user's port and project), reload the service
  *  manager so the change takes effect, and restart so the running process
  *  picks up both the new binary and any unit-file changes. Falls back to a
- *  plain restart when the unit can't be parsed — that still gets the new
- *  binary loaded even if regeneration is skipped. */
-export function updateInstalledService(
+ *  plain restart when the unit can't be parsed *or* when `webmuxPath` is
+ *  empty — both cases would otherwise corrupt the unit's `ExecStart`. */
+export async function updateInstalledService(
   service: InstalledService,
   webmuxPath: string,
-): UpdateOutcome {
-  const config = parseInstalledServiceConfig(service.filePath, service.platform, webmuxPath);
+  runner: ServiceRunner = defaultRunner,
+): Promise<UpdateOutcome> {
+  // Empty webmuxPath would write `ExecStart=  serve --port N` into the unit
+  // and silently break the next restart. Happens when `which webmux` returns
+  // nothing after a botched global install. Skip regeneration entirely; the
+  // existing unit's ExecStart is still valid, so a plain restart picks up the
+  // new binary in place.
+  const canRegenerate = webmuxPath.length > 0;
+  const config = canRegenerate
+    ? parseInstalledServiceConfig(service.filePath, service.platform, webmuxPath)
+    : null;
   let regenerated = false;
 
   if (config !== null) {
@@ -134,7 +169,7 @@ export function updateInstalledService(
     const expected = generateServiceFile(config);
     if (currentContent !== expected) {
       try {
-        writeFileSync(service.filePath, expected);
+        await Bun.write(service.filePath, expected);
         regenerated = true;
       } catch (err: unknown) {
         return {
@@ -148,14 +183,9 @@ export function updateInstalledService(
   }
 
   if (regenerated) {
-    const reload = reloadAfterRegenerate(service);
-    if (reload && !reload.success) {
-      return {
-        service,
-        regenerated,
-        restarted: false,
-        error: reload.stderr.toString().trim() || "reload failed",
-      };
+    const reload = reloadAfterRegenerate(service, runner);
+    if (!reload.ok) {
+      return { service, regenerated, restarted: false, error: reload.error };
     }
     // On launchd the load step already (re)started the service. systemd
     // still needs an explicit restart so an already-running process picks
@@ -165,7 +195,7 @@ export function updateInstalledService(
     }
   }
 
-  const outcome = restartInstalledService(service);
+  const outcome = restartInstalledService(service, runner);
   return {
     service,
     regenerated,

--- a/bin/src/service.ts
+++ b/bin/src/service.ts
@@ -1,6 +1,6 @@
 import * as p from "@clack/prompts";
-import { existsSync, mkdirSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { basename, join } from "node:path";
 import { homedir } from "node:os";
 import { run, getGitRoot, detectProjectName } from "./shared.ts";
 import type { RunResult } from "./shared.ts";
@@ -8,10 +8,10 @@ import { discoverTakenPorts, pickFreePort, readPortFromUnit } from "./install-po
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
-type Platform = "linux" | "darwin";
+export type Platform = "linux" | "darwin";
 type Command = [bin: string, args: string[]];
 
-interface ServiceConfig {
+export interface ServiceConfig {
   platform: Platform;
   projectName: string;
   serviceName: string;
@@ -130,9 +130,58 @@ function generateLaunchdPlist(config: ServiceConfig): string {
 `;
 }
 
-function generateServiceFile(config: ServiceConfig): string {
+export function generateServiceFile(config: ServiceConfig): string {
   if (config.platform === "linux") return generateSystemdUnit(config);
   return generateLaunchdPlist(config);
+}
+
+const SYSTEMD_WORKDIR_RE = /^WorkingDirectory=(.+)$/m;
+const LAUNCHD_WORKDIR_RE = /<key>WorkingDirectory<\/key>\s*<string>([^<]+)<\/string>/;
+
+function readWorkingDirFromUnit(filePath: string, platform: Platform): string | null {
+  let text: string;
+  try {
+    text = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  const regex = platform === "linux" ? SYSTEMD_WORKDIR_RE : LAUNCHD_WORKDIR_RE;
+  const match = regex.exec(text);
+  return match ? match[1].trim() : null;
+}
+
+/** Reconstruct a ServiceConfig from an installed unit file. The serviceName
+ *  is taken from the file basename (not re-derived) so a renamed project dir
+ *  doesn't change the launchd Label / systemd unit name that the OS is
+ *  already tracking — only the regenerated *content* (description, paths,
+ *  environment) reflects the current state. Returns null when the file is
+ *  missing required fields. */
+export function parseInstalledServiceConfig(
+  filePath: string,
+  platform: Platform,
+  webmuxPath: string,
+): ServiceConfig | null {
+  const port = readPortFromUnit(filePath);
+  if (port === null) return null;
+
+  const projectDir = readWorkingDirFromUnit(filePath, platform);
+  if (projectDir === null) return null;
+
+  const fileBase = basename(filePath);
+  const serviceName = platform === "linux"
+    ? fileBase.replace(/\.service$/, "")
+    : fileBase.replace(/^com\.webmux\./, "").replace(/\.plist$/, "");
+
+  const projectName = detectProjectName(projectDir);
+
+  return {
+    platform,
+    projectName,
+    serviceName,
+    webmuxPath,
+    projectDir,
+    port,
+  };
 }
 
 // ── Install/uninstall commands ──────────────────────────────────────────────

--- a/bin/src/service.ts
+++ b/bin/src/service.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { run, getGitRoot, detectProjectName } from "./shared.ts";
 import type { RunResult } from "./shared.ts";
+import { discoverTakenPorts, pickFreePort, readPortFromUnit } from "./install-ports.ts";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -168,10 +169,11 @@ function isInstalled(config: ServiceConfig): boolean {
 
 // ── Subcommands ─────────────────────────────────────────────────────────────
 
-async function install(config: ServiceConfig): Promise<void> {
+async function install(config: ServiceConfig, portExplicit: boolean): Promise<void> {
   const filePath = serviceFilePath(config);
+  const alreadyInstalled = isInstalled(config);
 
-  if (isInstalled(config)) {
+  if (alreadyInstalled) {
     const reinstall = await p.confirm({ message: "Service is already installed. Reinstall?" });
     if (p.isCancel(reinstall) || !reinstall) {
       p.log.info("Aborted.");
@@ -182,6 +184,33 @@ async function install(config: ServiceConfig): Promise<void> {
     }
   }
 
+  // Pick the port that will go into the unit file. With an explicit `--port`,
+  // the user wins. On reinstall, reuse the existing unit's port so a re-run
+  // without flags is idempotent. Otherwise scan the live registry + already
+  // installed unit files and find the lowest free port at or above the
+  // requested start, so installing in a second project doesn't silently
+  // collide on 5111.
+  const requestedPort = config.port;
+  let chosenPort = requestedPort;
+  let portNote: string | null = null;
+
+  if (!portExplicit) {
+    const existingPort = alreadyInstalled ? readPortFromUnit(filePath) : null;
+    if (existingPort !== null) {
+      chosenPort = existingPort;
+      if (existingPort !== requestedPort) {
+        portNote = `Reusing port ${existingPort} from the existing service unit (pass --port to override).`;
+      }
+    } else {
+      const taken = discoverTakenPorts({ excludeUnitPath: filePath });
+      chosenPort = pickFreePort(requestedPort, taken);
+      if (chosenPort !== requestedPort) {
+        portNote = `Port ${requestedPort} is already used by another webmux instance — picked ${chosenPort} instead (pass --port to override).`;
+      }
+    }
+  }
+
+  config = { ...config, port: chosenPort };
   const content = generateServiceFile(config);
   const commands = installCommands(config);
 
@@ -196,6 +225,8 @@ async function install(config: ServiceConfig): Promise<void> {
     ].join("\n"),
     "Install service",
   );
+
+  if (portNote) p.log.info(portNote);
 
   const ok = await p.confirm({ message: "Proceed?" });
   if (p.isCancel(ok) || !ok) {
@@ -322,6 +353,12 @@ Usage:
   webmux service uninstall   Stop, disable, and remove the service
   webmux service status      Show service status
   webmux service logs        Tail service logs
+
+Options:
+  --port N                   Pin the service to a specific port. When omitted,
+                             a free port is picked automatically by scanning
+                             other webmux instances and installed services
+                             — second-project installs no longer collide on 5111.
 `);
 }
 
@@ -365,6 +402,7 @@ export default async function service(args: string[]): Promise<void> {
   }
 
   let port = parseInt(process.env.PORT || "5111");
+  let portExplicit = false;
   for (let i = 1; i < args.length; i++) {
     if (args[i] === "--port" && args[i + 1]) {
       const parsed = parseInt(args[++i]);
@@ -373,6 +411,7 @@ export default async function service(args: string[]): Promise<void> {
         return;
       }
       port = parsed;
+      portExplicit = true;
     }
   }
 
@@ -390,7 +429,7 @@ export default async function service(args: string[]): Promise<void> {
 
   switch (action) {
     case "install":
-      await install(config);
+      await install(config, portExplicit);
       break;
     case "uninstall":
       await uninstall(config);

--- a/bin/src/service.ts
+++ b/bin/src/service.ts
@@ -193,6 +193,7 @@ async function install(config: ServiceConfig, portExplicit: boolean): Promise<vo
   const requestedPort = config.port;
   let chosenPort = requestedPort;
   let portNote: string | null = null;
+  let portWarning: string | null = null;
 
   if (!portExplicit) {
     const existingPort = alreadyInstalled ? readPortFromUnit(filePath) : null;
@@ -207,6 +208,14 @@ async function install(config: ServiceConfig, portExplicit: boolean): Promise<vo
       if (chosenPort !== requestedPort) {
         portNote = `Port ${requestedPort} is already used by another webmux instance — picked ${chosenPort} instead (pass --port to override).`;
       }
+    }
+  } else {
+    // Explicit `--port` always wins, but the service will fail to bind on
+    // start if something else is already there — surface it now rather than
+    // making the user dig through `journalctl` / `launchctl` logs later.
+    const taken = discoverTakenPorts({ excludeUnitPath: filePath });
+    if (taken.has(requestedPort)) {
+      portWarning = `Port ${requestedPort} is already claimed by another webmux instance. The service will fail to bind on start; omit --port to auto-pick a free port.`;
     }
   }
 
@@ -227,6 +236,7 @@ async function install(config: ServiceConfig, portExplicit: boolean): Promise<vo
   );
 
   if (portNote) p.log.info(portNote);
+  if (portWarning) p.log.warn(portWarning);
 
   const ok = await p.confirm({ message: "Proceed?" });
   if (p.isCancel(ok) || !ok) {

--- a/bin/src/webmux.test.ts
+++ b/bin/src/webmux.test.ts
@@ -66,6 +66,7 @@ describe("webmux entrypoint", () => {
 
     expect(parseRootArgs(["serve", "--port", "8080", "--debug"])).toEqual({
       port: 8080,
+      portExplicit: true,
       debug: true,
       app: false,
       prefix: null,
@@ -80,6 +81,7 @@ describe("webmux entrypoint", () => {
 
     expect(parseRootArgs(["serve", "--app"])).toEqual({
       port: 5111,
+      portExplicit: false,
       debug: false,
       app: true,
       prefix: null,
@@ -94,6 +96,7 @@ describe("webmux entrypoint", () => {
 
     expect(parseRootArgs(["serve", "--prefix", "myproj"])).toEqual({
       port: 5111,
+      portExplicit: false,
       debug: false,
       app: false,
       prefix: "myproj",
@@ -108,6 +111,7 @@ describe("webmux entrypoint", () => {
     try {
       expect(parseRootArgs(["serve"])).toEqual({
         port: 5111,
+        portExplicit: false,
         debug: false,
         app: false,
         prefix: "envproj",
@@ -119,12 +123,28 @@ describe("webmux entrypoint", () => {
     }
   });
 
+  it("treats PORT from env as an explicit port", () => {
+    process.env.PORT = "5500";
+    delete process.env.WEBMUX_PREFIX;
+
+    expect(parseRootArgs(["serve"])).toEqual({
+      port: 5500,
+      portExplicit: true,
+      debug: false,
+      app: false,
+      prefix: null,
+      command: "serve",
+      commandArgs: [],
+    });
+  });
+
   it("leaves service subcommand flags untouched", () => {
     delete process.env.PORT;
     delete process.env.WEBMUX_PREFIX;
 
     expect(parseRootArgs(["service", "install", "--port", "8080"])).toEqual({
       port: 5111,
+      portExplicit: false,
       debug: false,
       app: false,
       prefix: null,
@@ -139,6 +159,7 @@ describe("webmux entrypoint", () => {
 
     expect(parseRootArgs(["prune"])).toEqual({
       port: 5111,
+      portExplicit: false,
       debug: false,
       app: false,
       prefix: null,
@@ -153,6 +174,7 @@ describe("webmux entrypoint", () => {
 
     expect(parseRootArgs(["archive", "feature/search"])).toEqual({
       port: 5111,
+      portExplicit: false,
       debug: false,
       app: false,
       prefix: null,
@@ -167,6 +189,7 @@ describe("webmux entrypoint", () => {
 
     expect(parseRootArgs(["label", "feature/search", "Search", "ranking"])).toEqual({
       port: 5111,
+      portExplicit: false,
       debug: false,
       app: false,
       prefix: null,

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -320,17 +320,22 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
     });
     const code = await proc.exited;
     if (code === 0) {
-      const { listInstalledServices, restartInstalledService } = await import("./service-restart.ts");
+      const { listInstalledServices, updateInstalledService } = await import("./service-restart.ts");
       const services = listInstalledServices();
       if (services.length > 0) {
-        console.log(`\nRestarting ${services.length} installed webmux service(s) to pick up the new version...`);
+        const whichResult = Bun.spawnSync(["which", "webmux"], { stdout: "pipe", stderr: "pipe" });
+        const webmuxPath = whichResult.success ? whichResult.stdout.toString().trim() : "";
+        console.log(`\nRefreshing ${services.length} installed webmux service(s) to pick up the new version...`);
         for (const svc of services) {
-          const outcome = restartInstalledService(svc);
-          if (outcome.ok) {
-            console.log(`  ${svc.name}: restarted`);
-          } else {
-            console.log(`  ${svc.name}: restart failed — ${outcome.error}`);
-          }
+          const outcome = updateInstalledService(svc, webmuxPath);
+          const parts: string[] = [];
+          if (outcome.regenerated) parts.push("regenerated unit");
+          if (outcome.restarted) parts.push("restarted");
+          if (!outcome.regenerated && !outcome.restarted && !outcome.error) parts.push("no change");
+          const status = outcome.error
+            ? `failed — ${outcome.error}`
+            : parts.join(", ");
+          console.log(`  ${svc.name}: ${status}`);
         }
       }
     }

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -319,6 +319,21 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
       stderr: "inherit",
     });
     const code = await proc.exited;
+    if (code === 0) {
+      const { listInstalledServices, restartInstalledService } = await import("./service-restart.ts");
+      const services = listInstalledServices();
+      if (services.length > 0) {
+        console.log(`\nRestarting ${services.length} installed webmux service(s) to pick up the new version...`);
+        for (const svc of services) {
+          const outcome = restartInstalledService(svc);
+          if (outcome.ok) {
+            console.log(`  ${svc.name}: restarted`);
+          } else {
+            console.log(`  ${svc.name}: restart failed — ${outcome.error}`);
+          }
+        }
+      }
+    }
     process.exit(code);
   }
 

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -53,6 +53,10 @@ type RootCommand = "serve" | "init" | "service" | "update" | "add" | "oneshot" |
 
 interface ParsedRootArgs {
   port: number;
+  /** True when the port came from the user (--port flag or pre-existing PORT
+   *  env). False means the default 5111 — backend treats that as a hint and
+   *  may walk to the next free port on EADDRINUSE. */
+  portExplicit: boolean;
   debug: boolean;
   app: boolean;
   prefix: string | null;
@@ -94,6 +98,7 @@ function isServeRootOption(value: string): boolean {
 
 export function parseRootArgs(args: string[]): ParsedRootArgs {
   let port = parseInt(process.env.PORT || "5111", 10);
+  let portExplicit = process.env.PORT !== undefined;
   let debug = false;
   let app = false;
   let prefix: string | null = process.env.WEBMUX_PREFIX?.trim() || null;
@@ -119,6 +124,7 @@ export function parseRootArgs(args: string[]): ParsedRootArgs {
         if (Number.isNaN(port)) {
           throw new Error("Error: --port requires a numeric value");
         }
+        portExplicit = true;
         index += 1;
         break;
       }
@@ -156,6 +162,7 @@ export function parseRootArgs(args: string[]): ParsedRootArgs {
 
   return {
     port,
+    portExplicit,
     debug,
     app,
     prefix,
@@ -355,6 +362,7 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
     ...process.env,
     PORT: String(parsed.port),
     WEBMUX_PROJECT_DIR: process.cwd(),
+    ...(parsed.portExplicit ? { WEBMUX_PORT_STRICT: "1" } : {}),
     ...(parsed.prefix ? { WEBMUX_PREFIX: parsed.prefix } : {}),
     ...(parsed.debug ? { WEBMUX_DEBUG: "1" } : {}),
   };
@@ -391,7 +399,11 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
     process.exit(1);
   }
 
-  console.log(`Starting webmux on port ${parsed.port} (falls back to a free port if taken)...`);
+  console.log(
+    parsed.portExplicit
+      ? `Starting webmux on port ${parsed.port}...`
+      : `Starting webmux on port ${parsed.port} (falls back to a free port if taken)...`,
+  );
 
   const be = Bun.spawn(["bun", backendEntry], {
     env: { ...baseEnv, WEBMUX_STATIC_DIR: staticDir },

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -327,7 +327,7 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
         const webmuxPath = whichResult.success ? whichResult.stdout.toString().trim() : "";
         console.log(`\nRefreshing ${services.length} installed webmux service(s) to pick up the new version...`);
         for (const svc of services) {
-          const outcome = updateInstalledService(svc, webmuxPath);
+          const outcome = await updateInstalledService(svc, webmuxPath);
           const parts: string[] = [];
           if (outcome.regenerated) parts.push("regenerated unit");
           if (outcome.restarted) parts.push("restarted");


### PR DESCRIPTION
## Summary

Second-project `webmux service install` no longer silently collides on port 5111. When `--port` is omitted, the install command scans the live instance registry and the already-installed systemd/launchd unit files for webmux to find a port that isn't already claimed, and writes that port into the new unit file.

This builds on the symmetric peer registry from #241: the registry tells us which ports are currently live, the unit-file scan covers installed-but-stopped services that still own their port.

## Changes

- New `bin/src/install-ports.ts`: pure `pickFreePort(start, taken)` + thin I/O over `readInstalledServicePorts` (parses `--port N` out of `~/.config/systemd/user/webmux-*.service` and `~/Library/LaunchAgents/com.webmux.*.plist`) and `discoverTakenPorts` which unions those with `createInstanceRegistry().listLive()`.
- `bin/src/service.ts`:
  - Threads a `portExplicit` flag through the install path.
  - Reinstalls reuse the existing unit's port (parsed back out of the file), so re-running `webmux service install` is idempotent without re-passing `--port`.
  - Fresh installs auto-pick when no `--port` flag is supplied and 5111 / the requested start is already taken.
  - `--port` always wins, even against a colliding installed unit.
  - Help text updated to call out the auto-pick behavior.
- 12 unit tests covering `pickFreePort` boundary cases, both unit-file shapes (systemd, launchd), and the exclude-self-on-reinstall path.

## Test plan

- [x] `bun run test` — full suite green (backend 350, packages 4, bin 121, frontend 73)
- [x] `tsc --strict` over the new bin sources — clean
- [ ] Manual: `cd ~/projects/foo && webmux service install` then `cd ~/projects/bar && webmux service install` — second install should land on 5112, both services start cleanly, both visible in the InstanceSwitcher

---
Generated with [Claude Code](https://claude.com/claude-code)