### PR TITLE
fix: use canonical codex hooks flag

### DIFF
--- a/backend/src/__tests__/agent-service.test.ts
+++ b/backend/src/__tests__/agent-service.test.ts
@@ -124,7 +124,7 @@ describe("agent-service command builders", () => {
     expect(shell).toContain("docker exec -it -w '/repos/feature' 'wm-feature-container' /bin/sh -c");
     expect(shell).toContain("/bin/zsh");
     expect(shell).toContain('export PATH="$PATH:/root/.local/bin:/usr/local/bin:/root/.bun/bin:/root/.cargo/bin"');
-    expect(agent).toContain("codex --enable codex_hooks --yolo");
+    expect(agent).toContain("codex --enable hooks --yolo");
     expect(agent).toContain("ship the fix");
     expect(agent).toContain('export PATH="$PATH:/root/.local/bin:/usr/local/bin:/root/.bun/bin:/root/.cargo/bin"');
     expect(agent).not.toContain("docker exec");
@@ -168,7 +168,7 @@ describe("agent-service command builders", () => {
       launchMode: "resume",
     });
 
-    expect(command).toContain("codex --enable codex_hooks --yolo resume --last");
+    expect(command).toContain("codex --enable hooks --yolo resume --last");
     expect(command).not.toContain("developer_instructions=");
     expect(command).not.toContain("ship the fix");
     expect(command).not.toContain("stay focused");
@@ -196,7 +196,7 @@ describe("agent-service command builders", () => {
       prompt: "--help",
     });
     expect(codex).toContain("-- '--help'");
-    expect(codex).toContain("codex --enable codex_hooks");
+    expect(codex).toContain("codex --enable hooks");
   });
 
   it("omits -- when no prompt is provided", () => {

--- a/backend/src/__tests__/lifecycle-service.test.ts
+++ b/backend/src/__tests__/lifecycle-service.test.ts
@@ -1024,7 +1024,7 @@ describe("LifecycleService", () => {
 
     const agentCommand = tmux.commands.at(-1)?.command;
 
-    expect(agentCommand).toContain("codex --enable codex_hooks --yolo resume --last");
+    expect(agentCommand).toContain("codex --enable hooks --yolo resume --last");
     expect(agentCommand).not.toContain("developer_instructions=");
     expect(agentCommand).not.toContain("Database:");
     expect(agentCommand).not.toContain("ship the fix");

--- a/backend/src/services/agent-service.ts
+++ b/backend/src/services/agent-service.ts
@@ -33,7 +33,7 @@ function buildBuiltInAgentInvocation(input: {
   launchMode?: AgentLaunchMode;
 }): string {
   if (input.agent === "codex") {
-    const hooksFlag = " --enable codex_hooks";
+    const hooksFlag = " --enable hooks";
     const yoloFlag = input.yolo ? " --yolo" : "";
     if (input.launchMode === "resume") {
       return `codex${hooksFlag}${yoloFlag} resume --last`;


### PR DESCRIPTION
## Summary
Update Webmux's managed Codex launch command to enable lifecycle hooks with the canonical `hooks` feature flag now documented by Codex, replacing the deprecated `codex_hooks` alias.

## Changes
- Switch generated Codex agent commands from `--enable codex_hooks` to `--enable hooks`
- Update agent command builder expectations for host and docker launches
- Update lifecycle resume expectations for managed Codex worktrees

## Test plan
- [x] `bun test backend/src/__tests__/agent-service.test.ts backend/src/__tests__/lifecycle-service.test.ts backend/src/__tests__/agent-runtime.test.ts`
- [x] `bun run --cwd backend check`

---
Generated with [Claude Code](https://claude.com/claude-code)