### PR TITLE
docs: document oneshot.systemPrompt override in example config

### DIFF
--- a/.webmux.example.yaml
+++ b/.webmux.example.yaml
@@ -165,6 +165,14 @@ lifecycleHooks:
   # Shell command run before a managed worktree is removed.
   preRemove: scripts/pre-remove.sh
 
+# Overrides the system prompt injected into oneshot-mode agent runs.
+# Omit to use the built-in default (instructs the agent to finish, commit,
+# push, and open a PR without asking for confirmation).
+oneshot:
+  systemPrompt: >
+    You are running in webmux ONESHOT mode. Drive the task to completion
+    without asking for approval, then commit, push, and open a PR.
+
 auto_name:
   # Model used when the branch field is left empty and a prompt is provided.
   # Supported provider families currently include:


### PR DESCRIPTION
## Summary
- Adds an `oneshot.systemPrompt` block to `.webmux.example.yaml` so the override is discoverable from the example file (the parser already supports it — see `backend/src/adapters/config.ts:293-299`).
- Notes that omitting it falls back to the built-in default that drives oneshot agents to commit, push, and open a PR.

## Test plan
- [x] `.webmux.example.yaml` renders correctly and stays valid YAML
- [x] No code changes; behavior unchanged