### PR TITLE
fix: don't close dialog when drag-selecting text out of modal

### DIFF
--- a/frontend/src/lib/BaseDialog.svelte
+++ b/frontend/src/lib/BaseDialog.svelte
@@ -16,6 +16,7 @@
   } = $props();
 
   let dialogEl: HTMLDialogElement;
+  let pressStartedOnBackdrop = false;
 
   $effect(() => {
     dialogEl?.showModal();
@@ -25,8 +26,12 @@
 <dialog
   bind:this={dialogEl}
   {onclose}
+  onmousedown={(e: MouseEvent) => {
+    pressStartedOnBackdrop = e.target === dialogEl;
+  }}
   onclick={(e: MouseEvent) => {
-    if (e.target === dialogEl) dialogEl.close();
+    if (e.target === dialogEl && pressStartedOnBackdrop) dialogEl.close();
+    pressStartedOnBackdrop = false;
   }}
   class="bg-sidebar text-primary border border-edge rounded-xl w-[90%] {maxWidth
     ? ''


### PR DESCRIPTION
## Summary
The "New worktree" modal (and any other `BaseDialog` consumer) closes when the user mousedowns inside a textarea/input, drags the pointer outside the dialog, and releases — a common gesture when selecting prompt text with the mouse. The browser fires a synthetic `click` on the `<dialog>` element (the common ancestor of mousedown/mouseup), which the existing handler interprets as a backdrop click.

## Changes
- `BaseDialog.svelte`: track an `onmousedown` flag indicating whether the press originated on the backdrop. The `onclick` handler now only closes the dialog when both the click target *and* the original mousedown target are the dialog element itself.

## Test plan
- [ ] Open "New worktree", click+drag inside the prompt textarea, release outside the modal — modal stays open and text remains selected.
- [ ] Click on the backdrop (mousedown and mouseup both on the dimmed area outside the modal) — modal closes as before.
- [ ] Click the Cancel button — modal closes.
- [ ] Press Escape — modal closes.

---
Generated with [Claude Code](https://claude.com/claude-code)