### PR TITLE
feat: bake env vars into webmux service unit via --env and auto-pickup

### DIFF
--- a/bin/src/service-restart.test.ts
+++ b/bin/src/service-restart.test.ts
@@ -103,6 +103,7 @@ describe("parseInstalledServiceConfig", () => {
       webmuxPath: "/usr/local/bin/webmux",
       projectDir: dir,
       port: 5117,
+      envVars: {},
     };
     await writeFile(filePath, generateServiceFile(original));
 
@@ -126,6 +127,7 @@ describe("parseInstalledServiceConfig", () => {
       webmuxPath: "/usr/local/bin/webmux",
       projectDir: dir,
       port: 5222,
+      envVars: {},
     };
     await writeFile(filePath, generateServiceFile(original));
 
@@ -161,6 +163,7 @@ describe("generateServiceFile → parseInstalledServiceConfig → generateServic
       webmuxPath: "/usr/local/bin/webmux",
       projectDir: dir,
       port: 5333,
+      envVars: {},
     };
     const originalContent = generateServiceFile(original);
     await writeFile(filePath, originalContent);
@@ -186,6 +189,7 @@ describe("updateInstalledService", () => {
       webmuxPath: "/old/path/webmux",
       projectDir: dir,
       port: 5500,
+      envVars: {},
     };
     const originalContent = generateServiceFile(original);
     await writeFile(filePath, originalContent);
@@ -276,6 +280,7 @@ describe("updateInstalledService", () => {
       webmuxPath: "/old/path/webmux",
       projectDir: dir,
       port: 5600,
+      envVars: {},
     };
     await writeFile(filePath, generateServiceFile(original));
     const service: InstalledService = {

--- a/bin/src/service.test.ts
+++ b/bin/src/service.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "bun:test";
+import {
+  generateServiceFile,
+  parseEnvCliArgs,
+  parseInstalledServiceConfig,
+  readEnvVarsFromUnit,
+  resolveEnvVars,
+  type ServiceConfig,
+} from "./service.ts";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "webmux-service-env-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("parseEnvCliArgs", () => {
+  it("collects multiple --env KEY=VAL pairs", () => {
+    const { envVars, errors } = parseEnvCliArgs([
+      "--env", "LINEAR_API_KEY=lin_xyz",
+      "--env", "GITHUB_TOKEN=ghp_abc",
+    ]);
+    expect(errors).toEqual([]);
+    expect(envVars).toEqual({ LINEAR_API_KEY: "lin_xyz", GITHUB_TOKEN: "ghp_abc" });
+  });
+
+  it("preserves '=' characters inside the value", () => {
+    const { envVars, errors } = parseEnvCliArgs(["--env", "JWT=a.b=c"]);
+    expect(errors).toEqual([]);
+    expect(envVars).toEqual({ JWT: "a.b=c" });
+  });
+
+  it("rejects malformed pairs without dropping subsequent ones", () => {
+    const { envVars, errors } = parseEnvCliArgs([
+      "--env", "no_equals_here",
+      "--env", "GOOD=ok",
+    ]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("KEY=VALUE");
+    expect(envVars).toEqual({ GOOD: "ok" });
+  });
+
+  it("rejects keys that aren't valid identifiers", () => {
+    const { envVars, errors } = parseEnvCliArgs(["--env", "1BAD=x"]);
+    expect(errors.length).toBe(1);
+    expect(envVars).toEqual({});
+  });
+
+  it("refuses reserved generator keys", () => {
+    const { errors } = parseEnvCliArgs(["--env", "PATH=/tmp"]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("PATH");
+  });
+
+  it("flags a trailing --env with no argument", () => {
+    const { envVars, errors } = parseEnvCliArgs(["--env"]);
+    expect(errors).toEqual(["--env requires a KEY=VALUE argument"]);
+    expect(envVars).toEqual({});
+  });
+
+  it("ignores positional flags that aren't --env", () => {
+    const { envVars, errors } = parseEnvCliArgs(["--port", "5111", "--env", "A=1"]);
+    expect(errors).toEqual([]);
+    expect(envVars).toEqual({ A: "1" });
+  });
+});
+
+describe("resolveEnvVars", () => {
+  it("merges existing + auto-pick + CLI with CLI winning", () => {
+    const { envVars } = resolveEnvVars({
+      cliEnv: { LINEAR_API_KEY: "cli_value" },
+      processEnv: { LINEAR_API_KEY: "shell_value" },
+      existing: { LINEAR_API_KEY: "old_value", OTHER: "kept" },
+      autoPickup: true,
+    });
+    // CLI overrides everything; OTHER is preserved from existing unit.
+    expect(envVars).toEqual({ LINEAR_API_KEY: "cli_value", OTHER: "kept" });
+  });
+
+  it("auto-picks LINEAR_API_KEY from process.env when set", () => {
+    const { envVars, notes } = resolveEnvVars({
+      cliEnv: {},
+      processEnv: { LINEAR_API_KEY: "lin_shell" },
+      existing: {},
+      autoPickup: true,
+    });
+    expect(envVars).toEqual({ LINEAR_API_KEY: "lin_shell" });
+    expect(notes.some((n) => n.includes("auto-picked"))).toBe(true);
+  });
+
+  it("skips auto-pickup when disabled", () => {
+    const { envVars } = resolveEnvVars({
+      cliEnv: {},
+      processEnv: { LINEAR_API_KEY: "lin_shell" },
+      existing: {},
+      autoPickup: false,
+    });
+    expect(envVars).toEqual({});
+  });
+
+  it("preserves existing env vars when reinstalling without overrides", () => {
+    const { envVars } = resolveEnvVars({
+      cliEnv: {},
+      processEnv: {},
+      existing: { LINEAR_API_KEY: "kept" },
+      autoPickup: false,
+    });
+    expect(envVars).toEqual({ LINEAR_API_KEY: "kept" });
+  });
+
+  it("treats empty-string env values as unset", () => {
+    const { envVars } = resolveEnvVars({
+      cliEnv: {},
+      processEnv: { LINEAR_API_KEY: "" },
+      existing: {},
+      autoPickup: true,
+    });
+    expect(envVars).toEqual({});
+  });
+});
+
+describe("generateServiceFile + readEnvVarsFromUnit (round-trip)", () => {
+  it("round-trips env vars through a systemd unit", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = join(dir, "webmux-roundtrip.service");
+      const config: ServiceConfig = {
+        platform: "linux",
+        projectName: "roundtrip",
+        serviceName: "webmux-roundtrip",
+        webmuxPath: "/usr/local/bin/webmux",
+        projectDir: dir,
+        port: 5111,
+        envVars: { LINEAR_API_KEY: "lin_xyz", FOO: "bar=baz" },
+      };
+      await writeFile(filePath, generateServiceFile(config));
+      const back = readEnvVarsFromUnit(filePath, "linux");
+      expect(back).toEqual({ LINEAR_API_KEY: "lin_xyz", FOO: "bar=baz" });
+    });
+  });
+
+  it("strips reserved generator keys from the parsed result", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = join(dir, "webmux-roundtrip.service");
+      const config: ServiceConfig = {
+        platform: "linux",
+        projectName: "roundtrip",
+        serviceName: "webmux-roundtrip",
+        webmuxPath: "/usr/local/bin/webmux",
+        projectDir: dir,
+        port: 5111,
+        envVars: { LINEAR_API_KEY: "x" },
+      };
+      await writeFile(filePath, generateServiceFile(config));
+      const back = readEnvVarsFromUnit(filePath, "linux");
+      // PORT / WEBMUX_PROJECT_DIR / PATH stay out of the user-env view.
+      expect(back).toEqual({ LINEAR_API_KEY: "x" });
+    });
+  });
+
+  it("round-trips env vars through a launchd plist (XML-escaped)", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = join(dir, "com.webmux.webmux-roundtrip.plist");
+      const config: ServiceConfig = {
+        platform: "darwin",
+        projectName: "roundtrip",
+        serviceName: "webmux-roundtrip",
+        webmuxPath: "/usr/local/bin/webmux",
+        projectDir: dir,
+        port: 5222,
+        envVars: { TOKEN: "needs <escaping> & a&mp", PLAIN: "ok" },
+      };
+      await writeFile(filePath, generateServiceFile(config));
+      const back = readEnvVarsFromUnit(filePath, "darwin");
+      expect(back).toEqual({ TOKEN: "needs <escaping> & a&mp", PLAIN: "ok" });
+    });
+  });
+
+  it("parseInstalledServiceConfig surfaces envVars on the returned config", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = join(dir, "webmux-roundtrip.service");
+      await writeFile(join(dir, "package.json"), JSON.stringify({ name: "roundtrip" }));
+      const original: ServiceConfig = {
+        platform: "linux",
+        projectName: "roundtrip",
+        serviceName: "webmux-roundtrip",
+        webmuxPath: "/usr/local/bin/webmux",
+        projectDir: dir,
+        port: 5117,
+        envVars: { LINEAR_API_KEY: "lin_xyz" },
+      };
+      await writeFile(filePath, generateServiceFile(original));
+      const parsed = parseInstalledServiceConfig(filePath, "linux", "/usr/local/bin/webmux");
+      expect(parsed).not.toBeNull();
+      expect(parsed?.envVars).toEqual({ LINEAR_API_KEY: "lin_xyz" });
+      // Idempotent regeneration: generate(parse(generate(x))) === generate(x)
+      expect(generateServiceFile(parsed!)).toBe(generateServiceFile(original));
+    });
+  });
+});

--- a/bin/src/service.ts
+++ b/bin/src/service.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
 import { basename, join } from "node:path";
 import { homedir } from "node:os";
 import { run, getGitRoot, detectProjectName } from "./shared.ts";
@@ -18,7 +18,20 @@ export interface ServiceConfig {
   webmuxPath: string;
   projectDir: string;
   port: number;
+  /** Extra environment variables to bake into the unit (LINEAR_API_KEY etc.).
+   *  PORT / WEBMUX_PROJECT_DIR / PATH are managed by the generator and must
+   *  not be passed here. */
+  envVars: Record<string, string>;
 }
+
+/** Env vars webmux reads at runtime that are worth auto-detecting from the
+ *  installing shell's environment. Limited to credentials/integrations users
+ *  typically `export` in their dotfiles — not knobs like WEBMUX_DEBUG. */
+export const AUTO_PICKUP_ENV_VARS = ["LINEAR_API_KEY"] as const;
+
+/** Env-var names the generator owns and refuses to accept as user envVars —
+ *  the unit file sets them separately. */
+const RESERVED_ENV_KEYS = new Set(["PORT", "WEBMUX_PROJECT_DIR", "PATH"]);
 
 // ── Platform helpers ────────────────────────────────────────────────────────
 
@@ -70,6 +83,12 @@ function serviceFilePath(config: ServiceConfig): string {
 // ── Service file content ────────────────────────────────────────────────────
 
 function generateSystemdUnit(config: ServiceConfig): string {
+  // Sort by key so reinstalls / regenerations produce stable output regardless
+  // of which order the user passed --env flags or which order Object.keys
+  // happens to iterate.
+  const extra = Object.keys(config.envVars).sort()
+    .map((key) => `Environment=${key}=${config.envVars[key]}`)
+    .join("\n");
   return `[Unit]
 Description=webmux dashboard — ${config.projectName}
 
@@ -81,15 +100,25 @@ Restart=on-failure
 RestartSec=5
 Environment=PORT=${config.port}
 Environment=WEBMUX_PROJECT_DIR=${config.projectDir}
-Environment=PATH=${process.env.PATH}
+Environment=PATH=${process.env.PATH}${extra ? "\n" + extra : ""}
 
 [Install]
 WantedBy=default.target
 `;
 }
 
+function escapePlistText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 function generateLaunchdPlist(config: ServiceConfig): string {
   const logPath = join(homedir(), "Library", "Logs", `webmux-${config.serviceName}.log`);
+  const extra = Object.keys(config.envVars).sort()
+    .map((key) => `    <key>${escapePlistText(key)}</key>\n    <string>${escapePlistText(config.envVars[key])}</string>`)
+    .join("\n");
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -123,7 +152,7 @@ function generateLaunchdPlist(config: ServiceConfig): string {
     <key>WEBMUX_PROJECT_DIR</key>
     <string>${config.projectDir}</string>
     <key>PATH</key>
-    <string>${process.env.PATH}</string>
+    <string>${process.env.PATH}</string>${extra ? "\n" + extra : ""}
   </dict>
 </dict>
 </plist>
@@ -137,6 +166,9 @@ export function generateServiceFile(config: ServiceConfig): string {
 
 const SYSTEMD_WORKDIR_RE = /^WorkingDirectory=(.+)$/m;
 const LAUNCHD_WORKDIR_RE = /<key>WorkingDirectory<\/key>\s*<string>([^<]+)<\/string>/;
+const SYSTEMD_ENV_RE = /^Environment=([A-Za-z_][A-Za-z0-9_]*)=(.*)$/gm;
+const LAUNCHD_ENV_DICT_RE = /<key>EnvironmentVariables<\/key>\s*<dict>([\s\S]*?)<\/dict>/;
+const LAUNCHD_ENV_ENTRY_RE = /<key>([^<]+)<\/key>\s*<string>([^<]*)<\/string>/g;
 
 function readWorkingDirFromUnit(filePath: string, platform: Platform): string | null {
   let text: string;
@@ -148,6 +180,42 @@ function readWorkingDirFromUnit(filePath: string, platform: Platform): string | 
   const regex = platform === "linux" ? SYSTEMD_WORKDIR_RE : LAUNCHD_WORKDIR_RE;
   const match = regex.exec(text);
   return match ? match[1].trim() : null;
+}
+
+function unescapePlistText(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+/** Extract user-set env vars from an existing unit file. Strips out the keys
+ *  the generator manages itself (PORT/WEBMUX_PROJECT_DIR/PATH) so a re-parse
+ *  → re-generate cycle stays idempotent and doesn't double-emit them. */
+export function readEnvVarsFromUnit(filePath: string, platform: Platform): Record<string, string> {
+  let text: string;
+  try {
+    text = readFileSync(filePath, "utf8");
+  } catch {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  if (platform === "linux") {
+    for (const match of text.matchAll(SYSTEMD_ENV_RE)) {
+      const key = match[1];
+      if (RESERVED_ENV_KEYS.has(key)) continue;
+      out[key] = match[2];
+    }
+    return out;
+  }
+  const dict = LAUNCHD_ENV_DICT_RE.exec(text);
+  if (!dict) return out;
+  for (const match of dict[1].matchAll(LAUNCHD_ENV_ENTRY_RE)) {
+    const key = unescapePlistText(match[1]);
+    if (RESERVED_ENV_KEYS.has(key)) continue;
+    out[key] = unescapePlistText(match[2]);
+  }
+  return out;
 }
 
 /** Reconstruct a ServiceConfig from an installed unit file. The serviceName
@@ -173,6 +241,7 @@ export function parseInstalledServiceConfig(
     : fileBase.replace(/^com\.webmux\./, "").replace(/\.plist$/, "");
 
   const projectName = detectProjectName(projectDir);
+  const envVars = readEnvVarsFromUnit(filePath, platform);
 
   return {
     platform,
@@ -181,6 +250,7 @@ export function parseInstalledServiceConfig(
     webmuxPath,
     projectDir,
     port,
+    envVars,
   };
 }
 
@@ -218,7 +288,121 @@ function isInstalled(config: ServiceConfig): boolean {
 
 // ── Subcommands ─────────────────────────────────────────────────────────────
 
-async function install(config: ServiceConfig, portExplicit: boolean): Promise<void> {
+interface EnvVarResolution {
+  envVars: Record<string, string>;
+  /** Human-readable lines describing where each var came from, for logging. */
+  notes: string[];
+}
+
+/** Build the final env-var set for the unit by merging, in order of
+ *  precedence (later wins):
+ *    1. env vars already in the installed unit (so reinstall preserves them)
+ *    2. auto-picked from process.env (LINEAR_API_KEY etc.)
+ *    3. explicit --env KEY=VAL from the CLI
+ *  Notes capture every key added so the user sees what got baked in before
+ *  confirming the install. */
+export function resolveEnvVars(opts: {
+  cliEnv: Record<string, string>;
+  processEnv: Record<string, string | undefined>;
+  existing: Record<string, string>;
+  autoPickup: boolean;
+}): EnvVarResolution {
+  const envVars: Record<string, string> = { ...opts.existing };
+  const notes: string[] = [];
+
+  for (const key of Object.keys(opts.existing).sort()) {
+    notes.push(`  ${key}  (kept from existing unit)`);
+  }
+
+  if (opts.autoPickup) {
+    for (const key of AUTO_PICKUP_ENV_VARS) {
+      const value = opts.processEnv[key];
+      if (value === undefined || value === "") continue;
+      const prior = envVars[key];
+      envVars[key] = value;
+      notes.push(
+        prior === undefined
+          ? `  ${key}  (auto-picked from shell environment)`
+          : prior === value
+            ? `  ${key}  (auto-pick matched existing value)`
+            : `  ${key}  (auto-picked from shell environment, overrides existing)`,
+      );
+    }
+  }
+
+  for (const [key, value] of Object.entries(opts.cliEnv)) {
+    const prior = envVars[key];
+    envVars[key] = value;
+    notes.push(
+      prior === undefined
+        ? `  ${key}  (from --env)`
+        : `  ${key}  (from --env, overrides previous value)`,
+    );
+  }
+
+  return { envVars, notes };
+}
+
+export interface CliEnvParseResult {
+  envVars: Record<string, string>;
+  errors: string[];
+}
+
+/** Parse repeated `--env KEY=VAL` occurrences out of the CLI args. The split
+ *  is anchored on the first `=` so values containing `=` (JWTs, base64) pass
+ *  through intact. */
+export function parseEnvCliArgs(args: string[]): CliEnvParseResult {
+  const envVars: Record<string, string> = {};
+  const errors: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== "--env") continue;
+    const raw = args[i + 1];
+    if (raw === undefined) {
+      errors.push("--env requires a KEY=VALUE argument");
+      break;
+    }
+    i++;
+    const eq = raw.indexOf("=");
+    if (eq <= 0) {
+      errors.push(`--env expects KEY=VALUE (got: ${raw})`);
+      continue;
+    }
+    const key = raw.slice(0, eq);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      errors.push(`--env key is not a valid identifier: ${key}`);
+      continue;
+    }
+    if (RESERVED_ENV_KEYS.has(key)) {
+      errors.push(`--env cannot set ${key} — it is managed by the service unit`);
+      continue;
+    }
+    envVars[key] = raw.slice(eq + 1);
+  }
+  return { envVars, errors };
+}
+
+/** Replace secret-looking values in the preview output. Anything with a
+ *  key suffix that smells secret (TOKEN/KEY/PASSWORD/SECRET) is shown as
+ *  `••• (NN chars)` so the install note can be safely copy-pasted into a
+ *  bug report without leaking credentials. */
+function redactSecretsInUnit(content: string, envVars: Record<string, string>): string {
+  let out = content;
+  for (const [key, value] of Object.entries(envVars)) {
+    if (!value) continue;
+    if (!/(?:TOKEN|KEY|PASSWORD|SECRET)$/i.test(key)) continue;
+    const masked = `••• (${value.length} chars)`;
+    // Cheap whole-string replace — env values are unique enough in a unit
+    // file that this won't collide with other content.
+    out = out.split(value).join(masked);
+  }
+  return out;
+}
+
+async function install(
+  config: ServiceConfig,
+  portExplicit: boolean,
+  envVarNotes: string[],
+): Promise<void> {
   const filePath = serviceFilePath(config);
   const alreadyInstalled = isInstalled(config);
 
@@ -272,18 +456,25 @@ async function install(config: ServiceConfig, portExplicit: boolean): Promise<vo
   const content = generateServiceFile(config);
   const commands = installCommands(config);
 
+  // Mask secret-shaped values in the preview so the dry-run note doesn't
+  // splat tokens onto the terminal. The on-disk unit gets chmod 600 below.
+  const displayContent = redactSecretsInUnit(content, config.envVars);
+
   p.note(
     [
       `File: ${filePath}`,
       "",
       "Contents:",
-      content,
+      displayContent,
       "Commands to run:",
       ...commands.map((c) => `  $ ${formatCommand(c)}`),
     ].join("\n"),
     "Install service",
   );
 
+  if (Object.keys(config.envVars).length > 0) {
+    p.log.info(`Environment variables baked into the unit:\n${envVarNotes.join("\n")}`);
+  }
   if (portNote) p.log.info(portNote);
   if (portWarning) p.log.warn(portWarning);
 
@@ -296,6 +487,13 @@ async function install(config: ServiceConfig, portExplicit: boolean): Promise<vo
   mkdirSync(filePath.substring(0, filePath.lastIndexOf("/")), { recursive: true });
 
   await Bun.write(filePath, content);
+  if (Object.keys(config.envVars).length > 0) {
+    try {
+      chmodSync(filePath, 0o600);
+    } catch (err: unknown) {
+      p.log.warn(`Wrote ${filePath} but could not chmod 600: ${String(err)}`);
+    }
+  }
   p.log.success(`Wrote ${filePath}`);
 
   for (const cmd of commands) {
@@ -418,6 +616,16 @@ Options:
                              a free port is picked automatically by scanning
                              other webmux instances and installed services
                              — second-project installs no longer collide on 5111.
+  --env KEY=VALUE            Bake an environment variable into the service
+                             unit (repeatable). Reserved keys PORT,
+                             WEBMUX_PROJECT_DIR, and PATH are rejected.
+  --no-auto-env              Skip auto-detection of webmux-relevant env vars
+                             from the current shell (default: detect
+                             ${AUTO_PICKUP_ENV_VARS.join(", ")}).
+                             Useful in CI / non-interactive installs.
+
+  When any env var is set, the unit file is written with mode 0600 so
+  secrets are readable only by the installing user.
 `);
 }
 
@@ -462,6 +670,7 @@ export default async function service(args: string[]): Promise<void> {
 
   let port = parseInt(process.env.PORT || "5111");
   let portExplicit = false;
+  let autoPickup = true;
   for (let i = 1; i < args.length; i++) {
     if (args[i] === "--port" && args[i + 1]) {
       const parsed = parseInt(args[++i]);
@@ -471,11 +680,40 @@ export default async function service(args: string[]): Promise<void> {
       }
       port = parsed;
       portExplicit = true;
+    } else if (args[i] === "--no-auto-env") {
+      autoPickup = false;
     }
+  }
+
+  const cliEnv = parseEnvCliArgs(args.slice(1));
+  if (cliEnv.errors.length > 0) {
+    for (const err of cliEnv.errors) p.log.error(err);
+    return;
   }
 
   const projectName = detectProjectName(gitRoot);
   const serviceName = `webmux-${sanitizeName(projectName)}`;
+
+  let envVars: Record<string, string> = {};
+  let envVarNotes: string[] = [];
+  if (action === "install") {
+    const existing = isInstalledAt(platform, serviceName)
+      ? readEnvVarsFromUnit(
+          platform === "linux"
+            ? systemdUnitPath(serviceName)
+            : launchdPlistPath(serviceName),
+          platform,
+        )
+      : {};
+    const resolved = resolveEnvVars({
+      cliEnv: cliEnv.envVars,
+      processEnv: process.env,
+      existing,
+      autoPickup,
+    });
+    envVars = resolved.envVars;
+    envVarNotes = resolved.notes;
+  }
 
   const config: ServiceConfig = {
     platform,
@@ -484,11 +722,12 @@ export default async function service(args: string[]): Promise<void> {
     webmuxPath,
     projectDir: gitRoot,
     port,
+    envVars,
   };
 
   switch (action) {
     case "install":
-      await install(config, portExplicit);
+      await install(config, portExplicit, envVarNotes);
       break;
     case "uninstall":
       await uninstall(config);
@@ -500,4 +739,11 @@ export default async function service(args: string[]): Promise<void> {
       logs(config);
       break;
   }
+}
+
+function isInstalledAt(platform: Platform, serviceName: string): boolean {
+  const path = platform === "linux"
+    ? systemdUnitPath(serviceName)
+    : launchdPlistPath(serviceName);
+  return existsSync(path);
 }

--- a/site/src/lib/docs.ts
+++ b/site/src/lib/docs.ts
@@ -187,11 +187,15 @@ export const rootCommands: DocCommand[] = [
   {
     title: "service",
     usage:
-      "webmux service install [--port <number>]\nwebmux service uninstall\nwebmux service status\nwebmux service logs",
+      "webmux service install [--port <number>] [--env KEY=VALUE]... [--no-auto-env]\nwebmux service uninstall\nwebmux service status\nwebmux service logs",
     description: "Manage webmux as a user-level service on Linux or macOS.",
     details: [
       "Uses systemctl --user on Linux and launchctl on macOS.",
       "install writes a service file that runs webmux serve --port ... from the git root.",
+      "--env KEY=VALUE bakes an env var into the unit (repeatable). Reserved keys PORT, WEBMUX_PROJECT_DIR, PATH are rejected.",
+      "By default, install auto-picks LINEAR_API_KEY from the installing shell's environment. Pass --no-auto-env to disable.",
+      "Reinstall preserves env vars already in the existing unit file unless overridden by --env or auto-pickup.",
+      "The unit file is chmod'd to 0600 whenever any env var is set.",
       "Not supported on other platforms.",
     ],
   },


### PR DESCRIPTION
## Summary

- `webmux service install` now writes user env vars (e.g. `LINEAR_API_KEY`) directly into the systemd unit / launchd plist — no more hand-editing `~/.config/systemd/user/webmux-*.service` after each (re)install.
- Two ways to populate: `--env KEY=VALUE` (repeatable) for explicit pairs, plus auto-pickup of webmux-relevant secrets from the installing shell's `process.env` (currently `LINEAR_API_KEY`). Disable auto-pickup with `--no-auto-env`.
- Reinstall preserves env vars already in the existing unit, so re-running `webmux service install` from a different shell never silently drops a token. Precedence is **existing < auto-pickup < --env**.
- Each var that gets baked in is logged in the install preview note (with `TOKEN`/`KEY`/`PASSWORD`/`SECRET`-suffixed values masked as `••• (N chars)`). Unit files containing any env var are chmod'd to `0600`.
- `parseInstalledServiceConfig` / `generateServiceFile` round-trip env vars on both platforms (reserved keys `PORT`/`WEBMUX_PROJECT_DIR`/`PATH` are stripped from the parsed view to keep regen idempotent).

## Test plan

- [x] `bun test bin/src/service.test.ts bin/src/service-restart.test.ts` — 30 pass (16 new in `service.test.ts`, 14 existing in `service-restart.test.ts`)
- [ ] Manual: `webmux service install --env FOO=bar` on Linux, verify `Environment=FOO=bar` line + `0600` perms + `LINEAR_API_KEY` auto-picked from shell
- [ ] Manual: reinstall with `--no-auto-env` from a shell without `LINEAR_API_KEY`, verify the key is preserved from the existing unit
- [ ] Manual on macOS: same flow against launchd plist

🤖 Generated with [Claude Code](https://claude.com/claude-code)