### PR TITLE
feat: polish Linear issue title and detect duplicates on --linear <TEAM>

### DIFF
--- a/backend/src/__tests__/linear-title-service.test.ts
+++ b/backend/src/__tests__/linear-title-service.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "bun:test";
+import {
+  extractKeywords,
+  findDuplicateLinearIssue,
+  polishLinearIssueTitle,
+} from "../services/linear-title-service";
+import type { RunLlmResult } from "../services/llm-spawn";
+import type { LinearIssue, SearchTeamIssuesResult } from "../services/linear-service";
+
+function makeIssue(overrides: Partial<LinearIssue> & Pick<LinearIssue, "identifier" | "title">): LinearIssue {
+  return {
+    id: `id-${overrides.identifier}`,
+    description: null,
+    priority: 0,
+    priorityLabel: "No priority",
+    url: `https://linear.app/team/issue/${overrides.identifier}`,
+    branchName: overrides.identifier.toLowerCase(),
+    dueDate: null,
+    updatedAt: "2024-01-01T00:00:00Z",
+    state: { name: "Backlog", color: "#000", type: "backlog" },
+    team: { name: "Eng", key: "ENG" },
+    labels: [],
+    project: null,
+    ...overrides,
+  };
+}
+
+function okLlm(stdout: string): RunLlmResult {
+  return { ok: true, stdout, stderr: "", args: [] };
+}
+
+function failLlm(kind: "timeout" | "spawn_error" | "exit_nonzero"): RunLlmResult {
+  if (kind === "timeout") return { ok: false, kind: "timeout", timeoutMs: 1000, args: [] };
+  if (kind === "spawn_error") return { ok: false, kind: "spawn_error", error: new Error("ENOENT"), args: [] };
+  return { ok: false, kind: "exit_nonzero", exitCode: 1, stdout: "", stderr: "boom", args: [] };
+}
+
+describe("polishLinearIssueTitle", () => {
+  it("returns heuristic title when autoName is null", async () => {
+    const result = await polishLinearIssueTitle({
+      prompt: "Fix login bug\nMore detail here",
+      autoName: null,
+    });
+    expect(result).toEqual({ title: "Fix login bug", source: "heuristic_no_config" });
+  });
+
+  it("returns null when prompt is empty", async () => {
+    const result = await polishLinearIssueTitle({ prompt: "   \n  ", autoName: null });
+    expect(result).toBeNull();
+  });
+
+  it("polishes via LLM and normalizes the output", async () => {
+    const result = await polishLinearIssueTitle({
+      prompt: "we get logged out on token refresh",
+      autoName: { provider: "claude" },
+      runLlm: async () => okLlm('```\n"Fix logout on token refresh."\n```'),
+    });
+    expect(result).toEqual({ title: "Fix logout on token refresh", source: "llm" });
+  });
+
+  it("truncates output longer than 80 chars", async () => {
+    const long = "Add a really really really really really really really really really really really long title";
+    const result = await polishLinearIssueTitle({
+      prompt: "task",
+      autoName: { provider: "claude" },
+      runLlm: async () => okLlm(long),
+    });
+    expect(result?.title.length).toBeLessThanOrEqual(80);
+    expect(result?.source).toBe("llm");
+  });
+
+  it("falls back to heuristic on LLM timeout", async () => {
+    const result = await polishLinearIssueTitle({
+      prompt: "Fix the search bar",
+      autoName: { provider: "claude" },
+      runLlm: async () => failLlm("timeout"),
+    });
+    expect(result).toEqual({ title: "Fix the search bar", source: "heuristic_fallback" });
+  });
+
+  it("falls back to heuristic when the CLI isn't on PATH", async () => {
+    const result = await polishLinearIssueTitle({
+      prompt: "Fix the search bar",
+      autoName: { provider: "claude" },
+      runLlm: async () => failLlm("spawn_error"),
+    });
+    expect(result).toEqual({ title: "Fix the search bar", source: "heuristic_fallback" });
+  });
+
+  it("falls back to heuristic on non-zero exit", async () => {
+    const result = await polishLinearIssueTitle({
+      prompt: "Fix the search bar",
+      autoName: { provider: "claude" },
+      runLlm: async () => failLlm("exit_nonzero"),
+    });
+    expect(result).toEqual({ title: "Fix the search bar", source: "heuristic_fallback" });
+  });
+
+  it("falls back to heuristic when LLM returns empty output", async () => {
+    const result = await polishLinearIssueTitle({
+      prompt: "Fix the search bar",
+      autoName: { provider: "claude" },
+      runLlm: async () => okLlm("   \n   "),
+    });
+    expect(result).toEqual({ title: "Fix the search bar", source: "heuristic_fallback" });
+  });
+});
+
+describe("extractKeywords", () => {
+  it("drops stopwords and short tokens", () => {
+    expect(extractKeywords("Fix the login redirect on token refresh")).toEqual([
+      "fix",
+      "login",
+      "redirect",
+      "token",
+    ]);
+  });
+
+  it("caps at the requested max", () => {
+    expect(extractKeywords("alpha beta gamma delta epsilon zeta", 3)).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
+  });
+
+  it("deduplicates repeated tokens", () => {
+    expect(extractKeywords("login login session login", 4)).toEqual(["login", "session"]);
+  });
+
+  it("returns an empty array when nothing usable remains", () => {
+    expect(extractKeywords("the a an and or")).toEqual([]);
+  });
+});
+
+describe("findDuplicateLinearIssue", () => {
+  const baseInput = {
+    polishedTitle: "Fix logout on token refresh",
+    prompt: "Fix logout on token refresh",
+    teamId: "team-1",
+    autoName: { provider: "claude" as const },
+  };
+
+  it("returns null when no keywords can be extracted", async () => {
+    const result = await findDuplicateLinearIssue({
+      ...baseInput,
+      polishedTitle: "the a an or",
+      search: async () => ({ ok: true, data: [] }) satisfies SearchTeamIssuesResult,
+      runLlm: async () => okLlm("NONE"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when search returns no candidates", async () => {
+    const result = await findDuplicateLinearIssue({
+      ...baseInput,
+      search: async () => ({ ok: true, data: [] }) satisfies SearchTeamIssuesResult,
+      runLlm: async () => okLlm("ENG-1"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns the matching candidate when the LLM picks an identifier", async () => {
+    const candidates = [
+      makeIssue({ identifier: "ENG-1", title: "Login redirect broken" }),
+      makeIssue({ identifier: "ENG-2", title: "Logout drops session on refresh" }),
+    ];
+    const result = await findDuplicateLinearIssue({
+      ...baseInput,
+      search: async () => ({ ok: true, data: candidates }) satisfies SearchTeamIssuesResult,
+      runLlm: async () => okLlm("ENG-2"),
+    });
+    expect(result?.identifier).toBe("ENG-2");
+  });
+
+  it("returns null when LLM says NONE", async () => {
+    const candidates = [makeIssue({ identifier: "ENG-1", title: "Unrelated" })];
+    const result = await findDuplicateLinearIssue({
+      ...baseInput,
+      search: async () => ({ ok: true, data: candidates }) satisfies SearchTeamIssuesResult,
+      runLlm: async () => okLlm("NONE"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("ignores LLM-emitted identifiers that don't match any candidate", async () => {
+    const candidates = [makeIssue({ identifier: "ENG-1", title: "Something" })];
+    const result = await findDuplicateLinearIssue({
+      ...baseInput,
+      search: async () => ({ ok: true, data: candidates }) satisfies SearchTeamIssuesResult,
+      runLlm: async () => okLlm("ENG-999"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the LLM times out", async () => {
+    const candidates = [makeIssue({ identifier: "ENG-1", title: "Logout on refresh" })];
+    const result = await findDuplicateLinearIssue({
+      ...baseInput,
+      search: async () => ({ ok: true, data: candidates }) satisfies SearchTeamIssuesResult,
+      runLlm: async () => failLlm("timeout"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when keyword search fails", async () => {
+    const result = await findDuplicateLinearIssue({
+      ...baseInput,
+      search: async () => ({ ok: false, error: "boom" }) satisfies SearchTeamIssuesResult,
+      runLlm: async () => okLlm("ENG-1"),
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/backend/src/__tests__/linear-title-service.test.ts
+++ b/backend/src/__tests__/linear-title-service.test.ts
@@ -44,6 +44,13 @@ describe("polishLinearIssueTitle", () => {
     expect(result).toEqual({ title: "Fix login bug", source: "heuristic_no_config" });
   });
 
+  it("heuristic title is capped at the same 80-char ceiling as the LLM title", async () => {
+    const long = "Fix the very very very very very very very very very very very very long title that keeps going";
+    const result = await polishLinearIssueTitle({ prompt: long, autoName: null });
+    expect(result?.title.length).toBeLessThanOrEqual(80);
+    expect(result?.title.endsWith("…")).toBe(true);
+  });
+
   it("returns null when prompt is empty", async () => {
     const result = await polishLinearIssueTitle({ prompt: "   \n  ", autoName: null });
     expect(result).toBeNull();
@@ -158,6 +165,58 @@ describe("findDuplicateLinearIssue", () => {
       runLlm: async () => okLlm("ENG-1"),
     });
     expect(result).toBeNull();
+  });
+
+  it("extracts identifier from chatty LLM output", async () => {
+    const candidates = [
+      makeIssue({ identifier: "ENG-2", title: "Logout drops session on refresh" }),
+    ];
+    for (const chatty of [
+      "Answer: ENG-2",
+      "ENG-2 - this matches the new task",
+      "  ENG-2  ",
+      "The matching issue is ENG-2 because both describe the same logout bug.",
+    ]) {
+      const result = await findDuplicateLinearIssue({
+        ...baseInput,
+        search: async () => ({ ok: true, data: candidates }) satisfies SearchTeamIssuesResult,
+        runLlm: async () => okLlm(chatty),
+      });
+      expect(result?.identifier, `chatty=${chatty}`).toBe("ENG-2");
+    }
+  });
+
+  it("includes the full prompt as additional context in the dedup user prompt", async () => {
+    const candidates = [makeIssue({ identifier: "ENG-1", title: "Something" })];
+    const seenUserPrompts: string[] = [];
+    await findDuplicateLinearIssue({
+      ...baseInput,
+      polishedTitle: "Fix logout",
+      prompt: "Fix logout when token refresh races. Repro: open in two tabs.",
+      search: async () => ({ ok: true, data: candidates }) satisfies SearchTeamIssuesResult,
+      runLlm: async (_config, _system, user) => {
+        seenUserPrompts.push(user);
+        return okLlm("NONE");
+      },
+    });
+    expect(seenUserPrompts[0]).toContain("Fix logout when token refresh races");
+    expect(seenUserPrompts[0]).toContain("Full task description:");
+  });
+
+  it("omits the full-prompt block when prompt and polished title are identical", async () => {
+    const candidates = [makeIssue({ identifier: "ENG-1", title: "Something" })];
+    const seenUserPrompts: string[] = [];
+    await findDuplicateLinearIssue({
+      ...baseInput,
+      polishedTitle: "Fix logout",
+      prompt: "Fix logout",
+      search: async () => ({ ok: true, data: candidates }) satisfies SearchTeamIssuesResult,
+      runLlm: async (_config, _system, user) => {
+        seenUserPrompts.push(user);
+        return okLlm("NONE");
+      },
+    });
+    expect(seenUserPrompts[0]).not.toContain("Full task description:");
   });
 
   it("returns the matching candidate when the LLM picks an identifier", async () => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1379,6 +1379,10 @@ async function apiGetLinearIssues(): Promise<Response> {
   return jsonResponse(result.data);
 }
 
+function apiGetAutoNameConfig(): Response {
+  return jsonResponse({ autoName: config.autoName });
+}
+
 const MAX_DIFF_BYTES = 200 * 1024;
 
 async function apiGetWorktreeDiff(name: string): Promise<Response> {
@@ -1747,6 +1751,10 @@ function startServer(port: number): ReturnType<typeof Bun.serve> {
 
     [apiPaths.fetchLinearIssues]: {
       GET: () => catching("GET /api/linear/issues", () => apiGetLinearIssues()),
+    },
+
+    [apiPaths.fetchAutoNameConfig]: {
+      GET: () => catching("GET /api/project/auto-name", async () => apiGetAutoNameConfig()),
     },
 
     [apiPaths.setLinearAutoCreate]: {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1380,7 +1380,13 @@ async function apiGetLinearIssues(): Promise<Response> {
 }
 
 function apiGetAutoNameConfig(): Response {
-  return jsonResponse({ autoName: config.autoName });
+  const apiKey = Bun.env.LINEAR_API_KEY;
+  const linearAvailability = !config.integrations.linear.enabled
+    ? "disabled"
+    : !apiKey?.trim()
+      ? "missing_api_key"
+      : "ready";
+  return jsonResponse({ autoName: config.autoName, linearAvailability });
 }
 
 const MAX_DIFF_BYTES = 200 * 1024;

--- a/backend/src/services/auto-name-service.ts
+++ b/backend/src/services/auto-name-service.ts
@@ -2,21 +2,9 @@ import type { AutoNameConfig } from "../domain/config";
 import { isValidBranchName } from "../domain/policies";
 import { generateFallbackBranchName } from "../lib/branch-name";
 import { log } from "../lib/log";
-
-interface SpawnResult {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-}
-
-interface SpawnOptions {
-  timeoutMs?: number;
-}
-
-type SpawnLike = (args: string[], options?: SpawnOptions) => Promise<SpawnResult>;
+import { llmProviderLabel, runShortLlmTask, type RunLlmOptions, type SpawnLike } from "./llm-spawn";
 
 const MAX_BRANCH_LENGTH = 40;
-const DEFAULT_AUTO_NAME_MODEL = "claude-haiku-4-5-20251001";
 const AUTO_NAME_TIMEOUT_MS = 15_000;
 
 const DEFAULT_SYSTEM_PROMPT = [
@@ -53,86 +41,8 @@ function getSystemPrompt(config: AutoNameConfig): string {
   return config.systemPrompt?.trim() || DEFAULT_SYSTEM_PROMPT;
 }
 
-class AutoNameTimeoutError extends Error {
-  constructor(readonly timeoutMs: number) {
-    super(`Auto-name timed out after ${timeoutMs}ms`);
-  }
-}
-
-async function defaultSpawn(args: string[], options: SpawnOptions = {}): Promise<SpawnResult> {
-  const proc = Bun.spawn(args, {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const resultPromise = Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]).then(([stdout, stderr, exitCode]) => ({ exitCode, stdout, stderr }));
-
-  if (options.timeoutMs === undefined) {
-    return await resultPromise;
-  }
-
-  return await new Promise<SpawnResult>((resolve, reject) => {
-    let settled = false;
-    const timeoutId = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      try {
-        proc.kill("SIGKILL");
-      } catch {}
-      reject(new AutoNameTimeoutError(options.timeoutMs!));
-    }, options.timeoutMs);
-
-    void resultPromise.then((result) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeoutId);
-      resolve(result);
-    }, (error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeoutId);
-      reject(error);
-    });
-  });
-}
-
-function buildClaudeArgs(model: string | undefined, systemPrompt: string, prompt: string): string[] {
-  const args = [
-    "claude",
-    "-p",
-    "--system-prompt", systemPrompt,
-    "--output-format", "text",
-    "--no-session-persistence",
-    "--model", model || DEFAULT_AUTO_NAME_MODEL,
-    "--effort", "low",
-  ];
-  args.push(prompt);
-  return args;
-}
-
-function escapeTomlString(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
-}
-
 function buildPrompt(prompt: string): string {
   return `Here is the task description: ${prompt}. You MUST return the branch name only, no other text or comments. Be fast, make it simple, and concise.`;
-}
-
-function buildCodexArgs(model: string | undefined, systemPrompt: string, prompt: string): string[] {
-  const args = [
-    "codex",
-    "-c", `developer_instructions="${escapeTomlString(systemPrompt)}"`,
-    "exec",
-    "--ephemeral",
-  ];
-  if (model) {
-    args.push("-m", model);
-  }
-  args.push(prompt);
-  return args;
 }
 
 export interface AutoNameServiceDependencies {
@@ -145,11 +55,11 @@ export interface AutoNameGenerator {
 }
 
 export class AutoNameService implements AutoNameGenerator {
-  private readonly spawnImpl: SpawnLike;
+  private readonly spawnImpl: SpawnLike | undefined;
   private readonly timeoutMs: number;
 
   constructor(deps: AutoNameServiceDependencies = {}) {
-    this.spawnImpl = deps.spawnImpl ?? defaultSpawn;
+    this.spawnImpl = deps.spawnImpl;
     this.timeoutMs = deps.timeoutMs ?? AUTO_NAME_TIMEOUT_MS;
   }
 
@@ -161,30 +71,25 @@ export class AutoNameService implements AutoNameGenerator {
 
     const systemPrompt = getSystemPrompt(config);
     const userPrompt = buildPrompt(prompt);
+    const cli = llmProviderLabel(config);
 
-    const args = config.provider === "claude"
-      ? buildClaudeArgs(config.model, systemPrompt, userPrompt)
-      : buildCodexArgs(config.model, systemPrompt, userPrompt);
+    const runOptions: RunLlmOptions = { timeoutMs: this.timeoutMs };
+    if (this.spawnImpl) runOptions.spawnImpl = this.spawnImpl;
+    const result = await runShortLlmTask(config, systemPrompt, userPrompt, runOptions);
 
-    const cli = config.provider === "claude" ? "claude" : "codex";
-
-    let result: SpawnResult;
-    try {
-      result = await this.spawnImpl(args, { timeoutMs: this.timeoutMs });
-    } catch (error) {
-      if (error instanceof AutoNameTimeoutError) {
+    if (!result.ok) {
+      if (result.kind === "timeout") {
         const fallback = generateFallbackBranchName();
         log.warn(`[auto-name] ${cli} timed out after ${this.timeoutMs}ms; using fallback branch ${fallback}`);
         return fallback;
       }
-      throw new Error(`'${cli}' CLI not found. Install it or check your PATH.`);
-    }
-
-    if (result.exitCode !== 0) {
+      if (result.kind === "spawn_error") {
+        throw new Error(`'${cli}' CLI not found. Install it or check your PATH.`);
+      }
       const stderr = result.stderr.trim();
       const stdout = result.stdout.trim();
       const output = stderr || stdout || `exit ${result.exitCode}`;
-      const command = args.join(" ");
+      const command = result.args.join(" ");
       throw new Error(`${cli} failed (command: ${command}): ${output}`);
     }
 

--- a/backend/src/services/linear-service.ts
+++ b/backend/src/services/linear-service.ts
@@ -589,7 +589,7 @@ const TEAM_BY_KEY_QUERY = `
 `;
 
 const TEAM_ISSUES_BY_KEYWORDS_QUERY = `
-  query TeamIssuesByKeywords($teamId: String!, $titleFilters: [IssueFilter!]!, $first: Int!) {
+  query TeamIssuesByKeywords($teamId: ID!, $titleFilters: [IssueFilter!]!, $first: Int!) {
     issues(
       filter: {
         team: { id: { eq: $teamId } }

--- a/backend/src/services/linear-service.ts
+++ b/backend/src/services/linear-service.ts
@@ -589,7 +589,7 @@ const TEAM_BY_KEY_QUERY = `
 `;
 
 const TEAM_ISSUES_BY_KEYWORDS_QUERY = `
-  query TeamIssuesByKeywords($teamId: ID!, $titleFilters: [IssueFilter!]!, $first: Int!) {
+  query TeamIssuesByKeywords($teamId: String!, $titleFilters: [IssueFilter!]!, $first: Int!) {
     issues(
       filter: {
         team: { id: { eq: $teamId } }

--- a/backend/src/services/linear-service.ts
+++ b/backend/src/services/linear-service.ts
@@ -588,6 +588,86 @@ const TEAM_BY_KEY_QUERY = `
   }
 `;
 
+const TEAM_ISSUES_BY_KEYWORDS_QUERY = `
+  query TeamIssuesByKeywords($teamId: ID!, $titleFilters: [IssueFilter!]!, $first: Int!) {
+    issues(
+      filter: {
+        team: { id: { eq: $teamId } }
+        state: { type: { in: ["triage", "backlog", "unstarted", "started"] } }
+        or: $titleFilters
+      }
+      orderBy: updatedAt
+      first: $first
+    ) {
+      nodes {
+        id
+        identifier
+        title
+        description
+        priority
+        priorityLabel
+        url
+        branchName
+        dueDate
+        updatedAt
+        state { name color type }
+        team { name key }
+        labels { nodes { name color } }
+        project { name }
+      }
+    }
+  }
+`;
+
+interface TeamIssuesByKeywordsQueryData {
+  issues: {
+    nodes: GqlIssueNode[];
+  };
+}
+
+export type SearchTeamIssuesResult =
+  | { ok: true; data: LinearIssue[] }
+  | { ok: false; error: string };
+
+export async function searchTeamIssuesByKeywords(input: {
+  teamId: string;
+  keywords: string[];
+  limit?: number;
+}): Promise<SearchTeamIssuesResult> {
+  const keywords = input.keywords.map((k) => k.trim()).filter((k) => k.length > 0);
+  if (keywords.length === 0) {
+    return { ok: true, data: [] };
+  }
+  const titleFilters = keywords.map((keyword) => ({ title: { containsIgnoreCase: keyword } }));
+  const response = await postLinearGraphql<TeamIssuesByKeywordsQueryData>(
+    TEAM_ISSUES_BY_KEYWORDS_QUERY,
+    { teamId: input.teamId, titleFilters, first: input.limit ?? 10 },
+  );
+  if (!response.ok) return { ok: false, error: response.error };
+  const error = gqlErrorMessage(response.data);
+  if (error) return { ok: false, error };
+  const nodes = response.data.data?.issues.nodes ?? [];
+  return {
+    ok: true,
+    data: nodes.map((node) => ({
+      id: node.id,
+      identifier: node.identifier,
+      title: node.title,
+      description: node.description,
+      priority: node.priority,
+      priorityLabel: node.priorityLabel,
+      url: node.url,
+      branchName: node.branchName,
+      dueDate: node.dueDate,
+      updatedAt: node.updatedAt,
+      state: node.state,
+      team: node.team,
+      labels: node.labels.nodes,
+      project: node.project?.name ?? null,
+    })),
+  };
+}
+
 const FILE_UPLOAD_MUTATION = `
   mutation FileUpload($contentType: String!, $filename: String!, $size: Int!) {
     fileUpload(contentType: $contentType, filename: $filename, size: $size) {

--- a/backend/src/services/linear-title-service.ts
+++ b/backend/src/services/linear-title-service.ts
@@ -1,0 +1,217 @@
+import type { AutoNameConfig } from "../domain/config";
+import { log } from "../lib/log";
+import { llmProviderLabel, runShortLlmTask, type RunLlmResult } from "./llm-spawn";
+import { searchTeamIssuesByKeywords, type LinearIssue } from "./linear-service";
+
+const TITLE_TIMEOUT_MS = 15_000;
+const DEDUP_TIMEOUT_MS = 15_000;
+const MAX_TITLE_LENGTH = 80;
+const MAX_DEDUP_CANDIDATES = 10;
+
+const POLISH_SYSTEM_PROMPT = [
+  "You convert a developer task description into a concise Linear issue title.",
+  "Return only the title, one line, no quotes, no surrounding punctuation, no trailing period.",
+  "Use imperative mood (e.g., 'Fix login redirect', 'Add CSV export').",
+  "Use Sentence case.",
+  "Aim for 4-12 words.",
+  `Maximum ${MAX_TITLE_LENGTH} characters.`,
+].join(" ");
+
+const DEDUP_SYSTEM_PROMPT = [
+  "You decide whether an existing Linear issue describes the same task as a new one.",
+  "You will be shown a new task title and a numbered list of existing issues.",
+  "Respond with exactly one token: either the identifier of the matching issue (e.g., ENG-42), or NONE.",
+  "Be conservative: only match if the existing issue clearly describes the same underlying work.",
+  "Do not include any other text, punctuation, or explanation.",
+].join(" ");
+
+const STOPWORDS = new Set([
+  "the", "a", "an", "and", "or", "but", "is", "are", "was", "were", "be", "been",
+  "being", "to", "of", "in", "on", "at", "for", "with", "by", "from", "as", "into",
+  "this", "that", "these", "those", "it", "its", "we", "our", "you", "your",
+  "can", "should", "would", "could", "will", "do", "does", "did", "have", "has",
+  "had", "not", "no", "if", "then", "than", "when", "where", "why", "how",
+  "i", "me", "my", "us", "them", "their",
+]);
+
+export type TitlePolishSource = "llm" | "heuristic_no_config" | "heuristic_fallback";
+
+export interface PolishedTitleResult {
+  title: string;
+  source: TitlePolishSource;
+}
+
+function heuristicTitle(prompt: string): string | null {
+  const firstLine = prompt
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return null;
+  return firstLine.length > 100 ? `${firstLine.slice(0, 97)}…` : firstLine;
+}
+
+function normalizePolishedTitle(raw: string): string | null {
+  let title = raw.trim();
+  title = title.replace(/^```[\w-]*\s*/, "").replace(/\s*```$/, "");
+  title = title.split(/\r?\n/)[0]?.trim() ?? "";
+  title = title.replace(/^title\s*:\s*/i, "");
+  title = title.replace(/^["'`]+|["'`]+$/g, "");
+  title = title.replace(/[.!?,;:]+$/, "");
+  title = title.replace(/\s+/g, " ").trim();
+  if (!title) return null;
+  if (title.length > MAX_TITLE_LENGTH) {
+    title = title.slice(0, MAX_TITLE_LENGTH).trimEnd();
+  }
+  return title;
+}
+
+export type RunLlmFn = typeof runShortLlmTask;
+
+export interface PolishLinearIssueTitleInput {
+  prompt: string;
+  autoName: AutoNameConfig | null;
+  runLlm?: RunLlmFn;
+}
+
+export async function polishLinearIssueTitle(input: PolishLinearIssueTitleInput): Promise<PolishedTitleResult | null> {
+  const heuristic = heuristicTitle(input.prompt);
+  if (!input.autoName) {
+    return heuristic ? { title: heuristic, source: "heuristic_no_config" } : null;
+  }
+  if (!heuristic) return null;
+
+  const runLlm = input.runLlm ?? runShortLlmTask;
+  let result: RunLlmResult;
+  try {
+    result = await runLlm(
+      input.autoName,
+      POLISH_SYSTEM_PROMPT,
+      input.prompt.trim(),
+      { timeoutMs: TITLE_TIMEOUT_MS },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`[linear-title] polish call threw: ${msg}; falling back to heuristic`);
+    return { title: heuristic, source: "heuristic_fallback" };
+  }
+
+  const cli = llmProviderLabel(input.autoName);
+  if (!result.ok) {
+    if (result.kind === "timeout") {
+      log.warn(`[linear-title] ${cli} polish timed out after ${result.timeoutMs}ms; using heuristic`);
+    } else if (result.kind === "spawn_error") {
+      log.warn(`[linear-title] ${cli} not on PATH; using heuristic title`);
+    } else {
+      const stderr = result.stderr.trim() || `exit ${result.exitCode}`;
+      log.warn(`[linear-title] ${cli} polish failed: ${stderr}; using heuristic`);
+    }
+    return { title: heuristic, source: "heuristic_fallback" };
+  }
+
+  const normalized = normalizePolishedTitle(result.stdout);
+  if (!normalized) {
+    log.warn(`[linear-title] ${cli} returned empty/unusable title; using heuristic`);
+    return { title: heuristic, source: "heuristic_fallback" };
+  }
+  return { title: normalized, source: "llm" };
+}
+
+export function extractKeywords(title: string, max = 4): string[] {
+  const tokens = title
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 2 && !STOPWORDS.has(t));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const token of tokens) {
+    if (seen.has(token)) continue;
+    seen.add(token);
+    out.push(token);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+export interface FindDuplicateLinearIssueInput {
+  polishedTitle: string;
+  prompt: string;
+  teamId: string;
+  autoName: AutoNameConfig;
+  search?: typeof searchTeamIssuesByKeywords;
+  runLlm?: RunLlmFn;
+}
+
+export async function findDuplicateLinearIssue(
+  input: FindDuplicateLinearIssueInput,
+): Promise<LinearIssue | null> {
+  const keywords = extractKeywords(input.polishedTitle);
+  if (keywords.length === 0) return null;
+
+  const search = input.search ?? searchTeamIssuesByKeywords;
+  const searchResult = await search({
+    teamId: input.teamId,
+    keywords,
+    limit: MAX_DEDUP_CANDIDATES,
+  });
+  if (!searchResult.ok) {
+    log.warn(`[linear-title] dedup search failed: ${searchResult.error}`);
+    return null;
+  }
+  const candidates = searchResult.data;
+  if (candidates.length === 0) return null;
+
+  const userPrompt = buildDedupUserPrompt(input.polishedTitle, candidates);
+  const runLlm = input.runLlm ?? runShortLlmTask;
+
+  let result: RunLlmResult;
+  try {
+    result = await runLlm(
+      input.autoName,
+      DEDUP_SYSTEM_PROMPT,
+      userPrompt,
+      { timeoutMs: DEDUP_TIMEOUT_MS },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`[linear-title] dedup call threw: ${msg}`);
+    return null;
+  }
+
+  if (!result.ok) {
+    const cli = llmProviderLabel(input.autoName);
+    if (result.kind === "timeout") {
+      log.warn(`[linear-title] ${cli} dedup timed out after ${result.timeoutMs}ms`);
+    } else if (result.kind === "spawn_error") {
+      log.warn(`[linear-title] ${cli} not on PATH; skipping dedup`);
+    } else {
+      const stderr = result.stderr.trim() || `exit ${result.exitCode}`;
+      log.warn(`[linear-title] ${cli} dedup failed: ${stderr}`);
+    }
+    return null;
+  }
+
+  return parseDedupResponse(result.stdout, candidates);
+}
+
+function buildDedupUserPrompt(polishedTitle: string, candidates: LinearIssue[]): string {
+  const list = candidates
+    .map((c) => `${c.identifier}: ${c.title}`)
+    .join("\n");
+  return [
+    `New task title: ${polishedTitle}`,
+    "",
+    "Existing issues:",
+    list,
+    "",
+    "Return the identifier of the matching issue, or NONE.",
+  ].join("\n");
+}
+
+function parseDedupResponse(stdout: string, candidates: LinearIssue[]): LinearIssue | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  const firstLine = trimmed.split(/\r?\n/)[0]?.trim() ?? "";
+  const cleaned = firstLine.replace(/[^A-Z0-9-]/gi, "").toUpperCase();
+  if (!cleaned || cleaned === "NONE") return null;
+  return candidates.find((c) => c.identifier.toUpperCase() === cleaned) ?? null;
+}

--- a/backend/src/services/linear-title-service.ts
+++ b/backend/src/services/linear-title-service.ts
@@ -6,7 +6,7 @@ import { searchTeamIssuesByKeywords, type LinearIssue } from "./linear-service";
 const TITLE_TIMEOUT_MS = 15_000;
 const DEDUP_TIMEOUT_MS = 15_000;
 const MAX_TITLE_LENGTH = 80;
-const MAX_DEDUP_CANDIDATES = 10;
+const MAX_DEDUP_CANDIDATES = 20;
 
 const POLISH_SYSTEM_PROMPT = [
   "You convert a developer task description into a concise Linear issue title.",
@@ -209,8 +209,9 @@ function buildDedupUserPrompt(input: {
     .map((c) => `${c.identifier}: ${c.title}`)
     .join("\n");
   const fullPrompt = input.prompt.trim();
-  const excerpt = fullPrompt.length > MAX_DEDUP_PROMPT_EXCERPT
-    ? `${fullPrompt.slice(0, MAX_DEDUP_PROMPT_EXCERPT)}…`
+  const codePoints = [...fullPrompt];
+  const excerpt = codePoints.length > MAX_DEDUP_PROMPT_EXCERPT
+    ? `${codePoints.slice(0, MAX_DEDUP_PROMPT_EXCERPT).join("")}…`
     : fullPrompt;
   const lines = [`New task title: ${input.polishedTitle}`];
   if (excerpt && excerpt !== input.polishedTitle) {

--- a/backend/src/services/linear-title-service.ts
+++ b/backend/src/services/linear-title-service.ts
@@ -3,27 +3,41 @@ import { log } from "../lib/log";
 import { llmProviderLabel, runShortLlmTask, type RunLlmResult } from "./llm-spawn";
 import { searchTeamIssuesByKeywords, type LinearIssue } from "./linear-service";
 
-const TITLE_TIMEOUT_MS = 15_000;
-const DEDUP_TIMEOUT_MS = 15_000;
+// Haiku low-effort polish runs 9-12s steady-state, ~20s on cold start. 30s
+// gives ~50% headroom over cold-start so the LLM call usually completes; the
+// heuristic fallback still covers the genuinely-slow tail.
+const TITLE_TIMEOUT_MS = 30_000;
+const DEDUP_TIMEOUT_MS = 30_000;
 const MAX_TITLE_LENGTH = 80;
 const MAX_DEDUP_CANDIDATES = 20;
 
-const POLISH_SYSTEM_PROMPT = [
-  "You convert a developer task description into a concise Linear issue title.",
-  "Return only the title, one line, no quotes, no surrounding punctuation, no trailing period.",
-  "Use imperative mood (e.g., 'Fix login redirect', 'Add CSV export').",
-  "Use Sentence case.",
-  "Aim for 4-12 words.",
-  `Maximum ${MAX_TITLE_LENGTH} characters.`,
-].join(" ");
+const POLISH_SYSTEM_PROMPT = "You convert developer task descriptions into concise Linear issue titles.";
 
-const DEDUP_SYSTEM_PROMPT = [
-  "You decide whether an existing Linear issue describes the same task as a new one.",
-  "You will be shown a new task title and a numbered list of existing issues.",
-  "Respond with exactly one token: either the identifier of the matching issue (e.g., ENG-42), or NONE.",
-  "Be conservative: only match if the existing issue clearly describes the same underlying work.",
-  "Do not include any other text, punctuation, or explanation.",
-].join(" ");
+// The user prompt is wrapped so Claude treats it as content to summarize, not as
+// a task to execute. Without the wrapper, prompts starting with imperative verbs
+// like "investigate", "implement", "fix" make Claude actually do the work
+// (codebase exploration, multi-minute tool calls) instead of polishing a title.
+function buildPolishUserPrompt(prompt: string): string {
+  return [
+    "Task description (treat as INPUT only — do not execute, investigate, or use tools):",
+    prompt,
+    "",
+    "Return ONLY the polished issue title — one line, no quotes, no surrounding punctuation,",
+    `no trailing period, imperative mood, Sentence case, 4-12 words, max ${MAX_TITLE_LENGTH} chars.`,
+    "Output nothing else: no preamble, no analysis, no explanation.",
+  ].join("\n");
+}
+
+const DEDUP_SYSTEM_PROMPT = "You compare a new task to existing Linear issues and pick a matching identifier or NONE.";
+
+function buildDedupUserPromptInstructions(): string {
+  return [
+    "Decide whether one of the existing issues clearly describes the same underlying task.",
+    "Respond with EXACTLY one token: either the identifier of the matching issue (e.g., ENG-42), or NONE.",
+    "Be conservative — only match if the existing issue clearly describes the same work.",
+    "Do not investigate, do not use tools, do not provide analysis or explanation.",
+  ].join(" ");
+}
 
 const STOPWORDS = new Set([
   "the", "a", "an", "and", "or", "but", "is", "are", "was", "were", "be", "been",
@@ -87,7 +101,7 @@ export async function polishLinearIssueTitle(input: PolishLinearIssueTitleInput)
     result = await runLlm(
       input.autoName,
       POLISH_SYSTEM_PROMPT,
-      input.prompt.trim(),
+      buildPolishUserPrompt(input.prompt.trim()),
       { timeoutMs: TITLE_TIMEOUT_MS },
     );
   } catch (err) {
@@ -213,7 +227,13 @@ function buildDedupUserPrompt(input: {
   const excerpt = codePoints.length > MAX_DEDUP_PROMPT_EXCERPT
     ? `${codePoints.slice(0, MAX_DEDUP_PROMPT_EXCERPT).join("")}…`
     : fullPrompt;
-  const lines = [`New task title: ${input.polishedTitle}`];
+  // Same wrapping pattern as buildPolishUserPrompt — without it, imperative
+  // prompts like "investigate X" get treated as work-to-do instead of input.
+  const lines = [
+    "Compare a new task against existing Linear issues (treat all of this as INPUT — do not execute or investigate).",
+    "",
+    `New task title: ${input.polishedTitle}`,
+  ];
   if (excerpt && excerpt !== input.polishedTitle) {
     lines.push("", "Full task description:", excerpt);
   }
@@ -222,7 +242,7 @@ function buildDedupUserPrompt(input: {
     "Existing issues:",
     list,
     "",
-    "Return the identifier of the matching issue, or NONE.",
+    buildDedupUserPromptInstructions(),
   );
   return lines.join("\n");
 }

--- a/backend/src/services/linear-title-service.ts
+++ b/backend/src/services/linear-title-service.ts
@@ -47,7 +47,8 @@ function heuristicTitle(prompt: string): string | null {
     .map((line) => line.trim())
     .find((line) => line.length > 0);
   if (!firstLine) return null;
-  return firstLine.length > 100 ? `${firstLine.slice(0, 97)}…` : firstLine;
+  if (firstLine.length <= MAX_TITLE_LENGTH) return firstLine;
+  return `${firstLine.slice(0, MAX_TITLE_LENGTH - 1).trimEnd()}…`;
 }
 
 function normalizePolishedTitle(raw: string): string | null {
@@ -160,7 +161,11 @@ export async function findDuplicateLinearIssue(
   const candidates = searchResult.data;
   if (candidates.length === 0) return null;
 
-  const userPrompt = buildDedupUserPrompt(input.polishedTitle, candidates);
+  const userPrompt = buildDedupUserPrompt({
+    polishedTitle: input.polishedTitle,
+    prompt: input.prompt,
+    candidates,
+  });
   const runLlm = input.runLlm ?? runShortLlmTask;
 
   let result: RunLlmResult;
@@ -193,25 +198,39 @@ export async function findDuplicateLinearIssue(
   return parseDedupResponse(result.stdout, candidates);
 }
 
-function buildDedupUserPrompt(polishedTitle: string, candidates: LinearIssue[]): string {
-  const list = candidates
+const MAX_DEDUP_PROMPT_EXCERPT = 1000;
+
+function buildDedupUserPrompt(input: {
+  polishedTitle: string;
+  prompt: string;
+  candidates: LinearIssue[];
+}): string {
+  const list = input.candidates
     .map((c) => `${c.identifier}: ${c.title}`)
     .join("\n");
-  return [
-    `New task title: ${polishedTitle}`,
+  const fullPrompt = input.prompt.trim();
+  const excerpt = fullPrompt.length > MAX_DEDUP_PROMPT_EXCERPT
+    ? `${fullPrompt.slice(0, MAX_DEDUP_PROMPT_EXCERPT)}…`
+    : fullPrompt;
+  const lines = [`New task title: ${input.polishedTitle}`];
+  if (excerpt && excerpt !== input.polishedTitle) {
+    lines.push("", "Full task description:", excerpt);
+  }
+  lines.push(
     "",
     "Existing issues:",
     list,
     "",
     "Return the identifier of the matching issue, or NONE.",
-  ].join("\n");
+  );
+  return lines.join("\n");
 }
 
 function parseDedupResponse(stdout: string, candidates: LinearIssue[]): LinearIssue | null {
   const trimmed = stdout.trim();
   if (!trimmed) return null;
-  const firstLine = trimmed.split(/\r?\n/)[0]?.trim() ?? "";
-  const cleaned = firstLine.replace(/[^A-Z0-9-]/gi, "").toUpperCase();
-  if (!cleaned || cleaned === "NONE") return null;
-  return candidates.find((c) => c.identifier.toUpperCase() === cleaned) ?? null;
+  const match = trimmed.match(/\b([A-Z]+-\d+)\b/i);
+  if (!match) return null;
+  const identifier = match[1].toUpperCase();
+  return candidates.find((c) => c.identifier.toUpperCase() === identifier) ?? null;
 }

--- a/backend/src/services/llm-spawn.ts
+++ b/backend/src/services/llm-spawn.ts
@@ -1,0 +1,139 @@
+import type { AutoNameConfig } from "../domain/config";
+
+export interface SpawnResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface SpawnOptions {
+  timeoutMs?: number;
+}
+
+export type SpawnLike = (args: string[], options?: SpawnOptions) => Promise<SpawnResult>;
+
+export class LlmSpawnTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`LLM spawn timed out after ${timeoutMs}ms`);
+  }
+}
+
+export async function defaultLlmSpawn(args: string[], options: SpawnOptions = {}): Promise<SpawnResult> {
+  const proc = Bun.spawn(args, {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const resultPromise = Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]).then(([stdout, stderr, exitCode]) => ({ exitCode, stdout, stderr }));
+
+  if (options.timeoutMs === undefined) {
+    return await resultPromise;
+  }
+
+  return await new Promise<SpawnResult>((resolve, reject) => {
+    let settled = false;
+    const timeoutId = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        proc.kill("SIGKILL");
+      } catch {}
+      reject(new LlmSpawnTimeoutError(options.timeoutMs!));
+    }, options.timeoutMs);
+
+    void resultPromise.then((result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      resolve(result);
+    }, (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      reject(error);
+    });
+  });
+}
+
+function escapeTomlString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+const DEFAULT_CLAUDE_MODEL = "claude-haiku-4-5-20251001";
+
+export function buildLlmArgs(config: AutoNameConfig, systemPrompt: string, userPrompt: string): string[] {
+  if (config.provider === "claude") {
+    return [
+      "claude",
+      "-p",
+      "--system-prompt", systemPrompt,
+      "--output-format", "text",
+      "--no-session-persistence",
+      "--model", config.model || DEFAULT_CLAUDE_MODEL,
+      "--effort", "low",
+      userPrompt,
+    ];
+  }
+  const args = [
+    "codex",
+    "-c", `developer_instructions="${escapeTomlString(systemPrompt)}"`,
+    "exec",
+    "--ephemeral",
+  ];
+  if (config.model) {
+    args.push("-m", config.model);
+  }
+  args.push(userPrompt);
+  return args;
+}
+
+export type RunLlmResult =
+  | { ok: true; stdout: string; stderr: string; args: string[] }
+  | { ok: false; kind: "timeout"; timeoutMs: number; args: string[] }
+  | { ok: false; kind: "spawn_error"; error: unknown; args: string[] }
+  | { ok: false; kind: "exit_nonzero"; exitCode: number; stdout: string; stderr: string; args: string[] };
+
+export interface RunLlmOptions {
+  timeoutMs?: number;
+  spawnImpl?: SpawnLike;
+}
+
+export async function runShortLlmTask(
+  config: AutoNameConfig,
+  systemPrompt: string,
+  userPrompt: string,
+  options: RunLlmOptions = {},
+): Promise<RunLlmResult> {
+  const args = buildLlmArgs(config, systemPrompt, userPrompt);
+  const spawnImpl = options.spawnImpl ?? defaultLlmSpawn;
+
+  let result: SpawnResult;
+  try {
+    result = await spawnImpl(args, { timeoutMs: options.timeoutMs });
+  } catch (error) {
+    if (error instanceof LlmSpawnTimeoutError) {
+      return { ok: false, kind: "timeout", timeoutMs: error.timeoutMs, args };
+    }
+    return { ok: false, kind: "spawn_error", error, args };
+  }
+
+  if (result.exitCode !== 0) {
+    return {
+      ok: false,
+      kind: "exit_nonzero",
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      args,
+    };
+  }
+
+  return { ok: true, stdout: result.stdout, stderr: result.stderr, args };
+}
+
+export function llmProviderLabel(config: AutoNameConfig): string {
+  return config.provider === "claude" ? "claude" : "codex";
+}

--- a/backend/src/services/llm-spawn.ts
+++ b/backend/src/services/llm-spawn.ts
@@ -29,7 +29,8 @@ export async function defaultLlmSpawn(args: string[], options: SpawnOptions = {}
     proc.exited,
   ]).then(([stdout, stderr, exitCode]) => ({ exitCode, stdout, stderr }));
 
-  if (options.timeoutMs === undefined) {
+  const timeoutMs = options.timeoutMs;
+  if (timeoutMs === undefined) {
     return await resultPromise;
   }
 
@@ -41,8 +42,8 @@ export async function defaultLlmSpawn(args: string[], options: SpawnOptions = {}
       try {
         proc.kill("SIGKILL");
       } catch {}
-      reject(new LlmSpawnTimeoutError(options.timeoutMs!));
-    }, options.timeoutMs);
+      reject(new LlmSpawnTimeoutError(timeoutMs));
+    }, timeoutMs);
 
     void resultPromise.then((result) => {
       if (settled) return;

--- a/bin/src/oneshot.ts
+++ b/bin/src/oneshot.ts
@@ -714,17 +714,21 @@ export async function runOneshot(parsed: ParsedOneshotCommand, port: number): Pr
   try {
     // Preflight: the final `postWorktreeToLinear` call runs on the server, so
     // the server's LINEAR_API_KEY must be set. Without this check, the user
-    // could run for hours before discovering the post-back will fail.
+    // could run for hours before discovering the post-back will fail. We fold
+    // this availability check into the autoName fetch since both gate the same
+    // --linear flow and the combined endpoint avoids a second round-trip.
+    let autoName: Awaited<ReturnType<typeof api.fetchAutoNameConfig>>["autoName"] = null;
     if (postToLinearTarget) {
-      const availability = await api.fetchLinearIssues();
-      if (availability.availability === "missing_api_key") {
+      const projectAutoName = await api.fetchAutoNameConfig();
+      if (projectAutoName.linearAvailability === "missing_api_key") {
         stderr(`[${timestamp()}] [error] server has no LINEAR_API_KEY — the post-back to Linear at the end of the run will fail. Set the env var on the webmux server and restart it.`);
         return 1;
       }
-      if (availability.availability === "disabled") {
+      if (projectAutoName.linearAvailability === "disabled") {
         stderr(`[${timestamp()}] [error] Linear integration is disabled on the webmux server.`);
         return 1;
       }
+      autoName = projectAutoName.autoName;
     }
 
     // Resolve Linear in-process (using LINEAR_API_KEY from the CLI shell's env)
@@ -736,7 +740,6 @@ export async function runOneshot(parsed: ParsedOneshotCommand, port: number): Pr
         stderr(`[${timestamp()}] [error] --linear ${postToLinearTarget.teamKey} requires --prompt to derive an issue title`);
         return 1;
       }
-      const { autoName } = await api.fetchAutoNameConfig();
 
       const polished = await polishLinearIssueTitle({ prompt: parsed.prompt, autoName });
       if (!polished) {
@@ -783,6 +786,8 @@ export async function runOneshot(parsed: ParsedOneshotCommand, port: number): Pr
           stdout(`[${timestamp()}] [event] using existing Linear issue ${duplicate.identifier} → ${duplicate.url}`);
           fromLinearIssueId = duplicate.identifier;
           postToLinearTarget = { kind: "issue", issueId: duplicate.identifier };
+        } else {
+          stdout(`[${timestamp()}] [event] user chose to create a new issue despite candidate ${duplicate.identifier}`);
         }
       }
 

--- a/bin/src/oneshot.ts
+++ b/bin/src/oneshot.ts
@@ -1,6 +1,8 @@
+import * as p from "@clack/prompts";
 import { apiPaths, AgentsUiConversationEventSchema, createApi, parseLinearTarget, type AgentsUiConversationMessage, type AgentsUiConversationEvent, type AgentsUiWorktreeConversationResponse, type CreateWorktreeRequest, type PostWorktreeToLinearTarget, type ProjectWorktreeSnapshot } from "@webmux/api-contract";
-import { createLinearIssue, fetchTeamByKey } from "../../backend/src/services/linear-service";
+import { createLinearIssue, fetchTeamByKey, type LinearIssue } from "../../backend/src/services/linear-service";
 import { buildSeedFromLinear, defaultSeedFromLinearDeps } from "../../backend/src/services/conversation-export-service";
+import { findDuplicateLinearIssue, polishLinearIssueTitle } from "../../backend/src/services/linear-title-service";
 import { CommandUsageError, formatServerError } from "./shared";
 
 export interface ParsedOneshotCommand {
@@ -40,7 +42,9 @@ export function getOneshotUsage(): string {
     "  --keep-open              Don't auto-close the worktree session when the agent finishes",
     "  --linear ID|TEAM         Tie this oneshot to Linear:",
     "                             ENG-123  — load the issue body as context, post results back",
-    "                             ENG      — create a new issue in that team when done",
+    "                             ENG      — create a new issue in that team when done.",
+    "                                        When autoName is configured, the title is polished",
+    "                                        and likely duplicates are surfaced before creation.",
     "  --branch <name>          Override the branch when --linear resolves to one",
     "  --help                   Show this help message",
   ].join("\n");
@@ -652,14 +656,45 @@ function pollConversationHistory(
   };
 }
 
-function deriveOneshotIssueTitle(prompt: string | null): string | null {
-  if (!prompt) return null;
-  const firstLine = prompt
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find((line) => line.length > 0);
-  if (!firstLine) return null;
-  return firstLine.length > 100 ? `${firstLine.slice(0, 97)}…` : firstLine;
+type DuplicateChoice = "use_existing" | "create_new" | "cancel";
+
+async function promptDuplicateChoice(
+  candidate: LinearIssue,
+  polishedTitle: string,
+): Promise<DuplicateChoice> {
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      `[${timestamp()}] [warn] non-interactive shell; ignoring possible duplicate ${candidate.identifier}: "${candidate.title}" (${candidate.url})\n`,
+    );
+    return "create_new";
+  }
+  p.note(
+    `${candidate.identifier}: ${candidate.title}\n${candidate.url}`,
+    "Possible existing match",
+  );
+  const choice = await p.select<DuplicateChoice>({
+    message: "Found a possible existing match. What should webmux do?",
+    initialValue: "use_existing",
+    options: [
+      {
+        value: "use_existing",
+        label: `Use existing (${candidate.identifier})`,
+        hint: "Treat this oneshot as resuming the existing issue",
+      },
+      {
+        value: "create_new",
+        label: "Create new issue",
+        hint: `Title: "${polishedTitle}"`,
+      },
+      {
+        value: "cancel",
+        label: "Cancel",
+        hint: "Don't start the oneshot",
+      },
+    ],
+  });
+  if (p.isCancel(choice)) return "cancel";
+  return choice;
 }
 
 export async function runOneshot(parsed: ParsedOneshotCommand, port: number): Promise<number> {
@@ -697,11 +732,21 @@ export async function runOneshot(parsed: ParsedOneshotCommand, port: number): Pr
     // accepts a `fromLinear.issueId` payload — it just doesn't need to re-fetch
     // because we pass the resolved branch + conversationContext explicitly.
     if (postToLinearTarget?.kind === "team") {
-      const title = deriveOneshotIssueTitle(parsed.prompt);
-      if (!title) {
+      if (!parsed.prompt) {
         stderr(`[${timestamp()}] [error] --linear ${postToLinearTarget.teamKey} requires --prompt to derive an issue title`);
         return 1;
       }
+      const { autoName } = await api.fetchAutoNameConfig();
+
+      const polished = await polishLinearIssueTitle({ prompt: parsed.prompt, autoName });
+      if (!polished) {
+        stderr(`[${timestamp()}] [error] could not derive a title from --prompt`);
+        return 1;
+      }
+      if (polished.source === "llm") {
+        stdout(`[${timestamp()}] [event] polished title: "${polished.title}"`);
+      }
+
       if (parsed.resume) {
         // The resumed worktree has no Linear issue of its own (we'd have routed
         // through the issue-id path otherwise), so we're tracking this run as a
@@ -709,24 +754,54 @@ export async function runOneshot(parsed: ParsedOneshotCommand, port: number): Pr
         // from whatever the resumed session was originally about.
         stdout(`[${timestamp()}] [event] no Linear issue for this resume; creating a fresh ${postToLinearTarget.teamKey}-N for the post-back`);
       }
-      stdout(`[${timestamp()}] [event] creating Linear issue in team ${postToLinearTarget.teamKey}...`);
+
       const team = await fetchTeamByKey(postToLinearTarget.teamKey);
       if (!team.ok) {
         stderr(`[${timestamp()}] [error] Linear team lookup failed: ${team.error}`);
         return 1;
       }
-      const created = await createLinearIssue({
-        teamId: team.data.id,
-        title,
-        description: "",
-      });
-      if (!created.ok) {
-        stderr(`[${timestamp()}] [error] Linear issue creation failed: ${created.error}`);
-        return 1;
+
+      // Dedup check: only meaningful when an autoName LLM is available — the
+      // LLM is what filters keyword candidates down to actual semantic matches.
+      let duplicate: LinearIssue | null = null;
+      if (autoName) {
+        duplicate = await findDuplicateLinearIssue({
+          polishedTitle: polished.title,
+          prompt: parsed.prompt,
+          teamId: team.data.id,
+          autoName,
+        });
       }
-      stdout(`[${timestamp()}] [event] created Linear issue ${created.data.identifier} → ${created.data.url}`);
-      fromLinearIssueId = created.data.identifier;
-      postToLinearTarget = { kind: "issue", issueId: created.data.identifier };
+
+      if (duplicate) {
+        const choice = await promptDuplicateChoice(duplicate, polished.title);
+        if (choice === "cancel") {
+          stdout(`[${timestamp()}] [event] cancelled by user`);
+          return 0;
+        }
+        if (choice === "use_existing") {
+          stdout(`[${timestamp()}] [event] using existing Linear issue ${duplicate.identifier} → ${duplicate.url}`);
+          fromLinearIssueId = duplicate.identifier;
+          postToLinearTarget = { kind: "issue", issueId: duplicate.identifier };
+        }
+      }
+
+      // If we didn't switch to an existing issue, create a new one.
+      if (postToLinearTarget.kind === "team") {
+        stdout(`[${timestamp()}] [event] creating Linear issue in team ${postToLinearTarget.teamKey}...`);
+        const created = await createLinearIssue({
+          teamId: team.data.id,
+          title: polished.title,
+          description: "",
+        });
+        if (!created.ok) {
+          stderr(`[${timestamp()}] [error] Linear issue creation failed: ${created.error}`);
+          return 1;
+        }
+        stdout(`[${timestamp()}] [event] created Linear issue ${created.data.identifier} → ${created.data.url}`);
+        fromLinearIssueId = created.data.identifier;
+        postToLinearTarget = { kind: "issue", issueId: created.data.identifier };
+      }
     }
 
     if (fromLinearIssueId) {

--- a/packages/api-contract/src/contract.ts
+++ b/packages/api-contract/src/contract.ts
@@ -37,6 +37,7 @@ import {
   WorktreeNameParamsSchema,
   NotificationIdParamsSchema,
   LinearIssuesResponseSchema,
+  AutoNameConfigResponseSchema,
   InstancesResponseSchema,
 } from "./schemas";
 
@@ -70,6 +71,7 @@ export const apiPaths = {
   mergeWorktree: "/api/worktrees/:name/merge",
   fetchWorktreeDiff: "/api/worktrees/:name/diff",
   fetchLinearIssues: "/api/linear/issues",
+  fetchAutoNameConfig: "/api/project/auto-name",
   setLinearAutoCreate: "/api/linear/auto-create",
   setAutoRemoveOnMerge: "/api/github/auto-remove-on-merge",
   pullMain: "/api/pull-main",
@@ -338,6 +340,14 @@ export const apiContract = c.router({
       200: LinearIssuesResponseSchema,
       500: ErrorResponseSchema,
       502: ErrorResponseSchema,
+    },
+  },
+  fetchAutoNameConfig: {
+    method: "GET",
+    path: apiPaths.fetchAutoNameConfig,
+    responses: {
+      200: AutoNameConfigResponseSchema,
+      500: ErrorResponseSchema,
     },
   },
   setLinearAutoCreate: {

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -303,6 +303,16 @@ export const LinearIssuesResponseSchema = z.object({
   issues: z.array(LinearIssueSchema),
 });
 
+export const AutoNameProviderSchema = z.enum(["claude", "codex"]);
+
+export const AutoNameConfigResponseSchema = z.object({
+  autoName: z.object({
+    provider: AutoNameProviderSchema,
+    model: z.string().optional(),
+    systemPrompt: z.string().optional(),
+  }).nullable(),
+});
+
 export const WorktreeCreationStateSchema = z.object({
   phase: WorktreeCreationPhaseSchema,
 });
@@ -587,6 +597,7 @@ export type LinkedLinearIssue = z.infer<typeof LinkedLinearIssueSchema>;
 export type LinearIssue = z.infer<typeof LinearIssueSchema>;
 export type LinearIssueAvailability = z.infer<typeof LinearIssueAvailabilitySchema>;
 export type LinearIssuesResponse = z.infer<typeof LinearIssuesResponseSchema>;
+export type AutoNameConfigResponse = z.infer<typeof AutoNameConfigResponseSchema>;
 export type WorktreeCreationState = z.infer<typeof WorktreeCreationStateSchema>;
 export type AppNotification = z.infer<typeof AppNotificationSchema>;
 export type ProjectWorktreeSnapshot = z.infer<typeof ProjectWorktreeSnapshotSchema>;

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -311,6 +311,7 @@ export const AutoNameConfigResponseSchema = z.object({
     model: z.string().optional(),
     systemPrompt: z.string().optional(),
   }).nullable(),
+  linearAvailability: LinearIssueAvailabilitySchema,
 });
 
 export const WorktreeCreationStateSchema = z.object({


### PR DESCRIPTION
## Summary

When `webmux oneshot --linear <TEAM>` creates a new Linear issue, polish the title via the configured autoName LLM instead of using the raw first prompt line, and check the team for likely-duplicate existing issues so the user can pick "use existing" rather than create a new one.

Both behaviors are gated on `projectConfig.autoName` being set — same opt-in as branch auto-naming. If the LLM call fails (timeout, CLI not on PATH, non-zero exit) we fall back to the existing heuristic title and skip dedup, so the flow never becomes a blocker.

> **Note on AGENTS.md parity rule.** AGENTS.md asks that every user-facing feature work in both the frontend and the CLI. This change is intentionally CLI-only: it improves `webmux oneshot --linear <TEAM>`, which has no frontend counterpart (the dashboard's Linear flow already operates on existing issues — there's no "create new issue from prompt" surface to mirror). Filing this here so reviewers don't go looking for the frontend half.

## Changes

- New `backend/src/services/llm-spawn.ts` — extracts spawn / timeout / args plumbing from `AutoNameService` so polish + dedup can reuse it. `AutoNameService` is refactored onto it; all 17 existing tests stay green.
- New `backend/src/services/linear-title-service.ts` — `polishLinearIssueTitle` (LLM-driven with heuristic fallback), `findDuplicateLinearIssue` (keyword filter + LLM tie-break), and `extractKeywords`.
- `backend/src/services/linear-service.ts` — adds `searchTeamIssuesByKeywords` (Linear GraphQL `issues(filter: { team, state, or: [...title.containsIgnoreCase] })` over open-ish states).
- `backend/src/server.ts` + `packages/api-contract` — adds `GET /api/project/auto-name`, returning both autoName config and Linear availability so the CLI gates the whole `--linear` flow with a single round-trip.
- `bin/src/oneshot.ts` — rewires the `--linear <TEAM>` block: fetch autoName+availability → polish title → keyword-search candidates → LLM tie-break → if a match is found, `p.select` between **Use existing**, **Create new**, **Cancel**. Non-TTY shells default to "create new" with a warning. Help text updated.
- New `backend/src/__tests__/linear-title-service.test.ts` — 23 tests covering title normalization, all LLM failure modes, keyword extraction, chatty-LLM identifier extraction, the heuristic 80-char cap, and the full-prompt context passed to the dedup LLM.

### Review fixes (commits 2-5)

- `parseDedupResponse` now extracts the first identifier-shaped token via regex (`/\b([A-Z]+-\d+)\b/i`) instead of stripping punctuation, so chatty Haiku responses like `"Answer: ENG-2"` still match.
- `findDuplicateLinearIssue` now passes the full `--prompt` as additional context to the tie-break LLM (capped at 1000 chars, omitted when identical to the polished title).
- `heuristicTitle` capped at the same `MAX_TITLE_LENGTH = 80` as the LLM-polished path.
- Linear availability folded into the new auto-name endpoint to avoid a second round-trip (`fetchLinearIssues` was a heavy preflight just to read `availability`).
- Audit log when the user picks "create new" despite a duplicate candidate.
- Surrogate-pair-safe excerpt slice (`[...str].slice(...).join("")`).
- Removed non-null assertion on `options.timeoutMs` in `llm-spawn`.
- `MAX_DEDUP_CANDIDATES` widened from 10 to 20.

### Bugs caught by live testing

- **`$teamId: String!` is rejected by Linear** (commit 18b3653). The prior review nit suggested `String!` for consistency with other queries, but Linear strictly requires `ID` inside `IDComparator` filters — `String!` is only accepted at the top-level `team(id: ...)` argument. Reverted to `ID!`. Without the live test the dedup query would have shipped broken.
- **Polish was running the prompt as a task** (commit ccd87b7). The polish call passed the raw `--prompt` as the user message; Claude treated imperative prompts like `"investigate adding a stripe webhook handler..."` as work to do, ran tool calls against the codebase, and returned a multi-paragraph report instead of a title. Wrapped the user prompt the same way `AutoNameService.buildPrompt` does for branch naming — framing the prompt as INPUT and explicitly forbidding investigation/tool use. Also bumped `TITLE_TIMEOUT_MS` from 15s → 30s (measured Haiku low-effort polish at 9-12s steady-state, ~20s cold start).

## Test plan

- [x] `bun run --cwd backend test` — passes (one pre-existing unrelated failure in `agent-service codex_hooks`)
- [x] `bun test bin/src` — passes
- [x] `bun test packages/api-contract/src` — passes
- [x] `bun run --cwd frontend test` — passes
- [x] `bun run --cwd backend check` — clean
- [x] **Live: `GET /api/project/auto-name`** — verified both `linearAvailability: "ready"` (with `LINEAR_API_KEY`) and `"missing_api_key"` (without) by booting the backend and curling.
- [x] **Live: `searchTeamIssuesByKeywords`** — ran against real Linear (`WIN` team), single-keyword and multi-keyword OR semantics confirmed (`dedup` matched `deduplication` via `containsIgnoreCase`).
- [x] **Live: full `webmux oneshot --linear INT --prompt ...` flow** — created INT-58, exercised polish → search → no-candidates → create-new → worktree creation → agent start. Surfaced the two bugs above; both fixed and re-verified.

---
Generated with [Claude Code](https://claude.com/claude-code)