### PR TITLE
fix: scope stale terminal banner to terminal pane

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1245,10 +1245,6 @@
       onbellopen={handleBellOpen}
       onnotificationselect={handleSelectWorktree}
       archiving={isSelectedArchiving}
-      refreshingAgentTerminal={isSelectedAgentTerminalRefreshing}
-      onrefreshagentterminal={() => {
-        if (selectedBranch) void handleRefreshAgentTerminal(selectedBranch);
-      }}
     />
 
     {#if showWebChat}
@@ -1265,6 +1261,11 @@
           {isMobile}
           initialPane={isMobile ? activePane : undefined}
           {terminalTheme}
+          agentTerminalStale={selectedWorktree?.agentTerminalStale ?? false}
+          refreshingAgentTerminal={isSelectedAgentTerminalRefreshing}
+          onrefreshagentterminal={() => {
+            if (selectedBranch) void handleRefreshAgentTerminal(selectedBranch);
+          }}
           bind:this={terminalRef}
         />
       {/key}

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -810,6 +810,23 @@ describe("App create selection", () => {
     expect(attachWorktreeConversation).toHaveBeenCalledWith("feature/chat");
   });
 
+  it("does not show the stale terminal banner in the web chat UI", async () => {
+    const worktree = createWorktree("feature/chat-stale-terminal", {
+      mux: "✓",
+      agentName: "codex",
+      agentLabel: "Codex",
+      agentTerminalStale: true,
+    });
+    localStorage.setItem(WEB_CHAT_UI_STORAGE_KEY, "true");
+    vi.mocked(fetchWorktrees).mockResolvedValue([worktree]);
+    vi.mocked(attachWorktreeConversation).mockResolvedValue(createConversationResponse(worktree));
+
+    render(App);
+
+    expect(await screen.findByRole("textbox", { name: "Message" })).toBeInTheDocument();
+    expect(screen.queryByText("Terminal stale")).not.toBeInTheDocument();
+  });
+
   it("hides the Linear ticket option when disabled in config", async () => {
     vi.mocked(fetchWorktrees).mockResolvedValue([]);
 

--- a/frontend/src/lib/Terminal.svelte
+++ b/frontend/src/lib/Terminal.svelte
@@ -7,11 +7,22 @@
   import { uploadFiles } from "./api";
   import "@xterm/xterm/css/xterm.css";
 
-  let { worktree, isMobile = false, initialPane, terminalTheme }: {
+  let {
+    worktree,
+    isMobile = false,
+    initialPane,
+    terminalTheme,
+    agentTerminalStale = false,
+    refreshingAgentTerminal = false,
+    onrefreshagentterminal,
+  }: {
     worktree: string;
     isMobile?: boolean;
     initialPane?: number;
     terminalTheme: ITheme;
+    agentTerminalStale?: boolean;
+    refreshingAgentTerminal?: boolean;
+    onrefreshagentterminal?: () => void;
   } = $props();
 
   const DISCONNECTED_NOTICE = "\r\n\x1b[90m[Disconnected]\x1b[0m";
@@ -453,6 +464,23 @@
   ondragleave={handleDragLeave}
   ondrop={handleDrop}
 >
+  {#if agentTerminalStale}
+    <div class="absolute left-3 right-3 top-3 z-20 flex items-center justify-between gap-3 rounded-md border border-warning/40 bg-surface/95 px-4 py-3 text-sm text-primary shadow-lg">
+      <span class="min-w-0 truncate">Terminal stale</span>
+      {#if onrefreshagentterminal}
+        <button
+          type="button"
+          class="shrink-0 rounded-md border border-warning/50 bg-surface px-3 py-1.5 text-xs font-medium text-warning hover:bg-warning/10 disabled:cursor-not-allowed disabled:opacity-50"
+          title="Refresh agent terminal"
+          onclick={onrefreshagentterminal}
+          disabled={refreshingAgentTerminal}
+        >
+          {refreshingAgentTerminal ? "Refreshing" : "Refresh"}
+        </button>
+      {/if}
+    </div>
+  {/if}
+
   {#if isDraggingOver}
     <div class="absolute inset-0 z-10 flex items-center justify-center bg-black/50 border-2 border-dashed border-[var(--color-accent)] rounded pointer-events-none">
       <span class="text-white text-sm font-medium">Drop image(s) to upload</span>

--- a/frontend/src/lib/Terminal.test.ts
+++ b/frontend/src/lib/Terminal.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTheme } from "./themes";
 
@@ -208,5 +208,23 @@ describe("Terminal reconnect", () => {
     });
 
     expect(terminal.options.theme).toBe(nextTheme);
+  });
+
+  it("renders stale terminal refresh controls inside the terminal surface", async () => {
+    const onrefreshagentterminal = vi.fn();
+    render(Terminal, {
+      props: {
+        worktree: "feature/stale",
+        terminalTheme: getTheme("github-dark").terminal,
+        agentTerminalStale: true,
+        onrefreshagentterminal,
+      },
+    });
+
+    expect(screen.getByText("Terminal stale")).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(onrefreshagentterminal).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/lib/TopBar.svelte
+++ b/frontend/src/lib/TopBar.svelte
@@ -32,8 +32,6 @@
     onbellopen,
     onnotificationselect,
     archiving = false,
-    refreshingAgentTerminal = false,
-    onrefreshagentterminal,
   }: {
     name: string | null;
     worktree: WorktreeInfo | undefined;
@@ -55,8 +53,6 @@
     onbellopen?: () => void;
     onnotificationselect?: (branch: string) => void;
     archiving?: boolean;
-    refreshingAgentTerminal?: boolean;
-    onrefreshagentterminal?: () => void;
   } = $props();
 
   let bellOpen = $state(false);
@@ -377,25 +373,6 @@
     </button>
     </div>
   </div>
-
-  {#if worktree?.agentTerminalStale}
-    <div class="px-4 pb-3">
-      <div class="flex items-center justify-between gap-3 rounded-md border border-warning/40 bg-warning/10 px-4 py-3 text-sm text-primary">
-        <span class="min-w-0 truncate">Terminal stale</span>
-        {#if onrefreshagentterminal}
-          <button
-            type="button"
-            class="shrink-0 rounded-md border border-warning/50 bg-surface px-3 py-1.5 text-xs font-medium text-warning hover:bg-warning/10 disabled:cursor-not-allowed disabled:opacity-50"
-            title="Refresh agent terminal"
-            onclick={onrefreshagentterminal}
-            disabled={refreshingAgentTerminal || worktree.creating}
-          >
-            {refreshingAgentTerminal ? "Refreshing" : "Refresh"}
-          </button>
-        {/if}
-      </div>
-    </div>
-  {/if}
 </div>
 
 <svelte:window onclick={handleClickOutside} />

--- a/frontend/src/lib/TopBar.test.ts
+++ b/frontend/src/lib/TopBar.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/svelte";
+import { render, screen } from "@testing-library/svelte";
 import { describe, expect, it, vi } from "vitest";
 import TopBar from "./TopBar.svelte";
 import type { WorktreeInfo } from "./types";
@@ -128,9 +128,8 @@ describe("TopBar", () => {
     );
   });
 
-  it("shows stale terminal state as a top banner and refreshes from it", async () => {
+  it("does not render stale terminal state in the web top bar", () => {
     const branch = "feature/stale-terminal";
-    const onrefreshagentterminal = vi.fn();
 
     render(TopBar, {
       props: {
@@ -147,16 +146,10 @@ describe("TopBar", () => {
         onsettings: vi.fn(),
         onCiClick: vi.fn(),
         onReviewsClick: vi.fn(),
-        onrefreshagentterminal,
       },
     });
 
-    expect(screen.getByText("Terminal stale")).toBeInTheDocument();
-    const refreshButton = screen.getByRole("button", { name: "Refresh" });
-    expect(screen.queryByRole("button", { name: "Refresh terminal" })).not.toBeInTheDocument();
-
-    await fireEvent.click(refreshButton);
-    expect(onrefreshagentterminal).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Terminal stale")).not.toBeInTheDocument();
   });
 
   it("keeps desktop PR badges inside a wrapping header container", () => {


### PR DESCRIPTION
## Summary
Move the stale terminal banner out of the shared web top bar so it only appears when the terminal pane is shown. This keeps the web chat UI free of a terminal-specific stale state while preserving the terminal refresh action.

## Changes
- Removed stale terminal banner rendering and refresh props from `TopBar`.
- Added stale terminal banner and refresh action props to `Terminal`.
- Routed stale terminal state from `App` only into the terminal pane.
- Updated coverage for the top bar, terminal surface, and web chat UI behavior.

## Test plan
- [x] `bun run --cwd frontend test src/lib/TopBar.test.ts src/lib/Terminal.test.ts src/App.test.ts`
- [x] `bun run --cwd frontend check`
- [x] `bun run --cwd frontend test`
- [x] `bun run --cwd frontend build`

## Notes
- Screenshots not captured; the visibility behavior is covered by focused component and app tests.
- No known follow-up work.

---
Generated with [Claude Code](https://claude.com/claude-code)