### PR TITLE
fix: handle codex assistant message fields

### DIFF
--- a/backend/src/__tests__/worktree-conversation-service.test.ts
+++ b/backend/src/__tests__/worktree-conversation-service.test.ts
@@ -317,6 +317,68 @@ describe("buildConversationState", () => {
     });
   });
 
+  it("maps app-server assistant message fields into transcript messages", () => {
+    const thread = makeThread({
+      id: "thread-message-field",
+      cwd: "/tmp/worktree",
+      updatedAt: 120,
+      statusType: "idle",
+      source: "cli",
+      turns: [
+        makeTurn({
+          id: "turn-message-field",
+          status: "completed",
+          startedAt: 111,
+          items: [
+            {
+              type: "agentMessage",
+              id: "assistant-message-field",
+              message: "The newer app server uses message here.",
+              phase: "final_answer",
+              memoryCitation: null,
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(buildConversationState(thread).messages).toEqual([
+      {
+        id: "assistant-message-field",
+        turnId: "turn-message-field",
+        role: "assistant",
+        text: "The newer app server uses message here.",
+        status: "completed",
+        createdAt: "1970-01-01T00:03:20.000Z",
+      },
+    ]);
+  });
+
+  it("ignores assistant-looking items without message text", () => {
+    const thread = makeThread({
+      id: "thread-generic-agent",
+      cwd: "/tmp/worktree",
+      updatedAt: 120,
+      statusType: "idle",
+      source: "cli",
+      turns: [
+        makeTurn({
+          id: "turn-generic-agent",
+          status: "completed",
+          startedAt: 111,
+          items: [
+            {
+              type: "agentMessage",
+              id: "assistant-generic",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(buildConversationState(thread).messages).toEqual([]);
+  });
+
   it("does not mark interrupted turns as running", () => {
     const thread = makeThread({
       id: "thread-2",

--- a/backend/src/adapters/codex-app-server.ts
+++ b/backend/src/adapters/codex-app-server.ts
@@ -189,14 +189,7 @@ const CodexAppServerAgentMessageItemSchema: z.ZodType<CodexAppServerAgentMessage
   message: z.string().optional(),
   phase: z.string().optional(),
   memoryCitation: UnknownValueSchema.optional(),
-}).transform((value) => ({
-  type: value.type,
-  id: value.id,
-  ...(value.text !== undefined ? { text: value.text } : {}),
-  ...(value.message !== undefined ? { message: value.message } : {}),
-  ...(value.phase !== undefined ? { phase: value.phase } : {}),
-  ...(value.memoryCitation !== undefined ? { memoryCitation: value.memoryCitation } : {}),
-}));
+});
 const CodexAppServerGenericItemSchema: z.ZodType<CodexAppServerGenericItem, z.ZodTypeDef, unknown> = z.object({
   type: z.string(),
   id: z.string(),

--- a/backend/src/adapters/codex-app-server.ts
+++ b/backend/src/adapters/codex-app-server.ts
@@ -26,9 +26,10 @@ export interface CodexAppServerUserMessageItem {
 export interface CodexAppServerAgentMessageItem {
   type: "agentMessage";
   id: string;
-  text: string;
-  phase: string;
-  memoryCitation: unknown;
+  text?: string;
+  message?: string;
+  phase?: string;
+  memoryCitation?: unknown;
 }
 
 export interface CodexAppServerGenericItem {
@@ -184,15 +185,17 @@ const CodexAppServerUserMessageItemSchema: z.ZodType<CodexAppServerUserMessageIt
 const CodexAppServerAgentMessageItemSchema: z.ZodType<CodexAppServerAgentMessageItem, z.ZodTypeDef, unknown> = z.object({
   type: z.literal("agentMessage"),
   id: z.string(),
-  text: z.string(),
-  phase: z.string(),
-  memoryCitation: UnknownValueSchema,
+  text: z.string().optional(),
+  message: z.string().optional(),
+  phase: z.string().optional(),
+  memoryCitation: UnknownValueSchema.optional(),
 }).transform((value) => ({
   type: value.type,
   id: value.id,
-  text: value.text,
-  phase: value.phase,
-  memoryCitation: value.memoryCitation,
+  ...(value.text !== undefined ? { text: value.text } : {}),
+  ...(value.message !== undefined ? { message: value.message } : {}),
+  ...(value.phase !== undefined ? { phase: value.phase } : {}),
+  ...(value.memoryCitation !== undefined ? { memoryCitation: value.memoryCitation } : {}),
 }));
 const CodexAppServerGenericItemSchema: z.ZodType<CodexAppServerGenericItem, z.ZodTypeDef, unknown> = z.object({
   type: z.string(),

--- a/backend/src/services/worktree-conversation-service.ts
+++ b/backend/src/services/worktree-conversation-service.ts
@@ -105,9 +105,7 @@ function isUserMessageItem(item: CodexAppServerThreadItem): item is CodexAppServ
 }
 
 function isAgentMessageItem(item: CodexAppServerThreadItem): item is CodexAppServerAgentMessageItem {
-  return item.type === "agentMessage"
-    && (("text" in item && typeof item.text === "string")
-      || ("message" in item && typeof item.message === "string"));
+  return item.type === "agentMessage";
 }
 
 function extractUserText(item: CodexAppServerUserMessageItem): string {

--- a/backend/src/services/worktree-conversation-service.ts
+++ b/backend/src/services/worktree-conversation-service.ts
@@ -105,7 +105,9 @@ function isUserMessageItem(item: CodexAppServerThreadItem): item is CodexAppServ
 }
 
 function isAgentMessageItem(item: CodexAppServerThreadItem): item is CodexAppServerAgentMessageItem {
-  return item.type === "agentMessage";
+  return item.type === "agentMessage"
+    && (("text" in item && typeof item.text === "string")
+      || ("message" in item && typeof item.message === "string"));
 }
 
 function extractUserText(item: CodexAppServerUserMessageItem): string {
@@ -113,6 +115,10 @@ function extractUserText(item: CodexAppServerUserMessageItem): string {
     .map((contentItem) => contentItem.text ?? "")
     .join("")
     .trim();
+}
+
+function extractAgentText(item: CodexAppServerAgentMessageItem): string {
+  return item.text ?? item.message ?? "";
 }
 
 function isActiveTurnStatus(status: string): boolean {
@@ -152,13 +158,14 @@ function buildConversationMessages(thread: CodexAppServerThread): AgentsUiConver
       }
 
       if (!isAgentMessageItem(item)) continue;
-      if (item.text.length === 0) continue;
+      const text = extractAgentText(item);
+      if (text.length === 0) continue;
 
       messages.push({
         id: item.id,
         turnId: turn.id,
         role: "assistant",
-        text: item.text,
+        text,
         status: isActiveTurnStatus(turn.status) ? "inProgress" : "completed",
         createdAt: toIsoTimestamp(turn.completedAt ?? turn.startedAt),
       });


### PR DESCRIPTION
## Summary
Fix the web UI attach endpoint for Codex app-server conversations whose assistant items use the newer `message` field instead of the older `text` field. This prevents `/api/agents/worktrees/:name/attach` from returning a 502 when the transcript contains those items.

## Changes
- Accept both `text` and `message` on Codex app-server assistant message items.
- Guard assistant transcript mapping so assistant-looking generic items without message text are skipped instead of crashing.
- Add regression tests for the newer assistant item shape and the prior crash path.

## Test plan
- [x] `bun test backend/src/__tests__/worktree-conversation-service.test.ts`
- [x] `git diff --check`
- [ ] `bun run --cwd backend check` blocked locally because `../node_modules/@types/bun` is missing in this worktree

---
Generated with [Claude Code](https://claude.com/claude-code)