### PR TITLE
Update policies regex

### DIFF
--- a/backend/src/domain/policies.ts
+++ b/backend/src/domain/policies.ts
@@ -2,9 +2,9 @@ import type { ServiceSpec } from "./config";
 import type { WorktreeMeta } from "./model";
 
 const INVALID_BRANCH_CHARS_RE = /[~^:?*\[\]\\]+/g;
-const UNSAFE_ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const VALID_WORKTREE_NAME_RE = /^[a-z0-9][a-z0-9\-_./]*$/;
-const VALID_INSTANCE_PREFIX_RE = /^[a-z0-9][a-z0-9\-]*$/;
+const UNSAFE_ENV_KEY_RE = /^[a-z_][a-z0-9_]*$/i;
+const VALID_WORKTREE_NAME_RE = /^[a-z0-9][a-z0-9\-_./]*$/i;
+const VALID_INSTANCE_PREFIX_RE = /^[a-z0-9][a-z0-9\-]*$/i;
 
 export function sanitizeBranchName(raw: string): string {
   return raw


### PR DESCRIPTION
🐛 errors when trying to open a worktree with capital letters

This change allows uppercase for git branch/worktree and instances



<img width="1222" height="1027" alt="image" src="https://github.com/user-attachments/assets/22e2894f-9b76-4b44-bcf4-3b3559b5c5b7" />
