### PR TITLE
fix: connect server-backed CLI commands to the live webmux instance

### DIFF
--- a/bin/src/shared.test.ts
+++ b/bin/src/shared.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { formatServerError } from "./shared";
+
+describe("formatServerError", () => {
+  test("passes HTTP errors through untouched", () => {
+    expect(formatServerError(new Error("HTTP 404: not found"), 5111)).toBe("HTTP 404: not found");
+  });
+
+  test("translates legacy 'fetch failed' connection errors", () => {
+    expect(formatServerError(new Error("fetch failed"), 5111)).toBe(
+      "Could not connect to webmux server on port 5111. Is it running?",
+    );
+  });
+
+  test("translates Bun's connection-refused message", () => {
+    // Bun throws this exact message (code ConnectionRefused) when nothing is
+    // listening on the port — e.g. `webmux oneshot` with no `webmux serve`.
+    const err = new Error("Unable to connect. Is the computer able to access the url?");
+    expect(formatServerError(err, 5111)).toBe(
+      "Could not connect to webmux server on port 5111. Is it running?",
+    );
+  });
+
+  test("leaves unrelated errors untouched", () => {
+    expect(formatServerError(new Error("Linear team not found"), 5111)).toBe("Linear team not found");
+  });
+});

--- a/bin/src/shared.ts
+++ b/bin/src/shared.ts
@@ -45,15 +45,16 @@ export function detectProjectName(gitRoot: string): string {
 }
 
 /**
- * Bun throws a `TypeError: fetch failed` when the webmux server isn't
- * reachable; the bare message is unhelpful to users. This returns a friendly
- * "Is the server running?" hint for that case and leaves HTTP/other errors
- * untouched.
+ * When the webmux server isn't reachable the bare error message is unhelpful to
+ * users. Older Bun threw a `TypeError: fetch failed`; current Bun throws
+ * "Unable to connect. Is the computer able to access the url?" (code
+ * ConnectionRefused). This returns a friendly "Is the server running?" hint for
+ * either case and leaves HTTP/other errors untouched.
  */
 export function formatServerError(error: unknown, port: number): string {
   if (error instanceof Error) {
     if (error.message.startsWith("HTTP")) return error.message;
-    if (error.message.includes("fetch")) {
+    if (error.message.includes("fetch") || error.message.includes("Unable to connect")) {
       return `Could not connect to webmux server on port ${port}. Is it running?`;
     }
     return error.message;


### PR DESCRIPTION
## Summary
`webmux oneshot --linear=<TEAM>` failed with `Unable to connect. Is the computer able to access the url?` even though the webmux server was running — because it was running on port **5112** (a `webmux serve --port 5112` service), while the CLI hardcoded the **5111** default.

Two root causes, both fixed here:

1. **CLI didn't target the running server.** Server-backed commands (`oneshot`, `linear`, `send`) connect to `http://localhost:<port>` but only ever used `--port`/`PORT`/5111. `webmux serve` walks to a free port when 5111 is taken, so the live instance is often elsewhere. In-process commands (`add`, `list`, `open`, ...) talk to tmux/git/fs directly, which is why `webmux add` worked while `webmux oneshot` didn't.
2. **The connection error was unrecognizable.** `formatServerError` only translated the old Bun `fetch failed` message into the friendly "Is it running?" hint. Current Bun throws `Unable to connect. Is the computer able to access the url?` (code `ConnectionRefused`), which slipped through and was printed raw.

## Changes
- `bin/src/instance-port.ts` (new): `selectInstancePort` (pure) + `resolveLiveServerPort` (I/O) resolve the port of the live webmux instance serving the current project from the instance registry, falling back to the sole live instance, then the default.
- `bin/src/webmux.ts`: when `--port`/`PORT` isn't set, resolve the live server port before dispatching CLI commands; `--debug` logs the resolved source. `serve` is unaffected. Updated `--port` help text.
- `bin/src/shared.ts`: `formatServerError` now also recognizes Bun's `Unable to connect` message.
- Tests: `bin/src/instance-port.test.ts` (project match, subdir match, preference, sole/default fallbacks, sibling-prefix guard) and `bin/src/shared.test.ts` (HTTP passthrough, legacy + current Bun connection messages, unrelated errors).

## Test plan
- [ ] `bun test bin/src/instance-port.test.ts bin/src/shared.test.ts` passes
- [ ] With a `webmux serve --port 5112` running for the current project, `webmux oneshot --prompt 'x' --linear=TEAM` (no `--port`) connects to 5112 instead of failing on 5111
- [ ] `webmux --debug oneshot ...` logs `resolved port 5112 from live instance (project)`
- [ ] With no server running, the error reads `Could not connect to webmux server on port 5111. Is it running?`

---
Generated with [Claude Code](https://claude.com/claude-code)