### PR TITLE
fix: target the live server port for server-backed CLI commands

### DIFF
--- a/bin/src/instance-port.test.ts
+++ b/bin/src/instance-port.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { selectInstancePort } from "./instance-port";
+import type { InstanceEntry } from "../../backend/src/adapters/instance-registry";
+
+function entry(overrides: Partial<InstanceEntry>): InstanceEntry {
+  return {
+    prefix: "windmill",
+    port: 5112,
+    projectDir: "/home/me/windmill",
+    pid: 1012,
+    startedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("selectInstancePort", () => {
+  test("matches the instance serving the current project root", () => {
+    const result = selectInstancePort({
+      defaultPort: 5111,
+      candidateDirs: ["/home/me/windmill"],
+      instances: [entry({ port: 5112 })],
+    });
+    expect(result).toEqual({ port: 5112, source: "project" });
+  });
+
+  test("matches when cwd is a subdirectory of the project", () => {
+    const result = selectInstancePort({
+      defaultPort: 5111,
+      candidateDirs: ["/home/me/windmill/backend/src"],
+      instances: [entry({ port: 5112, projectDir: "/home/me/windmill" })],
+    });
+    expect(result).toEqual({ port: 5112, source: "project" });
+  });
+
+  test("prefers the project match over other live instances", () => {
+    const result = selectInstancePort({
+      defaultPort: 5111,
+      candidateDirs: ["/home/me/windmill"],
+      instances: [
+        entry({ port: 5113, projectDir: "/home/me/other" }),
+        entry({ port: 5112, projectDir: "/home/me/windmill" }),
+      ],
+    });
+    expect(result).toEqual({ port: 5112, source: "project" });
+  });
+
+  test("falls back to the sole live instance when none matches the project", () => {
+    const result = selectInstancePort({
+      defaultPort: 5111,
+      candidateDirs: ["/home/me/windmill"],
+      instances: [entry({ port: 5112, projectDir: "/home/me/other" })],
+    });
+    expect(result).toEqual({ port: 5112, source: "sole" });
+  });
+
+  test("falls back to default when nothing matches and multiple are live", () => {
+    const result = selectInstancePort({
+      defaultPort: 5111,
+      candidateDirs: ["/home/me/windmill"],
+      instances: [
+        entry({ port: 5112, projectDir: "/home/me/a" }),
+        entry({ port: 5113, projectDir: "/home/me/b" }),
+      ],
+    });
+    expect(result).toEqual({ port: 5111, source: "default" });
+  });
+
+  test("falls back to default when no instances are live", () => {
+    const result = selectInstancePort({
+      defaultPort: 5111,
+      candidateDirs: ["/home/me/windmill"],
+      instances: [],
+    });
+    expect(result).toEqual({ port: 5111, source: "default" });
+  });
+
+  test("does not treat a sibling project with a shared prefix as inside", () => {
+    const result = selectInstancePort({
+      defaultPort: 5111,
+      candidateDirs: ["/home/me/windmill-fork"],
+      instances: [entry({ port: 5112, projectDir: "/home/me/windmill" })],
+    });
+    // No project match → sole-instance fallback, not a bogus "project" match.
+    expect(result).toEqual({ port: 5112, source: "sole" });
+  });
+});

--- a/bin/src/instance-port.ts
+++ b/bin/src/instance-port.ts
@@ -1,0 +1,56 @@
+import { createInstanceRegistry, type InstanceEntry } from "../../backend/src/adapters/instance-registry";
+import { getGitRoot } from "./shared";
+
+export type PortSource = "project" | "sole" | "default";
+
+export interface ResolvedPort {
+  port: number;
+  source: PortSource;
+}
+
+export interface SelectInstancePortInput {
+  defaultPort: number;
+  /** Directories that identify the current project — typically `[cwd, gitRoot]`. */
+  candidateDirs: string[];
+  instances: InstanceEntry[];
+}
+
+function isInside(child: string, parent: string): boolean {
+  const root = parent.endsWith("/") ? parent.slice(0, -1) : parent;
+  return child === root || child.startsWith(`${root}/`);
+}
+
+/**
+ * Pick the port of the live webmux instance that serves the current project.
+ * Server-backed CLI commands (`oneshot`, `linear`, `send`) talk to a running
+ * `webmux serve`, whose port is whatever it bound at startup — not necessarily
+ * the 5111 default (it walks to a free port when 5111 is taken). Matching the
+ * registry by project dir lets those commands find the right server instead of
+ * blindly hitting 5111.
+ *
+ * Falls back to the sole live instance when nothing matches the project (the
+ * common single-instance setup), then to `defaultPort`.
+ */
+export function selectInstancePort(input: SelectInstancePortInput): ResolvedPort {
+  const match = input.instances.find((entry) =>
+    input.candidateDirs.some((dir) => isInside(dir, entry.projectDir)),
+  );
+  if (match) return { port: match.port, source: "project" };
+  if (input.instances.length === 1) return { port: input.instances[0]!.port, source: "sole" };
+  return { port: input.defaultPort, source: "default" };
+}
+
+/** I/O wrapper: read the live registry + resolve the current project's git root,
+ *  then delegate to the pure `selectInstancePort`. */
+export function resolveLiveServerPort(opts: {
+  defaultPort: number;
+  cwd: string;
+  registryDir?: string;
+}): ResolvedPort {
+  const instances = createInstanceRegistry(opts.registryDir).listLive();
+  const gitRoot = getGitRoot();
+  const candidateDirs = [opts.cwd, gitRoot].filter(
+    (dir): dir is string => typeof dir === "string" && dir.length > 0,
+  );
+  return selectInstancePort({ defaultPort: opts.defaultPort, candidateDirs, instances });
+}

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -37,6 +37,7 @@ Usage:
 
 Options:
   --port N            Set port (default: 5111). Falls back to a free port when taken.
+                      Without --port, CLI commands target the live server for this project.
   --prefix NAME       URL prefix this instance registers under (default: project dir basename).
                       Other webmux instances on this machine will redirect /<NAME> to this port.
   --app               Open dashboard in browser app mode (minimal window)
@@ -348,15 +349,30 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
   await loadEnvFile(resolve(process.cwd(), ".env.local"));
   await loadEnvFile(resolve(process.cwd(), ".env"));
 
+  // When the user didn't pin a port, point CLI commands at the live server for
+  // this project rather than the 5111 default. `webmux serve` walks to a free
+  // port when 5111 is taken, so the running instance is often elsewhere (e.g.
+  // a service installed on 5112); server-backed commands like `oneshot` would
+  // otherwise fail to connect.
+  let effectivePort = parsed.port;
+  if (!parsed.portExplicit) {
+    const { resolveLiveServerPort } = await import("./instance-port.ts");
+    const resolved = resolveLiveServerPort({ defaultPort: parsed.port, cwd: process.cwd() });
+    effectivePort = resolved.port;
+    if (parsed.debug && resolved.source !== "default") {
+      console.error(`[webmux] resolved port ${resolved.port} from live instance (${resolved.source})`);
+    }
+  }
+
   if (parsed.command === "oneshot") {
     const { runOneshotCommand } = await import("./oneshot.ts");
-    const exitCode = await runOneshotCommand(parsed.commandArgs, parsed.port);
+    const exitCode = await runOneshotCommand(parsed.commandArgs, effectivePort);
     process.exit(exitCode);
   }
 
   if (parsed.command === "linear") {
     const { runLinearCommand } = await import("./linear-commands.ts");
-    const exitCode = await runLinearCommand(parsed.commandArgs, parsed.port);
+    const exitCode = await runLinearCommand(parsed.commandArgs, effectivePort);
     process.exit(exitCode);
   }
 
@@ -366,7 +382,7 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
       command: parsed.command,
       args: parsed.commandArgs,
       projectDir: process.cwd(),
-      port: parsed.port,
+      port: effectivePort,
     });
     process.exit(exitCode);
   }


### PR DESCRIPTION
## Summary
Follow-up to #263. That PR fixed the *error message* when the webmux server is unreachable, but the underlying cause of `webmux oneshot --linear=<TEAM>` failing with `Unable to connect...` was a **port mismatch**: the server was running on 5112 (a `webmux serve --port 5112` service) while the CLI hardcoded the 5111 default.

`webmux serve` walks to a free port when 5111 is taken, but server-backed CLI commands (`oneshot`, `linear`, `send`) only ever used `--port`/`PORT`/5111 and never consulted the instance registry — so they connected to a dead port. In-process commands (`add`, `list`, `open`, ...) talk to tmux/git/fs directly, which is why `webmux add` worked while `webmux oneshot` didn't.

This resolves the live instance's port from the registry by matching the current project dir when `--port`/`PORT` isn't set.

## Changes
- `bin/src/instance-port.ts` (new): `selectInstancePort` (pure) + `resolveLiveServerPort` (I/O) resolve the port of the live webmux instance serving the current project, falling back to the sole live instance, then the default.
- `bin/src/webmux.ts`: when `--port`/`PORT` isn't set, resolve the live server port before dispatching CLI commands; `--debug` logs the resolved source. `serve` is unaffected. Updated `--port` help text.
- `bin/src/instance-port.test.ts`: project match, subdir match, preference over other instances, sole/default fallbacks, and a sibling-prefix guard.

## Test plan
- [ ] `bun test bin/src/instance-port.test.ts` passes
- [ ] With a `webmux serve --port 5112` running for the current project, `webmux oneshot --prompt 'x' --linear=TEAM` (no `--port`) connects to 5112 instead of failing on 5111
- [ ] `webmux --debug oneshot ...` logs `resolved port 5112 from live instance (project)`
- [ ] `webmux --port 5111 ...` still forces 5111 (explicit port wins)

---
Generated with [Claude Code](https://claude.com/claude-code)