### PR TITLE
feat: drag-and-drop worktree reordering with persistence

### DIFF
--- a/backend/src/__tests__/order-service.test.ts
+++ b/backend/src/__tests__/order-service.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { WORKTREE_ORDER_STATE_VERSION, type WorktreeOrderState } from "../domain/model";
+import {
+  buildWorktreeOrderComparator,
+  createWorktreeOrderState,
+  moveBranchInOrder,
+  pruneWorktreeOrder,
+} from "../services/order-service";
+
+function orderState(branches: string[]): WorktreeOrderState {
+  return { schemaVersion: WORKTREE_ORDER_STATE_VERSION, branches };
+}
+
+describe("createWorktreeOrderState", () => {
+  it("dedupes and drops empty branch names", () => {
+    const state = createWorktreeOrderState(["a", "", "b", "a", "c", "b"]);
+    expect(state).toEqual(orderState(["a", "b", "c"]));
+  });
+});
+
+describe("pruneWorktreeOrder", () => {
+  it("keeps only branches that still exist", () => {
+    const state = pruneWorktreeOrder({
+      state: orderState(["a", "b", "c"]),
+      branches: ["c", "a"],
+    });
+    expect(state.branches).toEqual(["a", "c"]);
+  });
+});
+
+describe("moveBranchInOrder", () => {
+  it("moves a branch before a target", () => {
+    expect(moveBranchInOrder(["a", "b", "c"], "c", "a", "before")).toEqual(["c", "a", "b"]);
+  });
+
+  it("moves a branch after a target", () => {
+    expect(moveBranchInOrder(["a", "b", "c"], "a", "c", "after")).toEqual(["b", "c", "a"]);
+  });
+
+  it("returns null for a no-op or unknown branch", () => {
+    expect(moveBranchInOrder(["a", "b"], "a", "a", "before")).toBeNull();
+    expect(moveBranchInOrder(["a", "b"], "z", "a", "before")).toBeNull();
+    expect(moveBranchInOrder(["a", "b"], "a", "z", "after")).toBeNull();
+  });
+});
+
+describe("buildWorktreeOrderComparator", () => {
+  it("orders saved branches first, then unknown branches alphabetically", () => {
+    const compare = buildWorktreeOrderComparator(["c", "a"]);
+    const sorted = ["b", "a", "d", "c"].sort(compare);
+    expect(sorted).toEqual(["c", "a", "b", "d"]);
+  });
+
+  it("falls back to alphabetical when no order is saved", () => {
+    const compare = buildWorktreeOrderComparator([]);
+    expect(["c", "a", "b"].sort(compare)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/backend/src/__tests__/order-state-service.test.ts
+++ b/backend/src/__tests__/order-state-service.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { WORKTREE_ORDER_STATE_VERSION, type WorktreeOrderState } from "../domain/model";
+import { OrderStateService } from "../services/order-state-service";
+
+function cloneOrderState(state: WorktreeOrderState): WorktreeOrderState {
+  return { schemaVersion: state.schemaVersion, branches: [...state.branches] };
+}
+
+function emptyOrderState(): WorktreeOrderState {
+  return { schemaVersion: WORKTREE_ORDER_STATE_VERSION, branches: [] };
+}
+
+describe("order-state-service", () => {
+  it("persists the requested branch order", async () => {
+    let state = emptyOrderState();
+    const service = new OrderStateService("/repo/.git", {
+      readState: async () => cloneOrderState(state),
+      writeState: async (_gitDir, nextState) => {
+        state = cloneOrderState(nextState);
+      },
+    });
+
+    await service.setOrder(["b", "a", "c"]);
+
+    expect(state.branches).toEqual(["b", "a", "c"]);
+  });
+
+  it("does not write when the order is unchanged", async () => {
+    let writes = 0;
+    let state: WorktreeOrderState = { schemaVersion: WORKTREE_ORDER_STATE_VERSION, branches: ["a", "b"] };
+    const service = new OrderStateService("/repo/.git", {
+      readState: async () => cloneOrderState(state),
+      writeState: async (_gitDir, nextState) => {
+        writes++;
+        state = cloneOrderState(nextState);
+      },
+    });
+
+    await service.setOrder(["a", "b"]);
+
+    expect(writes).toBe(0);
+  });
+
+  it("prunes branches that no longer exist", async () => {
+    let state: WorktreeOrderState = { schemaVersion: WORKTREE_ORDER_STATE_VERSION, branches: ["a", "b", "c"] };
+    const service = new OrderStateService("/repo/.git", {
+      readState: async () => cloneOrderState(state),
+      writeState: async (_gitDir, nextState) => {
+        state = cloneOrderState(nextState);
+      },
+    });
+
+    await service.prune(["a", "c"]);
+
+    expect(state.branches).toEqual(["a", "c"]);
+  });
+
+  it("serializes concurrent mutations", async () => {
+    let state = emptyOrderState();
+    const service = new OrderStateService("/repo/.git", {
+      readState: async () => {
+        const snapshot = cloneOrderState(state);
+        await Bun.sleep(5);
+        return snapshot;
+      },
+      writeState: async (_gitDir, nextState) => {
+        await Bun.sleep(5);
+        state = cloneOrderState(nextState);
+      },
+    });
+
+    await Promise.all([
+      service.setOrder(["a", "b"]),
+      service.setOrder(["b", "a"]),
+    ]);
+
+    expect(state.branches).toEqual(["b", "a"]);
+  });
+});

--- a/backend/src/__tests__/snapshot-service.test.ts
+++ b/backend/src/__tests__/snapshot-service.test.ts
@@ -304,4 +304,40 @@ describe("buildProjectSnapshot", () => {
       "feature/zebra",
     ]);
   });
+
+  it("applies a saved branch order, appending unknown branches alphabetically", () => {
+    const runtime = new ProjectRuntime();
+    runtime.upsertWorktree({
+      worktreeId: "wt_alpha",
+      branch: "feature/alpha",
+      path: "/repo/__worktrees/feature-alpha",
+      runtime: "host",
+    });
+    runtime.upsertWorktree({
+      worktreeId: "wt_beta",
+      branch: "feature/beta",
+      path: "/repo/__worktrees/feature-beta",
+      runtime: "host",
+    });
+    runtime.upsertWorktree({
+      worktreeId: "wt_gamma",
+      branch: "feature/gamma",
+      path: "/repo/__worktrees/feature-gamma",
+      runtime: "host",
+    });
+
+    const snapshot = buildProjectSnapshot({
+      projectName: "Project",
+      mainBranch: "main",
+      runtime,
+      notifications: [],
+      order: ["feature/gamma", "feature/alpha"],
+    });
+
+    expect(snapshot.worktrees.map((worktree) => worktree.branch)).toEqual([
+      "feature/gamma",
+      "feature/alpha",
+      "feature/beta",
+    ]);
+  });
 });

--- a/backend/src/adapters/fs.ts
+++ b/backend/src/adapters/fs.ts
@@ -11,10 +11,16 @@ import type {
   WorktreeConversationMeta,
   WorktreeArchiveState,
   WorktreeMeta,
+  WorktreeOrderState,
   WorktreeStoragePaths,
   WorktreeTab,
 } from "../domain/model";
-import { conversationSessionId, ROOT_TAB_ID, WORKTREE_ARCHIVE_STATE_VERSION } from "../domain/model";
+import {
+  conversationSessionId,
+  ROOT_TAB_ID,
+  WORKTREE_ARCHIVE_STATE_VERSION,
+  WORKTREE_ORDER_STATE_VERSION,
+} from "../domain/model";
 
 const SAFE_ENV_VALUE_RE = /^[A-Za-z0-9_./:@%+=,-]+$/;
 const DOTENV_LINE_RE = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)/;
@@ -72,6 +78,10 @@ export function getWorktreeStoragePaths(gitDir: string): WorktreeStoragePaths {
 
 export function getProjectArchiveStatePath(gitDir: string): string {
   return join(gitDir, "webmux", "archive.json");
+}
+
+export function getProjectOrderStatePath(gitDir: string): string {
+  return join(gitDir, "webmux", "order.json");
 }
 
 export async function ensureWorktreeStorageDirs(gitDir: string): Promise<WorktreeStoragePaths> {
@@ -134,6 +144,41 @@ export async function writeWorktreeArchiveState(gitDir: string, state: WorktreeA
   const archivePath = getProjectArchiveStatePath(gitDir);
   await ensureWorktreeStorageDirs(gitDir);
   await Bun.write(archivePath, JSON.stringify(state, null, 2) + "\n");
+}
+
+function emptyWorktreeOrderState(): WorktreeOrderState {
+  return {
+    schemaVersion: WORKTREE_ORDER_STATE_VERSION,
+    branches: [],
+  };
+}
+
+function isWorktreeOrderState(raw: unknown): raw is WorktreeOrderState {
+  return isRecord(raw)
+    && typeof raw.schemaVersion === "number"
+    && Array.isArray(raw.branches)
+    && raw.branches.every((branch) => typeof branch === "string");
+}
+
+export async function readWorktreeOrderState(gitDir: string): Promise<WorktreeOrderState> {
+  const orderPath = getProjectOrderStatePath(gitDir);
+  try {
+    const raw: unknown = await Bun.file(orderPath).json();
+    return isWorktreeOrderState(raw)
+      ? {
+          schemaVersion: raw.schemaVersion,
+          branches: [...raw.branches],
+        }
+      : emptyWorktreeOrderState();
+  } catch {
+    return emptyWorktreeOrderState();
+  }
+}
+
+export async function writeWorktreeOrderState(gitDir: string, state: WorktreeOrderState): Promise<void> {
+  const orderPath = getProjectOrderStatePath(gitDir);
+  await ensureWorktreeStorageDirs(gitDir);
+  await Bun.write(orderPath, JSON.stringify(state, null, 2) + "\n");
 }
 
 export function buildRuntimeEnvMap(

--- a/backend/src/domain/model.ts
+++ b/backend/src/domain/model.ts
@@ -2,6 +2,7 @@ import type { AgentId, RuntimeKind } from "./config";
 
 export const WORKTREE_META_SCHEMA_VERSION = 1;
 export const WORKTREE_ARCHIVE_STATE_VERSION = 1;
+export const WORKTREE_ORDER_STATE_VERSION = 1;
 
 export type WorktreeConversationProvider = "codexAppServer" | "claudeCode";
 
@@ -97,6 +98,11 @@ export interface ArchivedWorktreeEntry {
 export interface WorktreeArchiveState {
   schemaVersion: number;
   entries: ArchivedWorktreeEntry[];
+}
+
+export interface WorktreeOrderState {
+  schemaVersion: number;
+  branches: string[];
 }
 
 export interface WorktreeStoragePaths {

--- a/backend/src/runtime.ts
+++ b/backend/src/runtime.ts
@@ -8,6 +8,7 @@ import { BunTmuxGateway } from "./adapters/tmux";
 import { FileSessionDiscovery } from "./adapters/session-discovery";
 import { AutoNameService } from "./services/auto-name-service";
 import { ArchiveStateService } from "./services/archive-state-service";
+import { OrderStateService } from "./services/order-state-service";
 import { LifecycleService, type CreateWorktreeProgress } from "./services/lifecycle-service";
 import { NotificationService as RuntimeNotificationService } from "./services/notification-service";
 import { ProjectRuntime } from "./services/project-runtime";
@@ -25,6 +26,7 @@ export interface WebmuxRuntime {
   projectDir: string;
   config: ProjectConfig;
   archiveStateService: ArchiveStateService;
+  orderStateService: OrderStateService;
   git: BunGitGateway;
   portProbe: BunPortProbe;
   tmux: BunTmuxGateway;
@@ -44,6 +46,7 @@ export function createWebmuxRuntime(options: WebmuxRuntimeOptions = {}): WebmuxR
   const config = loadConfig(projectDir, { resolvedRoot: true });
   const git = new BunGitGateway();
   const archiveStateService = new ArchiveStateService(git.resolveWorktreeGitDir(projectDir));
+  const orderStateService = new OrderStateService(git.resolveWorktreeGitDir(projectDir));
   const portProbe = new BunPortProbe();
   const tmux = new BunTmuxGateway();
   const docker = new BunDockerGateway();
@@ -86,6 +89,7 @@ export function createWebmuxRuntime(options: WebmuxRuntimeOptions = {}): WebmuxR
     projectDir,
     config,
     archiveStateService,
+    orderStateService,
     git,
     portProbe,
     tmux,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -19,6 +19,7 @@ import {
   SendWorktreePromptRequestSchema,
   SetWorktreeArchivedRequestSchema,
   SetWorktreeLabelRequestSchema,
+  SetWorktreeOrderRequestSchema,
   ToggleEnabledRequestSchema,
   UpsertCustomAgentRequestSchema,
   WorktreeNameParamsSchema,
@@ -119,6 +120,7 @@ const PROJECT_DIR = runtime.projectDir;
 const config: ProjectConfig = runtime.config;
 const git = runtime.git;
 const archiveStateService = runtime.archiveStateService;
+const orderStateService = runtime.orderStateService;
 const tmux = runtime.tmux;
 const projectRuntime = runtime.projectRuntime;
 const worktreeCreationTracker = runtime.worktreeCreationTracker;
@@ -580,6 +582,7 @@ async function readProjectSnapshot(): Promise<ProjectSnapshot> {
     : Promise.resolve({ ok: true as const, data: [] });
   await reconciliationService.reconcile(PROJECT_DIR);
   const archiveState = await archiveStateService.prune(projectRuntime.listWorktrees().map((worktree) => worktree.path));
+  const orderState = await orderStateService.prune(projectRuntime.listWorktrees().map((worktree) => worktree.branch));
   const linearResult = await linearIssuesPromise;
   const archivedPaths = buildArchivedWorktreePathSet(archiveState);
   const linearIssues = linearResult.ok ? linearResult.data : [];
@@ -589,6 +592,7 @@ async function readProjectSnapshot(): Promise<ProjectSnapshot> {
     runtime: projectRuntime,
     creatingWorktrees: worktreeCreationTracker.list(),
     notifications: runtimeNotifications.list(),
+    order: orderState.branches,
     isArchived: (path) => archivedPaths.has(normalizeArchivePath(path)),
     findLinearIssue: (branch) => {
       const match = linearIssues.find((issue) => branchMatchesIssue(branch, issue.branchName));
@@ -1219,6 +1223,15 @@ async function apiSetWorktreeLabel(name: string, req: Request): Promise<Response
   return jsonResponse({ ok: true, label: result.label });
 }
 
+async function apiSetWorktreeOrder(req: Request): Promise<Response> {
+  const parsed = await parseJsonBody(req, SetWorktreeOrderRequestSchema);
+  if (!parsed.ok) return parsed.response;
+
+  log.info(`[worktree:order] branches=${parsed.data.branches.length}`);
+  const state = await orderStateService.setOrder(parsed.data.branches);
+  return jsonResponse({ ok: true, branches: state.branches });
+}
+
 async function apiSendPrompt(name: string, req: Request): Promise<Response> {
   ensureBranchNotBusy(name);
   const parsed = await parseJsonBody(req, SendWorktreePromptRequestSchema);
@@ -1752,6 +1765,10 @@ function startServer(port: number): ReturnType<typeof Bun.serve> {
     [apiPaths.fetchWorktrees]: {
       GET: () => catching("GET /api/worktrees", () => apiGetWorktrees()),
       POST: (req) => catching("POST /api/worktrees", () => apiCreateWorktree(req)),
+    },
+
+    [apiPaths.setWorktreeOrder]: {
+      PUT: (req) => catching("PUT /api/worktrees/order", () => apiSetWorktreeOrder(req)),
     },
 
     [apiPaths.removeWorktree]: {

--- a/backend/src/services/order-service.ts
+++ b/backend/src/services/order-service.ts
@@ -1,0 +1,57 @@
+import {
+  WORKTREE_ORDER_STATE_VERSION,
+  type WorktreeOrderState,
+} from "../domain/model";
+
+export function createWorktreeOrderState(branches: string[]): WorktreeOrderState {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const branch of branches) {
+    if (!branch || seen.has(branch)) continue;
+    seen.add(branch);
+    deduped.push(branch);
+  }
+  return {
+    schemaVersion: WORKTREE_ORDER_STATE_VERSION,
+    branches: deduped,
+  };
+}
+
+export function pruneWorktreeOrder(input: {
+  state: WorktreeOrderState;
+  branches: string[];
+}): WorktreeOrderState {
+  const valid = new Set(input.branches);
+  return createWorktreeOrderState(input.state.branches.filter((branch) => valid.has(branch)));
+}
+
+/** Remove `moved` from the order and reinsert it before/after `target`.
+ *  Returns null when the move is a no-op or references an unknown branch. */
+export function moveBranchInOrder(
+  branches: string[],
+  moved: string,
+  target: string,
+  position: "before" | "after",
+): string[] | null {
+  if (moved === target) return null;
+  if (!branches.includes(moved) || !branches.includes(target)) return null;
+
+  const without = branches.filter((branch) => branch !== moved);
+  const targetIndex = without.indexOf(target);
+  const insertAt = position === "before" ? targetIndex : targetIndex + 1;
+  return [...without.slice(0, insertAt), moved, ...without.slice(insertAt)];
+}
+
+/** Sort comparator that places ordered branches first in their saved order and
+ *  appends unknown branches alphabetically. */
+export function buildWorktreeOrderComparator(
+  branches: string[],
+): (left: string, right: string) => number {
+  const orderIndex = new Map(branches.map((branch, index) => [branch, index]));
+  return (left, right) => {
+    const leftIndex = orderIndex.get(left) ?? Number.POSITIVE_INFINITY;
+    const rightIndex = orderIndex.get(right) ?? Number.POSITIVE_INFINITY;
+    if (leftIndex !== rightIndex) return leftIndex - rightIndex;
+    return left.localeCompare(right);
+  };
+}

--- a/backend/src/services/order-state-service.ts
+++ b/backend/src/services/order-state-service.ts
@@ -1,0 +1,85 @@
+import {
+  readWorktreeOrderState,
+  writeWorktreeOrderState,
+} from "../adapters/fs";
+import type { WorktreeOrderState } from "../domain/model";
+import {
+  createWorktreeOrderState,
+  pruneWorktreeOrder,
+} from "./order-service";
+
+function orderStatesEqual(
+  left: WorktreeOrderState,
+  right: WorktreeOrderState,
+): boolean {
+  if (left.schemaVersion !== right.schemaVersion) return false;
+  if (left.branches.length !== right.branches.length) return false;
+
+  return left.branches.every((branch, index) => branch === right.branches[index]);
+}
+
+export interface OrderStateServiceDependencies {
+  readState?: (gitDir: string) => Promise<WorktreeOrderState>;
+  writeState?: (gitDir: string, state: WorktreeOrderState) => Promise<void>;
+}
+
+export class OrderStateService {
+  private mutationQueue = Promise.resolve();
+  private readonly readState: (gitDir: string) => Promise<WorktreeOrderState>;
+  private readonly writeState: (gitDir: string, state: WorktreeOrderState) => Promise<void>;
+
+  constructor(
+    private readonly gitDir: string,
+    deps: OrderStateServiceDependencies = {},
+  ) {
+    this.readState = deps.readState ?? readWorktreeOrderState;
+    this.writeState = deps.writeState ?? writeWorktreeOrderState;
+  }
+
+  async read(): Promise<WorktreeOrderState> {
+    return await this.readState(this.gitDir);
+  }
+
+  async setOrder(branches: string[]): Promise<WorktreeOrderState> {
+    return await this.mutate(() => createWorktreeOrderState(branches));
+  }
+
+  async prune(branches: string[]): Promise<WorktreeOrderState> {
+    return await this.mutate((state) =>
+      pruneWorktreeOrder({
+        state,
+        branches,
+      })
+    );
+  }
+
+  private async mutate(
+    transform: (state: WorktreeOrderState) => WorktreeOrderState | Promise<WorktreeOrderState>,
+  ): Promise<WorktreeOrderState> {
+    return await this.withMutationLock(async () => {
+      const state = await this.readState(this.gitDir);
+      const nextState = await transform(state);
+
+      if (!orderStatesEqual(state, nextState)) {
+        await this.writeState(this.gitDir, nextState);
+      }
+
+      return nextState;
+    });
+  }
+
+  private async withMutationLock<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.mutationQueue;
+    let release = () => {};
+    this.mutationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await previous.catch(() => {});
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}

--- a/backend/src/services/snapshot-service.ts
+++ b/backend/src/services/snapshot-service.ts
@@ -1,5 +1,6 @@
 import type { CreatingWorktreeState, PrEntry, ProjectSnapshot, WorktreeSnapshot } from "../domain/model";
 import type { RuntimeNotification } from "./notification-service";
+import { buildWorktreeOrderComparator } from "./order-service";
 import { ProjectRuntime } from "./project-runtime";
 
 function formatElapsedSince(startedAt: string | null, now: () => Date): string {
@@ -112,6 +113,7 @@ interface BuildWorktreeSnapshotsInput {
   isArchived?: (path: string) => boolean;
   findLinearIssue?: (branch: string) => WorktreeSnapshot["linearIssue"];
   findAgentLabel?: (agentId: string | null) => string | null;
+  order?: string[];
   now?: () => Date;
 }
 
@@ -139,7 +141,8 @@ export function buildWorktreeSnapshots(input: BuildWorktreeSnapshotsInput): Work
     }
   }
 
-  worktrees.sort((left, right) => left.branch.localeCompare(right.branch));
+  const compareByOrder = buildWorktreeOrderComparator(input.order ?? []);
+  worktrees.sort((left, right) => compareByOrder(left.branch, right.branch));
 
   return worktrees;
 }

--- a/bin/src/completions.ts
+++ b/bin/src/completions.ts
@@ -11,7 +11,7 @@ interface ListBranchesDeps {
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
-const BRANCH_SUBCOMMANDS = new Set(["open", "close", "refresh", "archive", "unarchive", "label", "remove", "merge", "send"]);
+const BRANCH_SUBCOMMANDS = new Set(["open", "close", "refresh", "archive", "unarchive", "label", "remove", "merge", "send", "reorder"]);
 
 // ── Pure logic ─────────────────────────────────────────────────────────────
 
@@ -133,6 +133,7 @@ _webmux() {
     'remove:Remove a worktree'
     'merge:Merge a worktree into main'
     'send:Send a prompt to a running worktree agent'
+    'reorder:Reorder a worktree in the list'
     'prune:Remove all worktrees in the current project'
     'linear:Post a worktree conversation to a Linear issue/team'
     'completion:Generate shell completion script'
@@ -197,7 +198,7 @@ const BASH_SCRIPT = `_webmux() {
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
-    COMPREPLY=($(compgen -W "serve init service update add oneshot list open close refresh archive unarchive label remove merge send prune linear completion" -- "\${cur}"))
+    COMPREPLY=($(compgen -W "serve init service update add oneshot list open close refresh archive unarchive label remove merge send reorder prune linear completion" -- "\${cur}"))
     return
   fi
 

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -32,6 +32,7 @@ Usage:
   webmux merge        Merge a worktree into the main branch and remove it
   webmux send         Send a prompt to a running worktree agent
   webmux tab          List, create, switch, or close agent tabs in a worktree
+  webmux reorder      Reorder a worktree in the list (persisted)
   webmux prune        Remove all worktrees in the current project
   webmux linear       Post a worktree conversation to a Linear issue/team
   webmux completion   Generate shell completion script (bash, zsh)
@@ -52,7 +53,7 @@ Environment:
 `);
 }
 
-type RootCommand = "serve" | "init" | "service" | "update" | "add" | "oneshot" | "list" | "open" | "close" | "refresh" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "tab" | "prune" | "linear" | "completion" | null;
+type RootCommand = "serve" | "init" | "service" | "update" | "add" | "oneshot" | "list" | "open" | "close" | "refresh" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "tab" | "reorder" | "prune" | "linear" | "completion" | null;
 
 interface ParsedRootArgs {
   port: number;
@@ -85,6 +86,7 @@ function isRootCommand(value: string): value is NonNullable<RootCommand> {
     || value === "merge"
     || value === "send"
     || value === "tab"
+    || value === "reorder"
     || value === "prune"
     || value === "linear"
     || value === "completion";
@@ -176,7 +178,7 @@ export function parseRootArgs(args: string[]): ParsedRootArgs {
   };
 }
 
-function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "open" | "close" | "refresh" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "tab" | "prune" {
+function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "open" | "close" | "refresh" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "tab" | "reorder" | "prune" {
   return command === "add"
     || command === "list"
     || command === "open"
@@ -189,6 +191,7 @@ function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "o
     || command === "merge"
     || command === "send"
     || command === "tab"
+    || command === "reorder"
     || command === "prune";
 }
 

--- a/bin/src/worktree-commands.test.ts
+++ b/bin/src/worktree-commands.test.ts
@@ -277,9 +277,15 @@ describe("parseReorderCommandArgs", () => {
     });
   });
 
-  it("returns null for --help or a missing target", () => {
+  it("returns null only for --help", () => {
     expect(parseReorderCommandArgs(["--help"])).toBeNull();
-    expect(parseReorderCommandArgs(["feat-a"])).toBeNull();
+  });
+
+  it("throws when required args are missing", () => {
+    expect(() => parseReorderCommandArgs([])).toThrow("reorder requires a <branch> to move");
+    expect(() => parseReorderCommandArgs(["feat-a"])).toThrow(
+      "reorder requires --before <branch> or --after <branch>",
+    );
   });
 
   it("rejects using both --before and --after", () => {

--- a/bin/src/worktree-commands.test.ts
+++ b/bin/src/worktree-commands.test.ts
@@ -9,6 +9,7 @@ import {
   parseBranchCommandArgs,
   parseLabelCommandArgs,
   parseListCommandArgs,
+  parseReorderCommandArgs,
   parseSendCommandArgs,
   parseTabCommandArgs,
   runWorktreeCommand,
@@ -256,6 +257,35 @@ describe("parseListCommandArgs", () => {
 
   it("rejects conflicting archive filters", () => {
     expect(() => parseListCommandArgs(["--all", "--archived"])).toThrow("Cannot use --archived with --all");
+  });
+});
+
+describe("parseReorderCommandArgs", () => {
+  it("parses a branch with --before", () => {
+    expect(parseReorderCommandArgs(["feat-b", "--before", "feat-a"])).toEqual({
+      branch: "feat-b",
+      target: "feat-a",
+      position: "before",
+    });
+  });
+
+  it("parses a branch with --after", () => {
+    expect(parseReorderCommandArgs(["feat-a", "--after", "feat-b"])).toEqual({
+      branch: "feat-a",
+      target: "feat-b",
+      position: "after",
+    });
+  });
+
+  it("returns null for --help or a missing target", () => {
+    expect(parseReorderCommandArgs(["--help"])).toBeNull();
+    expect(parseReorderCommandArgs(["feat-a"])).toBeNull();
+  });
+
+  it("rejects using both --before and --after", () => {
+    expect(() => parseReorderCommandArgs(["feat-a", "--before", "x", "--after", "y"])).toThrow(
+      "Use only one of --before or --after",
+    );
   });
 });
 
@@ -851,6 +881,66 @@ describe("runWorktreeCommand", () => {
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("persists a reorder and lists worktrees in the saved order", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "webmux-cli-reorder-"));
+    try {
+      const projectDir = join(tempDir, "repo");
+      await mkdir(projectDir, { recursive: true });
+      const makeReorderRuntime = () => ({
+        projectDir,
+        config: { workspace: { mainBranch: "main" } },
+        git: stubGit([
+          { path: projectDir, branch: "main", bare: false },
+          { path: join(projectDir, ".worktrees", "feat-a"), branch: "feat-a", bare: false },
+          { path: join(projectDir, ".worktrees", "feat-b"), branch: "feat-b", bare: false },
+        ]),
+        tmux: stubTmux(),
+        lifecycleService: stubLifecycleService([]),
+      });
+
+      const reorderOut: string[] = [];
+      const reorderExit = await runWorktreeCommand(
+        { command: "reorder", args: ["feat-b", "--before", "feat-a"], projectDir, port: 5111 },
+        { createRuntime: makeReorderRuntime, stdout: (msg) => reorderOut.push(msg) },
+      );
+      expect(reorderExit).toBe(0);
+      expect(reorderOut).toEqual(["Moved feat-b before feat-a"]);
+
+      const listOut: string[] = [];
+      const listExit = await runWorktreeCommand(
+        { command: "list", args: ["--all"], projectDir, port: 5111 },
+        { createRuntime: makeReorderRuntime, stdout: (msg) => listOut.push(msg) },
+      );
+      expect(listExit).toBe(0);
+      expect(listOut.map((line) => line.split(/\s+/)[0])).toEqual(["feat-b", "feat-a"]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("errors when reordering an unknown worktree", async () => {
+    const stderr: string[] = [];
+    const exitCode = await runWorktreeCommand(
+      { command: "reorder", args: ["missing", "--before", "main"], projectDir: "/repo", port: 5111 },
+      {
+        createRuntime: () => ({
+          projectDir: "/repo",
+          config: { workspace: { mainBranch: "main" } },
+          git: stubGit([
+            { path: "/repo", branch: "main", bare: false },
+            { path: "/repo/.worktrees/feat-a", branch: "feat-a", bare: false },
+          ]),
+          tmux: stubTmux(),
+          lifecycleService: stubLifecycleService([]),
+        }),
+        stderr: (msg) => stderr.push(msg),
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr[0]).toContain("Worktree not found: missing");
   });
 
   it("prints empty message when no worktrees exist", async () => {

--- a/bin/src/worktree-commands.ts
+++ b/bin/src/worktree-commands.ts
@@ -3,12 +3,22 @@ import { createApi } from "@webmux/api-contract";
 import { basename, resolve } from "node:path";
 import { buildSeedFromLinear, defaultSeedFromLinearDeps } from "../../backend/src/services/conversation-export-service";
 import { CommandUsageError, withServerConnection } from "./shared";
-import { readWorktreeArchiveState, readWorktreeMeta } from "../../backend/src/adapters/fs";
+import {
+  readWorktreeArchiveState,
+  readWorktreeMeta,
+  readWorktreeOrderState,
+  writeWorktreeOrderState,
+} from "../../backend/src/adapters/fs";
 import { buildProjectSessionName, buildWorktreeWindowName } from "../../backend/src/adapters/tmux";
 import type { AgentId } from "../../backend/src/domain/config";
 import type { WorktreeCreationPhase } from "../../backend/src/domain/model";
 import { isValidWorktreeName } from "../../backend/src/domain/policies";
 import { buildArchivedWorktreePathSet } from "../../backend/src/services/archive-service";
+import {
+  buildWorktreeOrderComparator,
+  createWorktreeOrderState,
+  moveBranchInOrder,
+} from "../../backend/src/services/order-service";
 import { createWebmuxRuntime } from "../../backend/src/runtime";
 import type { CreateLifecycleWorktreeInput, CreateLifecycleWorktreesInput, CreateLifecycleWorktreesResult, CreateWorktreeProgress, PruneWorktreesResult } from "../../backend/src/services/lifecycle-service";
 
@@ -20,7 +30,7 @@ const PHASE_LABELS: Record<WorktreeCreationPhase, string> = {
   reconciling: "Reconciling",
 };
 
-export type WorktreeSubcommand = "add" | "list" | "open" | "close" | "refresh" | "remove" | "merge" | "send" | "prune" | "archive" | "unarchive" | "label" | "tab";
+export type WorktreeSubcommand = "add" | "list" | "open" | "close" | "refresh" | "remove" | "merge" | "send" | "prune" | "archive" | "unarchive" | "label" | "tab" | "reorder";
 
 type WorktreeListMode = "active" | "all" | "archived";
 
@@ -140,6 +150,17 @@ export function getWorktreeCommandUsage(command: WorktreeSubcommand): string {
       ].join("\n");
     case "prune":
       return "Usage:\n  webmux prune";
+    case "reorder":
+      return [
+        "Usage:",
+        "  webmux reorder <branch> --before <branch>",
+        "  webmux reorder <branch> --after <branch>",
+        "",
+        "Options:",
+        "  --before <branch>        Place <branch> immediately before the given worktree",
+        "  --after <branch>         Place <branch> immediately after the given worktree",
+        "  --help                   Show this help message",
+      ].join("\n");
     case "tab":
       return [
         "Usage:",
@@ -571,6 +592,54 @@ export function parseListCommandArgs(args: string[]): ParsedListCommand | null {
   return { mode, search };
 }
 
+interface ParsedReorderCommand {
+  branch: string;
+  target: string;
+  position: "before" | "after";
+}
+
+export function parseReorderCommandArgs(args: string[]): ParsedReorderCommand | null {
+  let branch: string | null = null;
+  let target: string | null = null;
+  let position: "before" | "after" | null = null;
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (!arg) continue;
+
+    if (arg === "--help" || arg === "-h") {
+      return null;
+    }
+
+    if (arg === "--before" || arg.startsWith("--before=") || arg === "--after" || arg.startsWith("--after=")) {
+      if (position) {
+        throw new CommandUsageError("Use only one of --before or --after");
+      }
+      const flag = arg.startsWith("--before") ? "--before" : "--after";
+      const { value, nextIndex } = readOptionValue(args, index, flag);
+      target = value;
+      position = flag === "--before" ? "before" : "after";
+      index = nextIndex;
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      throw new CommandUsageError(`Unknown option: ${arg}`);
+    }
+
+    if (branch) {
+      throw new CommandUsageError(`Unexpected argument: ${arg}`);
+    }
+    branch = arg;
+  }
+
+  if (!branch || !target || !position) {
+    return null;
+  }
+
+  return { branch, target, position };
+}
+
 function listProjectWorktrees(
   runtime: WorktreeRuntimeLike,
 ): Array<{ path: string; branch: string | null; bare: boolean }> {
@@ -660,6 +729,7 @@ async function listWorktrees(
 
   const projectGitDir = runtime.git.resolveWorktreeGitDir(projectDir);
   const archivedPaths = buildArchivedWorktreePathSet(await readWorktreeArchiveState(projectGitDir));
+  const orderComparator = buildWorktreeOrderComparator((await readWorktreeOrderState(projectGitDir)).branches);
   const rows = await Promise.all(entries.map(async (entry) => {
     const branch = entry.branch ?? basename(entry.path);
     const isOpen = openWindows.has(buildWorktreeWindowName(branch));
@@ -684,7 +754,7 @@ async function listWorktrees(
 
   const matchingRows = rows
     .filter((row) => matchesListSearch(row, options.search.trim()))
-    .sort((a, b) => a.branch.localeCompare(b.branch));
+    .sort((a, b) => orderComparator(a.branch, b.branch));
   const visibleRows = matchingRows.filter((row) => {
     if (options.mode === "all") return true;
     if (options.mode === "archived") return row.archived;
@@ -924,7 +994,45 @@ export async function runWorktreeCommand(
       return 0;
     }
 
-    const command: Exclude<WorktreeSubcommand, "add" | "list" | "send" | "prune" | "label" | "tab"> = context.command;
+    if (context.command === "reorder") {
+      const parsed = parseReorderCommandArgs(context.args);
+      if (!parsed) {
+        stdout(getWorktreeCommandUsage("reorder"));
+        return 0;
+      }
+
+      const runtime = createRuntime({
+        projectDir: context.projectDir,
+        port: context.port,
+      });
+      const projectDir = resolve(runtime.projectDir);
+      const projectGitDir = runtime.git.resolveWorktreeGitDir(projectDir);
+      const branches = listProjectWorktrees(runtime).map((entry) => entry.branch ?? basename(entry.path));
+
+      if (!branches.includes(parsed.branch)) {
+        stderr(`Worktree not found: ${parsed.branch}`);
+        return 1;
+      }
+      if (!branches.includes(parsed.target)) {
+        stderr(`Worktree not found: ${parsed.target}`);
+        return 1;
+      }
+
+      const orderState = await readWorktreeOrderState(projectGitDir);
+      const comparator = buildWorktreeOrderComparator(orderState.branches);
+      const currentOrder = [...branches].sort(comparator);
+      const nextOrder = moveBranchInOrder(currentOrder, parsed.branch, parsed.target, parsed.position);
+      if (!nextOrder) {
+        stderr(`Cannot move ${parsed.branch} ${parsed.position} ${parsed.target}`);
+        return 1;
+      }
+
+      await writeWorktreeOrderState(projectGitDir, createWorktreeOrderState(nextOrder));
+      stdout(`Moved ${parsed.branch} ${parsed.position} ${parsed.target}`);
+      return 0;
+    }
+
+    const command: Exclude<WorktreeSubcommand, "add" | "list" | "send" | "prune" | "label" | "tab" | "reorder"> = context.command;
     const branch = parseBranchCommandArgs(context.args);
     if (!branch) {
       stdout(getWorktreeCommandUsage(command));

--- a/bin/src/worktree-commands.ts
+++ b/bin/src/worktree-commands.ts
@@ -633,8 +633,11 @@ export function parseReorderCommandArgs(args: string[]): ParsedReorderCommand | 
     branch = arg;
   }
 
-  if (!branch || !target || !position) {
-    return null;
+  if (!branch) {
+    throw new CommandUsageError("reorder requires a <branch> to move");
+  }
+  if (!target || !position) {
+    throw new CommandUsageError("reorder requires --before <branch> or --after <branch>");
   }
 
   return { branch, target, position };

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -48,10 +48,12 @@
     saveUseWebChatUi,
   } from "./lib/utils";
   import {
+    applyBranchOrder,
     buildWorktreeListRows,
     countArchivedMatches,
     filterWorktrees,
     matchesWorktreeSearch,
+    moveBranchInOrder,
   } from "./lib/worktree-list";
   import { getTheme } from "./lib/themes";
   import type { ThemeKey } from "./lib/themes";
@@ -65,6 +67,7 @@
     refreshWorktreeAgentTerminal,
     selectWorktreeTab,
     setWorktreeLabel,
+    setWorktreeOrder,
     subscribeNotifications,
   } from "./lib/api";
   import TabBar from "./lib/TabBar.svelte";
@@ -861,6 +864,24 @@
     }
   }
 
+  async function reorderWorktree(
+    draggedBranch: string,
+    targetBranch: string,
+    position: "before" | "after",
+  ): Promise<void> {
+    const order = moveBranchInOrder({ worktrees, draggedBranch, targetBranch, position });
+    if (!order) return;
+
+    const previous = worktrees;
+    worktrees = applyBranchOrder(worktrees, order);
+    try {
+      await setWorktreeOrder(order);
+    } catch (err) {
+      worktrees = previous;
+      showToast({ tone: "error", message: `Failed to reorder: ${errorMessage(err)}` });
+    }
+  }
+
   async function closeWorktree(branch: string): Promise<void> {
     selectNeighborOf(branch);
     try {
@@ -1217,6 +1238,7 @@
         }}
         onremove={(b) => (removeBranch = b)}
         onposttolinear={handlePostToLinear}
+        onreorder={reorderWorktree}
       />
       {#if config.projectDir}
         <SidebarRepoRow

--- a/frontend/src/lib/WorktreeList.svelte
+++ b/frontend/src/lib/WorktreeList.svelte
@@ -212,8 +212,10 @@
   }
 
   function handleRowDragOver(event: DragEvent & { currentTarget: HTMLElement }, row: WorktreeListRow): void {
-    // Only allow dropping between siblings sharing the same parent.
+    // Only allow dropping between siblings sharing the same parent. Clear any
+    // lingering indicator when hovering the dragged row or a non-sibling.
     if (!draggingBranch || row.worktree.branch === draggingBranch || row.parentBranch !== draggingParent) {
+      dropTarget = null;
       return;
     }
     event.preventDefault();
@@ -238,7 +240,15 @@
 </script>
 
 <div class="relative flex min-h-0 flex-1 flex-col">
-  <ul bind:this={listEl} class="list-none overflow-y-auto flex-1 min-h-0 p-2">
+  <ul
+    bind:this={listEl}
+    class="list-none overflow-y-auto flex-1 min-h-0 p-2"
+    ondragleave={(event) => {
+      if (!(event.relatedTarget instanceof Node) || !event.currentTarget.contains(event.relatedTarget)) {
+        dropTarget = null;
+      }
+    }}
+  >
     {#if rows.length === 0}
       <li class="px-3 py-4 text-xs text-muted text-center">{emptyMessage}</li>
     {/if}

--- a/frontend/src/lib/WorktreeList.svelte
+++ b/frontend/src/lib/WorktreeList.svelte
@@ -31,6 +31,7 @@
     onmerge,
     onremove,
     onposttolinear,
+    onreorder = () => {},
   }: {
     rows: WorktreeListRow[];
     selected: string | null;
@@ -46,6 +47,7 @@
     onmerge: (branch: string) => void;
     onremove: (branch: string) => void;
     onposttolinear?: (branch: string) => void;
+    onreorder?: (draggedBranch: string, targetBranch: string, position: "before" | "after") => void;
   } = $props();
 
   function toggleMenu(branch: string): void {
@@ -192,6 +194,47 @@
     );
     target?.scrollIntoView({ behavior: "smooth", block: "center" });
   }
+
+  type DropPosition = "before" | "after";
+
+  let draggingBranch = $state<string | null>(null);
+  let draggingParent = $state<string | null>(null);
+  let dropTarget = $state<{ branch: string; position: DropPosition } | null>(null);
+
+  function handleRowDragStart(event: DragEvent, row: WorktreeListRow): void {
+    openMenuBranch = null;
+    draggingBranch = row.worktree.branch;
+    draggingParent = row.parentBranch;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", row.worktree.branch);
+    }
+  }
+
+  function handleRowDragOver(event: DragEvent & { currentTarget: HTMLElement }, row: WorktreeListRow): void {
+    // Only allow dropping between siblings sharing the same parent.
+    if (!draggingBranch || row.worktree.branch === draggingBranch || row.parentBranch !== draggingParent) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+    const rect = event.currentTarget.getBoundingClientRect();
+    const position: DropPosition = event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+    dropTarget = { branch: row.worktree.branch, position };
+  }
+
+  function handleRowDrop(event: DragEvent, row: WorktreeListRow): void {
+    if (!draggingBranch || !dropTarget || row.parentBranch !== draggingParent) return;
+    event.preventDefault();
+    onreorder(draggingBranch, dropTarget.branch, dropTarget.position);
+    resetDragState();
+  }
+
+  function resetDragState(): void {
+    draggingBranch = null;
+    draggingParent = null;
+    dropTarget = null;
+  }
 </script>
 
 <div class="relative flex min-h-0 flex-1 flex-col">
@@ -211,10 +254,24 @@
       {@const isBusy = isRemoving || isInitializing}
       {@const hasLabel = !!wt.label}
       {@const hasBadgeRow = isArchived || isCreating || isInitializing || isClosed || wt.prs.length > 0 || !!wt.linearIssue || wt.source === "oneshot"}
+      {@const isDragging = draggingBranch === wt.branch}
+      {@const isDropBefore = dropTarget?.branch === wt.branch && dropTarget.position === "before"}
+      {@const isDropAfter = dropTarget?.branch === wt.branch && dropTarget.position === "after"}
       <li
         data-branch={wt.branch}
-        class="mb-0.5 group relative {isBusy ? 'opacity-40 pointer-events-none' : ''}"
+        draggable={!isBusy}
+        class="mb-0.5 group relative {isBusy ? 'opacity-40 pointer-events-none' : ''} {isDragging ? 'opacity-40' : ''}"
+        ondragstart={(event) => handleRowDragStart(event, row)}
+        ondragover={(event) => handleRowDragOver(event, row)}
+        ondrop={(event) => handleRowDrop(event, row)}
+        ondragend={resetDragState}
       >
+        {#if isDropBefore}
+          <div class="pointer-events-none absolute -top-0.5 inset-x-1 h-0.5 rounded bg-accent"></div>
+        {/if}
+        {#if isDropAfter}
+          <div class="pointer-events-none absolute -bottom-0.5 inset-x-1 h-0.5 rounded bg-accent"></div>
+        {/if}
         <button
           type="button"
           disabled={isBusy}

--- a/frontend/src/lib/WorktreeList.test.ts
+++ b/frontend/src/lib/WorktreeList.test.ts
@@ -42,7 +42,7 @@ function createWorktree(branch: string): WorktreeInfo {
 }
 
 function createRow(worktree: WorktreeInfo, depth = 0): WorktreeListRow {
-  return { worktree, depth };
+  return { worktree, depth, parentBranch: null };
 }
 
 describe("WorktreeList", () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -105,6 +105,13 @@ export async function setWorktreeLabel(branch: string, label: string | null): Pr
   return response.label;
 }
 
+export async function setWorktreeOrder(branches: string[]): Promise<string[]> {
+  const response = await api.setWorktreeOrder({
+    body: { branches },
+  });
+  return response.branches;
+}
+
 export function attachWorktreeConversation(branch: string): Promise<AgentsUiWorktreeConversationResponse> {
   return api.attachAgentsWorktreeConversation({
     params: { name: branch },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -116,6 +116,7 @@ export interface WorktreeInfo {
 export interface WorktreeListRow {
   worktree: WorktreeInfo;
   depth: number;
+  parentBranch: string | null;
 }
 
 export type ToastTone = "info" | "success" | "error";

--- a/frontend/src/lib/worktree-list.test.ts
+++ b/frontend/src/lib/worktree-list.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyBranchOrder,
   branchesWithAgentStatus,
   buildWorktreeListRows,
   countAgentStatusesIn,
   countArchivedMatches,
   filterWorktrees,
+  moveBranchInOrder,
 } from "./worktree-list";
 import type { WorktreeInfo, WorktreeListRow } from "./types";
 
@@ -104,8 +106,68 @@ describe("buildWorktreeListRows", () => {
 });
 
 function createRow(branch: string, overrides: Partial<WorktreeInfo> = {}): WorktreeListRow {
-  return { worktree: createWorktree(branch, { mux: "✓", ...overrides }), depth: 0 };
+  return { worktree: createWorktree(branch, { mux: "✓", ...overrides }), depth: 0, parentBranch: null };
 }
+
+describe("buildWorktreeListRows parentBranch", () => {
+  it("records the parent branch of each row", () => {
+    const rows = buildWorktreeListRows([
+      createWorktree("feature/base"),
+      createWorktree("feature/child", { baseBranch: "feature/base" }),
+      createWorktree("feature/root"),
+    ]);
+
+    expect(rows.map((row) => [row.worktree.branch, row.parentBranch])).toEqual([
+      ["feature/base", null],
+      ["feature/child", "feature/base"],
+      ["feature/root", null],
+    ]);
+  });
+});
+
+describe("moveBranchInOrder", () => {
+  const worktrees = [
+    createWorktree("main"),
+    createWorktree("feat-a", { baseBranch: "main" }),
+    createWorktree("feat-b", { baseBranch: "main" }),
+    createWorktree("other"),
+  ];
+
+  it("reorders siblings sharing the same parent", () => {
+    expect(
+      moveBranchInOrder({ worktrees, draggedBranch: "feat-b", targetBranch: "feat-a", position: "before" }),
+    ).toEqual(["main", "feat-b", "feat-a", "other"]);
+  });
+
+  it("reorders roots", () => {
+    expect(
+      moveBranchInOrder({ worktrees, draggedBranch: "other", targetBranch: "main", position: "before" }),
+    ).toEqual(["other", "main", "feat-a", "feat-b"]);
+  });
+
+  it("rejects moves across different parents", () => {
+    expect(
+      moveBranchInOrder({ worktrees, draggedBranch: "feat-a", targetBranch: "other", position: "after" }),
+    ).toBeNull();
+  });
+
+  it("rejects no-op and unknown branches", () => {
+    expect(
+      moveBranchInOrder({ worktrees, draggedBranch: "feat-a", targetBranch: "feat-a", position: "before" }),
+    ).toBeNull();
+    expect(
+      moveBranchInOrder({ worktrees, draggedBranch: "missing", targetBranch: "main", position: "before" }),
+    ).toBeNull();
+  });
+});
+
+describe("applyBranchOrder", () => {
+  it("sorts worktrees to match the given order, unknown branches last", () => {
+    const worktrees = [createWorktree("a"), createWorktree("b"), createWorktree("c")];
+    const ordered = applyBranchOrder(worktrees, ["c", "a"]);
+    expect(ordered.map((worktree) => worktree.branch)).toEqual(["c", "a", "b"]);
+  });
+});
 
 describe("countAgentStatusesIn", () => {
   const rows = [

--- a/frontend/src/lib/worktree-list.ts
+++ b/frontend/src/lib/worktree-list.ts
@@ -108,23 +108,62 @@ export function buildWorktreeListRows(worktrees: WorktreeInfo[]): WorktreeListRo
   const rows: WorktreeListRow[] = [];
   const visited = new Set<string>();
 
-  function append(worktree: WorktreeInfo, depth: number): void {
+  function append(worktree: WorktreeInfo, depth: number, parentBranch: string | null): void {
     if (visited.has(worktree.branch)) return;
     visited.add(worktree.branch);
-    rows.push({ worktree, depth });
+    rows.push({ worktree, depth, parentBranch });
 
     for (const child of childrenByParent.get(worktree.branch) ?? []) {
-      append(child, depth + 1);
+      append(child, depth + 1, worktree.branch);
     }
   }
 
   for (const root of roots) {
-    append(root, 0);
+    append(root, 0, null);
   }
 
   for (const worktree of worktrees) {
-    append(worktree, 0);
+    append(worktree, 0, null);
   }
 
   return rows;
+}
+
+/** Reorder a worktree relative to a sibling, returning the new full branch order
+ *  (including filtered-out worktrees). Returns null when the move is invalid —
+ *  a no-op, an unknown branch, or a drop onto a non-sibling (different parent). */
+export function moveBranchInOrder(input: {
+  worktrees: WorktreeInfo[];
+  draggedBranch: string;
+  targetBranch: string;
+  position: "before" | "after";
+}): string[] | null {
+  const { worktrees, draggedBranch, targetBranch, position } = input;
+  if (draggedBranch === targetBranch) return null;
+
+  const worktreesByBranch = new Map(worktrees.map((worktree) => [worktree.branch, worktree]));
+  const dragged = worktreesByBranch.get(draggedBranch);
+  const target = worktreesByBranch.get(targetBranch);
+  if (!dragged || !target) return null;
+
+  if (parentBranchOf(dragged, worktreesByBranch) !== parentBranchOf(target, worktreesByBranch)) {
+    return null;
+  }
+
+  const order = worktrees.map((worktree) => worktree.branch).filter((branch) => branch !== draggedBranch);
+  const targetIndex = order.indexOf(targetBranch);
+  const insertAt = position === "before" ? targetIndex : targetIndex + 1;
+  return [...order.slice(0, insertAt), draggedBranch, ...order.slice(insertAt)];
+}
+
+/** Reorder the full worktree list to match a branch order, keeping any branch
+ *  not present in `order` in its original relative position at the end. */
+export function applyBranchOrder(worktrees: WorktreeInfo[], order: string[]): WorktreeInfo[] {
+  const orderIndex = new Map(order.map((branch, index) => [branch, index]));
+  return [...worktrees].sort((left, right) => {
+    const leftIndex = orderIndex.get(left.branch) ?? Number.POSITIVE_INFINITY;
+    const rightIndex = orderIndex.get(right.branch) ?? Number.POSITIVE_INFINITY;
+    if (leftIndex !== rightIndex) return leftIndex - rightIndex;
+    return left.branch.localeCompare(right.branch);
+  });
 }

--- a/packages/api-contract/src/contract.ts
+++ b/packages/api-contract/src/contract.ts
@@ -32,6 +32,8 @@ import {
   ProjectWorktreeSnapshotSchema,
   SetWorktreeLabelRequestSchema,
   SetWorktreeLabelResponseSchema,
+  SetWorktreeOrderRequestSchema,
+  SetWorktreeOrderResponseSchema,
   ToggleEnabledRequestSchema,
   WorktreeDiffResponseSchema,
   WorktreeListResponseSchema,
@@ -61,6 +63,7 @@ export const apiPaths = {
   interruptAgentsWorktreeConversation: "/api/agents/worktrees/:name/interrupt",
   streamAgentsWorktreeConversation: "/ws/agents/worktrees/:name",
   fetchWorktrees: "/api/worktrees",
+  setWorktreeOrder: "/api/worktrees/order",
   createWorktree: "/api/worktrees",
   removeWorktree: "/api/worktrees/:name",
   openWorktree: "/api/worktrees/:name/open",
@@ -230,6 +233,15 @@ export const apiContract = c.router({
       200: WorktreeListResponseSchema,
       500: ErrorResponseSchema,
       502: ErrorResponseSchema,
+    },
+  },
+  setWorktreeOrder: {
+    method: "PUT",
+    path: apiPaths.setWorktreeOrder,
+    body: SetWorktreeOrderRequestSchema,
+    responses: {
+      200: SetWorktreeOrderResponseSchema,
+      ...commonErrorResponses,
     },
   },
   createWorktree: {

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -191,6 +191,15 @@ export const SetWorktreeLabelResponseSchema = z.object({
   label: z.string().nullable(),
 });
 
+export const SetWorktreeOrderRequestSchema = z.object({
+  branches: z.array(z.string()),
+});
+
+export const SetWorktreeOrderResponseSchema = z.object({
+  ok: z.literal(true),
+  branches: z.array(z.string()),
+});
+
 export const ToggleEnabledRequestSchema = z.object({
   enabled: z.boolean(),
 });
@@ -627,6 +636,8 @@ export type SetWorktreeArchivedRequest = z.infer<typeof SetWorktreeArchivedReque
 export type SetWorktreeArchivedResponse = z.infer<typeof SetWorktreeArchivedResponseSchema>;
 export type SetWorktreeLabelRequest = z.infer<typeof SetWorktreeLabelRequestSchema>;
 export type SetWorktreeLabelResponse = z.infer<typeof SetWorktreeLabelResponseSchema>;
+export type SetWorktreeOrderRequest = z.infer<typeof SetWorktreeOrderRequestSchema>;
+export type SetWorktreeOrderResponse = z.infer<typeof SetWorktreeOrderResponseSchema>;
 export type ToggleEnabledRequest = z.infer<typeof ToggleEnabledRequestSchema>;
 export type SendWorktreePromptRequest = z.infer<typeof SendWorktreePromptRequestSchema>;
 export type AgentsSendMessageRequest = z.infer<typeof AgentsSendMessageRequestSchema>;


### PR DESCRIPTION
## Summary
Adds drag-and-drop reordering of the worktree list with a persisted custom order, available across both the web dashboard and the CLI. Previously the list was always sorted alphabetically by branch.

The order is stored per-project in `.webmux/order.json` (a `{ schemaVersion, branches[] }` global branch order), mirroring the existing archive-state pattern. The sidebar sorts by this order (ordered branches first, unknown/new branches appended alphabetically), so newly created worktrees slot in predictably and renamed/removed branches degrade gracefully.

## Demo

https://github.com/user-attachments/assets/0fbb366f-a9e9-4b12-b9f8-0889b282f573


## Changes
**Persistence (backend)**
- `WorktreeOrderState` type + `WORKTREE_ORDER_STATE_VERSION` in `domain/model.ts`
- `getProjectOrderStatePath` / `readWorktreeOrderState` / `writeWorktreeOrderState` in `adapters/fs.ts`
- Pure `order-service.ts`: `createWorktreeOrderState` (dedupe), `moveBranchInOrder`, `pruneWorktreeOrder`, `buildWorktreeOrderComparator`
- `OrderStateService` (locked mutations, skip-write-if-unchanged), mirroring `ArchiveStateService`; wired into `runtime.ts`
- `buildWorktreeSnapshots` sorts by the saved order instead of plain alphabetical
- `readProjectSnapshot` prunes stale branches and passes the order through
- `PUT /api/worktrees/order` endpoint (`apiSetWorktreeOrder`)

**API contract**
- `setWorktreeOrder` path, request/response schemas, contract entry, exported types

**Frontend**
- Native HTML5 drag-and-drop on each sidebar row with a drop-indicator bar
- Dragging is constrained to **siblings** (same parent) so the git-derived hierarchy stays intact
- Optimistic reorder with rollback + toast on API failure (`App.svelte`)
- Pure helpers `moveBranchInOrder` (sibling-validated) and `applyBranchOrder`; `WorktreeListRow` gains `parentBranch`

**CLI parity**
- `webmux list` honors the saved order
- New `webmux reorder <branch> --before|--after <branch>` command (parsing, usage, handler, root-command wiring, shell completions)

## Checks
- `svelte-check`: 0 errors / 0 warnings
- backend `tsc --noEmit`: clean
- New tests pass: order-service, order-state-service, snapshot ordering (backend); `moveBranchInOrder` / `applyBranchOrder` / `parentBranch` (frontend); reorder parsing + end-to-end reorder→list (CLI)
- Production bundles build for both `webmux` and the server

## Manual testing
- Launched the dashboard against a real project (`/Users/guilhem/Devel/windmill`, 31 worktrees): UI loads, `GET /api/worktrees` returns the list, `PUT /api/worktrees/order` returns 200
- Drag-reordered rows in the sidebar and confirmed the order persisted across refresh
- _Note:_ pre-existing unrelated test failures (`localStorage.clear` env issue; git/lifecycle/instance-registry suites) are present on the clean base too

## Test plan
- [ ] Drag a worktree above/below a sibling; confirm the drop indicator and that order persists after reload
- [ ] Confirm a child cannot be dropped outside its parent group
- [ ] Create a new worktree; confirm it appears in a sensible position (alphabetical, after ordered ones)
- [ ] `webmux reorder <branch> --before <other>` then `webmux list` reflects the new order
- [ ] `webmux reorder <unknown> --after <branch>` errors cleanly

---
Generated with [Claude Code](https://claude.com/claude-code)