### PR TITLE
feat: AI-polish Linear issue titles in web create-ticket path

### DIFF
--- a/backend/src/__tests__/linear-service.test.ts
+++ b/backend/src/__tests__/linear-service.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   buildLinearIssuesResponse,
   createLinearIssue,
-  deriveLinearIssueTitle,
   fetchAssignedIssues,
   parseIssueCreateResponse,
   resetLinearCaches,
@@ -170,20 +169,6 @@ describe("buildLinearIssuesResponse", () => {
       ok: false,
       error: "Linear API 401: Unauthorized",
     });
-  });
-});
-
-describe("deriveLinearIssueTitle", () => {
-  it("prefers the explicit title when present", () => {
-    expect(deriveLinearIssueTitle("Manual title", "Prompt line")).toBe("Manual title");
-  });
-
-  it("falls back to the first non-empty prompt line", () => {
-    expect(deriveLinearIssueTitle(undefined, "\n  First useful line\nSecond line")).toBe("First useful line");
-  });
-
-  it("returns null when no title can be derived", () => {
-    expect(deriveLinearIssueTitle("   ", "\n \n")).toBeNull();
   });
 });
 

--- a/backend/src/__tests__/linear-title-service.test.ts
+++ b/backend/src/__tests__/linear-title-service.test.ts
@@ -3,6 +3,7 @@ import {
   extractKeywords,
   findDuplicateLinearIssue,
   polishLinearIssueTitle,
+  resolveLinearTicketTitle,
 } from "../services/linear-title-service";
 import type { RunLlmResult } from "../services/llm-spawn";
 import type { LinearIssue, SearchTeamIssuesResult } from "../services/linear-service";
@@ -110,6 +111,59 @@ describe("polishLinearIssueTitle", () => {
       runLlm: async () => okLlm("   \n   "),
     });
     expect(result).toEqual({ title: "Fix the search bar", source: "heuristic_fallback" });
+  });
+});
+
+describe("resolveLinearTicketTitle", () => {
+  it("uses the explicit title verbatim without calling the LLM", async () => {
+    let called = false;
+    const result = await resolveLinearTicketTitle({
+      explicitTitle: "  Manual title  ",
+      prompt: "fix the thing",
+      autoName: { provider: "claude" },
+      runLlm: async () => {
+        called = true;
+        return okLlm("AI title");
+      },
+    });
+    expect(result).toEqual({ title: "Manual title", source: "explicit" });
+    expect(called).toBe(false);
+  });
+
+  it("AI-polishes the prompt when no explicit title is given", async () => {
+    const result = await resolveLinearTicketTitle({
+      prompt: "we get logged out on token refresh\nmore detail",
+      autoName: { provider: "claude" },
+      runLlm: async () => okLlm("Fix logout on token refresh"),
+    });
+    expect(result).toEqual({ title: "Fix logout on token refresh", source: "llm" });
+  });
+
+  it("falls back to the heuristic title when the LLM fails", async () => {
+    const result = await resolveLinearTicketTitle({
+      prompt: "Fix the search bar",
+      autoName: { provider: "claude" },
+      runLlm: async () => failLlm("timeout"),
+    });
+    expect(result).toEqual({ title: "Fix the search bar", source: "heuristic_fallback" });
+  });
+
+  it("treats a blank explicit title as absent and polishes instead", async () => {
+    const result = await resolveLinearTicketTitle({
+      explicitTitle: "   ",
+      prompt: "rename the export button",
+      autoName: { provider: "claude" },
+      runLlm: async () => okLlm("Rename the export button"),
+    });
+    expect(result).toEqual({ title: "Rename the export button", source: "llm" });
+  });
+
+  it("returns null when there is no title to derive", async () => {
+    const result = await resolveLinearTicketTitle({
+      prompt: "   \n  ",
+      autoName: null,
+    });
+    expect(result).toBeNull();
   });
 });
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -66,12 +66,12 @@ import {
   buildLinearPickupMarkdown,
   createIssueComment,
   createLinearIssue,
-  deriveLinearIssueTitle,
   fetchAssignedIssues,
   fetchIssueWithAttachments,
   fetchTeamByKey,
   uploadAttachmentFile,
 } from "./services/linear-service";
+import { resolveLinearTicketTitle } from "./services/linear-title-service";
 import {
   buildSeedFromLinear,
   defaultSeedFromLinearDeps,
@@ -1070,8 +1070,12 @@ async function apiCreateWorktree(req: Request): Promise<Response> {
   }
 
   if (createLinearTicket) {
-    const title = deriveLinearIssueTitle(linearTitle, prompt);
-    if (!title) {
+    const resolvedTitle = await resolveLinearTicketTitle({
+      explicitTitle: linearTitle,
+      prompt: prompt ?? "",
+      autoName: config.autoName,
+    });
+    if (!resolvedTitle) {
       return errorResponse("Linear ticket title could not be derived from the prompt", 400);
     }
 
@@ -1088,7 +1092,7 @@ async function apiCreateWorktree(req: Request): Promise<Response> {
     }
 
     const linearResult = await createLinearIssue({
-      title,
+      title: resolvedTitle.title,
       description: resolvedPrompt ?? "",
       teamId: teamResult.data.id,
     });
@@ -1098,7 +1102,7 @@ async function apiCreateWorktree(req: Request): Promise<Response> {
 
     resolvedBranch = linearResult.data.branchName;
     log.info(
-      `[linear] created ticket ${linearResult.data.identifier} branch=${linearResult.data.branchName} title="${linearResult.data.title.slice(0, 80)}"`,
+      `[linear] created ticket ${linearResult.data.identifier} branch=${linearResult.data.branchName} title="${linearResult.data.title.slice(0, 80)}" titleSource=${resolvedTitle.source}`,
     );
   }
 

--- a/backend/src/services/linear-service.ts
+++ b/backend/src/services/linear-service.ts
@@ -402,22 +402,6 @@ export function parseIssueCreateResponse(raw: GqlResponse<IssueCreateMutationDat
   };
 }
 
-export function deriveLinearIssueTitle(
-  explicitTitle: string | undefined,
-  prompt: string | undefined,
-): string | null {
-  const trimmedTitle = explicitTitle?.trim();
-  if (trimmedTitle) {
-    return trimmedTitle;
-  }
-
-  const firstPromptLine = prompt
-    ?.split(/\r?\n/)
-    .map((line) => line.trim())
-    .find((line) => line.length > 0);
-  return firstPromptLine ?? null;
-}
-
 export function branchMatchesIssue(
   worktreeBranch: string,
   issueBranchName: string,

--- a/backend/src/services/linear-title-service.ts
+++ b/backend/src/services/linear-title-service.ts
@@ -131,6 +131,37 @@ export async function polishLinearIssueTitle(input: PolishLinearIssueTitleInput)
   return { title: normalized, source: "llm" };
 }
 
+export interface ResolvedLinearTicketTitle {
+  title: string;
+  source: "explicit" | TitlePolishSource;
+}
+
+export interface ResolveLinearTicketTitleInput {
+  explicitTitle?: string;
+  prompt: string;
+  autoName: AutoNameConfig | null;
+  runLlm?: RunLlmFn;
+}
+
+// Used by the worktree-create endpoint's createLinearTicket path. An explicit
+// title (typed in the dialog) always wins; otherwise we AI-polish the prompt the
+// same way `webmux oneshot --linear` does, so the web and CLI surfaces produce
+// the same kind of title instead of the raw first prompt line.
+export async function resolveLinearTicketTitle(
+  input: ResolveLinearTicketTitleInput,
+): Promise<ResolvedLinearTicketTitle | null> {
+  const explicit = input.explicitTitle?.trim();
+  if (explicit) {
+    return { title: explicit, source: "explicit" };
+  }
+  const polished = await polishLinearIssueTitle({
+    prompt: input.prompt,
+    autoName: input.autoName,
+    runLlm: input.runLlm,
+  });
+  return polished ? { title: polished.title, source: polished.source } : null;
+}
+
 export function extractKeywords(title: string, max = 4): string[] {
   const tokens = title
     .toLowerCase()

--- a/frontend/src/lib/CreateWorktreeDialog.svelte
+++ b/frontend/src/lib/CreateWorktreeDialog.svelte
@@ -501,7 +501,7 @@
               id="wt-linear-title"
               type="text"
               class="w-full px-2.5 py-1.5 rounded-md border border-edge bg-surface text-primary text-[13px] placeholder:text-muted/50 outline-none focus:border-accent"
-              placeholder="Defaults to the first non-empty line of the prompt"
+              placeholder="Auto-generated from the prompt when left blank"
               bind:value={linearTitle}
             />
           </div>


### PR DESCRIPTION
## Summary

The web UI "Create Linear ticket" option (and web oneshot runs that create a ticket) produced a bad issue title — it used `deriveLinearIssueTitle()`, i.e. the raw first non-empty line of the prompt, and **never called the LLM at all**. Meanwhile the CLI `webmux oneshot --linear <TEAM>` path was already AI-polishing titles via `polishLinearIssueTitle()` (added in #264, May 2026).

This brings the web surface to parity with the CLI: both now derive issue titles the same way worktree branch names are generated.

## Changes

- **`linear-title-service.ts`**: add `resolveLinearTicketTitle()` — an explicit title (typed in the dialog) always wins; otherwise the prompt is AI-polished via the existing `polishLinearIssueTitle()`, with the heuristic/first-line fallback preserved for when the `auto_name` LLM is unavailable or times out. Returns a `source` (`explicit` | `llm` | `heuristic_*`) for observability.
- **`server.ts`**: the `createLinearTicket` branch of `apiCreateWorktree` now calls `resolveLinearTicketTitle({ explicitTitle, prompt, autoName: config.autoName })` instead of the raw heuristic, and logs `titleSource=…`.
- **Removed** the now-dead `deriveLinearIssueTitle()` (and its tests) — it had no remaining callers.
- **`CreateWorktreeDialog.svelte`**: placeholder updated from "Defaults to the first non-empty line of the prompt" → "Auto-generated from the prompt when left blank".
- **Tests**: 5 new cases for `resolveLinearTicketTitle` (explicit-title verbatim / no LLM call, AI-polish, heuristic fallback, blank-explicit → polish, null).

## Notes

- As with the CLI path and worktree naming, the LLM only runs when `config.autoName` (the `auto_name` config block) is set; otherwise both fall back to the first-line heuristic. This PR does not change that gate — it just stops the web path from ignoring it.

## Checks

- `bun run --cwd backend check` — clean (tsc, 0 errors)
- backend `linear-title-service` + `linear-service` tests — 48 pass
- `bun run --cwd frontend check` (svelte-check) — 0 errors / 0 warnings
- `bun run --cwd frontend test` — 114 pass (incl. existing explicit-title `App.test.ts` case)
- `bun test bin/src` — 173 pass
- Pre-existing, unrelated failures in `instance-registry` / `isValidInstancePrefix` were confirmed failing on the clean tree as well.

## Test plan

- [ ] With `auto_name` configured server-side, toggle "Create Linear ticket" in the create-worktree dialog, leave the title field blank, and confirm the created issue gets an AI-polished title (not the raw first prompt line).
- [ ] Provide an explicit title in the dialog and confirm it is used verbatim.
- [ ] With `auto_name` unset, confirm it gracefully falls back to the first-line heuristic.

---
Generated with [Claude Code](https://claude.com/claude-code)