### PR TITLE
fix: keep claude chat stream open across turns to preserve message order

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -784,6 +784,7 @@ async function sendClaudeStreamingMessage(input: {
     }
   }
 
+  // TODO: a tool-call-ending turn can still re-stick "running" if the subprocess's async PostToolUse hook lands after this onRunSettled; fully fix by suppressing status hooks for owned runs.
   const turnId = `claude-turn:${randomUUID()}`;
   const started = claudeConversationStreamService.startRun({
     conversationId: sessionId,

--- a/frontend/src/lib/MobileChatSurface.svelte
+++ b/frontend/src/lib/MobileChatSurface.svelte
@@ -108,27 +108,23 @@
   }
 
   function syncConversationStream(force = false): void {
-    if (!supportsStreaming(conversation)) {
+    const conversationId = supportsStreaming(conversation) ? conversation?.conversationId ?? null : null;
+
+    // Keep one stream open across turns (close only on conversation change) so the
+    // server-side message ordering isn't reseeded per turn, which interleaves turns.
+    if (streamConnection && streamConnection.conversationId !== conversationId) {
       closeConversationStream();
+    }
+
+    if (!conversationId || hasActiveConversationStream(conversationId)) {
       return;
     }
 
-    const conversationId = conversation?.conversationId ?? null;
-    if (!conversationId) {
-      closeConversationStream();
-      return;
-    }
-
+    // Not connected yet: open on a send (force) or when a run is already active.
     if (!force && conversation?.running !== true) {
-      closeConversationStream();
       return;
     }
 
-    if (hasActiveConversationStream(conversationId)) {
-      return;
-    }
-
-    closeConversationStream();
     lastStreamRevision = 0;
     const disconnect = connectWorktreeConversationStream(worktree.branch, {
       onEvent: (event) => {

--- a/frontend/src/lib/MobileChatSurface.test.ts
+++ b/frontend/src/lib/MobileChatSurface.test.ts
@@ -155,6 +155,59 @@ describe("MobileChatSurface", () => {
     expect(fetchWorktreeConversationHistory).not.toHaveBeenCalled();
   });
 
+  it("reuses one Claude stream across turns instead of reconnecting", async () => {
+    vi.mocked(attachWorktreeConversation).mockResolvedValue(createConversationResponse("claudeCode"));
+    vi.mocked(sendWorktreeConversationMessage)
+      .mockResolvedValueOnce({
+        conversationId: "session-1",
+        turnId: "turn-1",
+        running: true,
+        streaming: true,
+      } satisfies AgentsUiSendMessageResponse)
+      .mockResolvedValueOnce({
+        conversationId: "session-1",
+        turnId: "turn-2",
+        running: true,
+        streaming: true,
+      } satisfies AgentsUiSendMessageResponse);
+
+    render(MobileChatSurface, {
+      props: {
+        worktree: createWorktree(),
+      },
+    });
+
+    await screen.findByText("No messages yet. Send the first prompt to start this chat.");
+
+    // Turn 1 opens the stream.
+    await fireEvent.input(screen.getByLabelText("Message"), { target: { value: "first" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await screen.findByText("first");
+    expect(connectWorktreeConversationStream).toHaveBeenCalledTimes(1);
+
+    // Turn 1 completes — the stream must stay open, not tear down.
+    const callbacks = vi.mocked(connectWorktreeConversationStream).mock.calls[0]?.[1];
+    callbacks?.onEvent({
+      type: "conversationStatus",
+      revision: 1,
+      conversationId: "session-1",
+      running: false,
+      activeTurnId: null,
+    });
+    await tick();
+
+    // Turn 2 must reuse the existing stream. Reconnecting spins up a fresh
+    // server-side session that reseeds ordering and interleaves turns into
+    // user/user/assistant/assistant.
+    await fireEvent.input(screen.getByLabelText("Message"), { target: { value: "second" } });
+    await fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await waitFor(() => {
+      expect(sendWorktreeConversationMessage).toHaveBeenCalledTimes(2);
+    });
+
+    expect(connectWorktreeConversationStream).toHaveBeenCalledTimes(1);
+  });
+
   it("polls Claude history after terminal-routed sends", async () => {
     vi.mocked(attachWorktreeConversation).mockResolvedValue(createConversationResponse("claudeCode"));
     vi.mocked(sendWorktreeConversationMessage).mockResolvedValue({


### PR DESCRIPTION
## Summary

In the Claude web chat, sending multiple messages could render them out of order — e.g. `user, user, assistant, assistant` instead of interleaved turns. Root cause: the conversation stream **tore down on every turn completion and reconnected on the next send**. Each reconnect built a fresh server-side `AgentsConversationStreamSession` that reseeded its message `order` counter from the *persisted* history count and replayed/re-`reserve`d already-shown messages. Two turns sent close together (before the first persisted) both got seeded at the same `nextOrder`, so different turns were assigned identical `order` values and collided.

Captured from live `[ordering]` debug logs (two messages "hello" then "wow"): both reconnects seeded `nextOrder=5`, so hello-user and wow-user both landed on order 5 and both assistants on order 6 → stable-sorted into `user, user, assistant, assistant`.

## Fix

Keep a **single** stream open for the life of the open conversation. `syncConversationStream` now closes only when the stream no longer matches the active conversation (provider change / conversation switch / unmount); a matching stream is reused across turns. With one persistent session the server-side `reserveOrder` stays monotonic (`hello-user=2, hello-assistant=3, wow-user=4, wow-assistant=5`), so no reseed, no replay-renumber, no collision.

## Changes

- `frontend/src/lib/MobileChatSurface.svelte`: rewrite `syncConversationStream` to keep one stream open across turns instead of close-on-idle + reconnect-on-send.
- `frontend/src/lib/MobileChatSurface.test.ts`: regression test asserting the stream connects once across two turns (turn → completion → turn). Verified it fails on the old code (connects 2×) and passes now (1×).
- `backend/src/server.ts`: one-line TODO documenting the residual tool-call-ending-turn race from the previous fix (#273).

## Test plan

- [x] `bun run test` (frontend) — 117 pass / 0 fail; new regression test included
- [x] `bun run check` (frontend svelte-check) — 0 errors
- [x] `bun run check` (backend tsc) — exit 0
- [x] Manually reproduced with debug logging, then confirmed fixed: orders stay monotonic and the stream connects once per conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)