### PR TITLE
fix: live web-chat updates for terminal-initiated Claude turns

### DIFF
--- a/frontend/src/lib/MobileChatSurface.svelte
+++ b/frontend/src/lib/MobileChatSurface.svelte
@@ -44,6 +44,7 @@
     lastSignature: string | null;
     sawProgress: boolean;
     unchangedTicks: number;
+    stopWhenIdle: boolean;
   } | null>(null);
   let streamConnection: {
     conversationId: string;
@@ -162,6 +163,7 @@
 
   function startRefreshPolling(
     baselineConversation: AgentsUiConversationState | null = conversation,
+    stopWhenIdle = false,
   ): void {
     const baselineSignature = buildConversationProgressSignature(baselineConversation);
     refreshPollingState = {
@@ -170,6 +172,7 @@
       lastSignature: baselineSignature,
       sawProgress: false,
       unchangedTicks: 0,
+      stopWhenIdle,
     };
     nextRefreshPollingToken += 1;
   }
@@ -180,6 +183,10 @@
   ): void {
     const currentState = refreshPollingState;
     if (!currentState || currentState.token !== token) return;
+
+    // Terminal-owned turns settle when the worktree agent goes idle (handled by the
+    // busy-poll effect below), not via the message-progress heuristic used for sends.
+    if (currentState.stopWhenIdle) return;
 
     const nextSignature = buildConversationProgressSignature(nextConversation);
     const sawProgress = currentState.sawProgress || nextSignature !== currentState.baselineSignature;
@@ -254,6 +261,27 @@
     return () => {
       closeConversationStream();
     };
+  });
+
+  $effect(() => {
+    // A Claude turn started in the terminal (the initial worktree prompt, or anything
+    // typed in the pane) is not a backend-owned run, so there is no stream to subscribe
+    // to and the snapshot reports running:false. While the worktree agent is busy, poll
+    // history so the terminal claude's flushed messages appear live; stop once it idles.
+    const agentBusy = worktree.agent === "working";
+    const isTerminalOwnedClaudeTurn =
+      conversation?.provider === "claudeCode" && conversation.running !== true;
+
+    if (agentBusy && isTerminalOwnedClaudeTurn) {
+      if (refreshPollingState === null) {
+        startRefreshPolling(conversation, true);
+      }
+      return;
+    }
+
+    if (refreshPollingState?.stopWhenIdle === true) {
+      refreshPollingState = null;
+    }
   });
 
   $effect(() => {

--- a/frontend/src/lib/MobileChatSurface.test.ts
+++ b/frontend/src/lib/MobileChatSurface.test.ts
@@ -535,4 +535,70 @@ describe("MobileChatSurface", () => {
     expect(text.indexOf("Completed shell")).toBeLessThan(text.indexOf("Second assistant"));
   });
 
+  it("polls Claude history for a busy terminal-owned turn and stops when the agent goes idle", async () => {
+    const userMessage = {
+      id: "user-1",
+      turnId: "turn-1",
+      order: 0,
+      role: "user" as const,
+      kind: "text" as const,
+      text: "Build the feature",
+      status: "completed" as const,
+      createdAt: "2026-05-28T10:00:00.000Z",
+    };
+    vi.mocked(attachWorktreeConversation).mockResolvedValue(
+      createConversationResponse("claudeCode", {
+        running: false,
+        activeTurnId: null,
+        messages: [userMessage],
+      }),
+    );
+    vi.mocked(fetchWorktreeConversationHistory).mockResolvedValue(
+      createConversationResponse("claudeCode", {
+        running: false,
+        activeTurnId: null,
+        messages: [
+          userMessage,
+          {
+            id: "assistant-1",
+            turnId: "turn-1",
+            order: 1,
+            role: "assistant",
+            kind: "text",
+            text: "Done from terminal",
+            status: "completed",
+            createdAt: "2026-05-28T10:00:01.000Z",
+          },
+        ],
+      }),
+    );
+
+    const { rerender } = render(MobileChatSurface, {
+      props: {
+        worktree: createWorktree({ agent: "working", status: "running" }),
+      },
+    });
+
+    await screen.findByText("Build the feature");
+    // A terminal-owned turn has no backend stream to subscribe to.
+    expect(connectWorktreeConversationStream).not.toHaveBeenCalled();
+
+    // Polling surfaces the terminal claude's flushed response live.
+    await vi.advanceTimersByTimeAsync(1000);
+    await waitFor(() => {
+      expect(fetchWorktreeConversationHistory).toHaveBeenCalledWith("feature/mobile-chat");
+    });
+    await screen.findByText("Done from terminal");
+
+    // Polling keeps running while the agent is busy (it must not settle early).
+    await vi.advanceTimersByTimeAsync(5000);
+    const callsWhileBusy = vi.mocked(fetchWorktreeConversationHistory).mock.calls.length;
+    expect(callsWhileBusy).toBeGreaterThan(1);
+
+    // When the run settles and the agent goes idle, polling stops.
+    await rerender({ worktree: createWorktree({ agent: "waiting", status: "idle" }) });
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(vi.mocked(fetchWorktreeConversationHistory).mock.calls.length).toBe(callsWhileBusy);
+  });
+
 });


### PR DESCRIPTION
## Summary

The Claude web chat (`MobileChatSurface.svelte`) only live-streams turns sent **from the web chat**. Those run as a backend-owned `claude -p` tracked by `claudeConversationStreamService`, which broadcasts WS stream events the frontend subscribes to.

The **initial worktree-creation prompt** (and anything typed in the terminal pane) instead launches an **interactive** `claude -- <prompt>` in the tmux pane, so the stream service has no run for it. On attach, the conversation snapshot reports `running: false`, `syncConversationStream` opens nothing, and (since #262 removed the history-polling fallback on attach) the chat shows only the static attach-time snapshot and never updates live.

This PR restores **message-level** live updates for terminal-owned Claude turns by reusing the existing refresh-polling machinery — no second polling system, no backend changes.

## Root cause

- Terminal-initiated turns are not backend-owned runs → no stream events → `conversation.running` stays `false`.
- `syncConversationStream` only opens a stream when `running === true` (or on a forced send), so a fresh attach to a busy terminal turn subscribes to nothing.
- There is no longer a history-polling fallback on attach, so the response never appears until a manual refresh.

## Fix (frontend-only)

- New `$effect` that, while the **worktree agent is busy** (`worktree.agent === "working"`) and the conversation is a **Claude** conversation that is **not** backend-streaming (`provider === "claudeCode"` and `running !== true`), starts the existing `startRefreshPolling` loop so `fetchWorktreeConversationHistory` is polled and the terminal claude's flushed messages appear live.
- Polling **stops when the agent goes idle** (the prop flips away from `"working"`), so it never runs forever on an idle worktree.
- `startRefreshPolling` gains a `stopWhenIdle` flag; for these terminal-owned polls `updateRefreshPollingState` skips the message-progress settle heuristic (which can stop early mid-turn) and instead relies on the agent-busy signal to gate the lifecycle. Send/interrupt-initiated polls are unchanged (`stopWhenIdle` defaults to `false`).

Orthogonal to #274 (keep-stream-open across turns): this change does not touch `syncConversationStream`.

## Changes

- `frontend/src/lib/MobileChatSurface.svelte`
  - Add `stopWhenIdle` to `refreshPollingState` and `startRefreshPolling`.
  - Skip the settle heuristic for `stopWhenIdle` polls in `updateRefreshPollingState`.
  - Add the busy-worktree controller `$effect` that starts/stops history polling for terminal-owned Claude turns.
- `frontend/src/lib/MobileChatSurface.test.ts`
  - Add a test that lands on a busy Claude worktree with no backend stream, asserts history is polled (so the response appears) and keeps polling while busy, then stops once the agent goes idle.

## Test plan

- [x] New test fails before the fix (history never polled → `waitFor` times out) and passes after.
- [x] `bun run test` in `frontend` — 118 passed (15 files), including existing stream/keep-open and terminal-routed-send tests.
- [x] `bun run check` in `frontend` — 0 errors, 0 warnings.
- [x] Svelte autofixer on the component — no issues.
- [ ] Manual: create a worktree with a prompt, open its web chat while the terminal claude runs → assistant response appears live without manual refresh; polling stops after the run settles.
- [ ] Manual: type a prompt directly in the terminal pane of an existing worktree → web chat updates live.

---
Generated with [Claude Code](https://claude.com/claude-code)