### PR TITLE
feat: render AskUserQuestion tool as a clickable web-chat card

### DIFF
--- a/bin/src/oneshot.ts
+++ b/bin/src/oneshot.ts
@@ -275,6 +275,17 @@ function summarizeToolInput(toolName: string, jsonText: string): string {
   }
   if (!input) return truncateInline(jsonText, 100);
 
+  if (toolName.toLowerCase() === "askuserquestion" && Array.isArray(input.questions)) {
+    const headers: string[] = [];
+    for (const question of input.questions) {
+      if (question && typeof question === "object" && !Array.isArray(question)) {
+        const header = (question as Record<string, unknown>).header;
+        if (typeof header === "string") headers.push(header);
+      }
+    }
+    if (headers.length > 0) return truncateInline(headers.join(", "), 120);
+  }
+
   const keys = TOOL_PRIMARY_KEY[toolName.toLowerCase()];
   if (keys) {
     const values: string[] = [];

--- a/frontend/src/lib/AskUserQuestionCard.svelte
+++ b/frontend/src/lib/AskUserQuestionCard.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  import { formatAskUserQuestionAnswer } from "./ask-user-question";
+  import type { AskUserQuestionInput } from "./types";
+
+  interface Props {
+    input: AskUserQuestionInput;
+    disabled: boolean;
+    onSubmit: (text: string) => void;
+  }
+
+  const { input, disabled, onSubmit }: Props = $props();
+
+  // One single-select question can answer on a single tap; anything else
+  // (multiple questions, or a multi-select) needs an explicit Submit.
+  const autoSend = $derived(input.questions.length === 1 && input.questions[0]?.multiSelect !== true);
+
+  let selections = $state<Record<number, string[]>>({});
+  let customText = $state<Record<number, string>>({});
+
+  function setSelection(qIndex: number, next: string[]): void {
+    selections = { ...selections, [qIndex]: next };
+  }
+
+  function setCustom(qIndex: number, value: string): void {
+    customText = { ...customText, [qIndex]: value };
+  }
+
+  function isSelected(qIndex: number, label: string): boolean {
+    return (selections[qIndex] ?? []).includes(label);
+  }
+
+  function buildAnswers(): Array<{ header: string; values: string[] }> {
+    return input.questions.map((question, index) => {
+      const custom = customText[index]?.trim() ?? "";
+      const values = [...(selections[index] ?? [])];
+      if (custom.length > 0) values.push(custom);
+      return { header: question.header, values };
+    });
+  }
+
+  const canSubmit = $derived(!disabled && buildAnswers().some((answer) => answer.values.length > 0));
+
+  function submitSingle(header: string, value: string): void {
+    onSubmit(formatAskUserQuestionAnswer([{ header, values: [value] }]));
+  }
+
+  function submitAll(): void {
+    if (disabled) return;
+    const text = formatAskUserQuestionAnswer(buildAnswers());
+    if (text.length === 0) return;
+    onSubmit(text);
+  }
+
+  function toggleOption(qIndex: number, label: string): void {
+    if (disabled) return;
+    const question = input.questions[qIndex];
+    if (!question) return;
+    if (autoSend) {
+      submitSingle(question.header, label);
+      return;
+    }
+    const current = selections[qIndex] ?? [];
+    if (question.multiSelect) {
+      setSelection(qIndex, current.includes(label) ? current.filter((value) => value !== label) : [...current, label]);
+    } else {
+      setSelection(qIndex, current.includes(label) ? [] : [label]);
+    }
+  }
+
+  function handleCustomKeydown(event: KeyboardEvent, qIndex: number): void {
+    if (event.key !== "Enter" || event.shiftKey) return;
+    event.preventDefault();
+    if (disabled) return;
+    const custom = customText[qIndex]?.trim() ?? "";
+    if (autoSend) {
+      const question = input.questions[qIndex];
+      if (!question || custom.length === 0) return;
+      submitSingle(question.header, custom);
+      return;
+    }
+    if (canSubmit) submitAll();
+  }
+</script>
+
+<div class="self-start w-full max-w-[94%] min-w-0 rounded-md border border-accent/40 bg-topbar/40 text-xs text-primary">
+  <div class="border-b border-edge/60 px-3 py-2 text-[10px] uppercase tracking-[0.12em] text-muted">
+    Question
+  </div>
+
+  <div class="flex flex-col gap-4 px-3 py-3">
+    {#each input.questions as question, qIndex (`${question.header}:${qIndex}`)}
+      <div class="flex min-w-0 flex-col gap-2">
+        <div class="text-[10px] uppercase tracking-[0.12em] text-muted">{question.header}</div>
+        <div class="text-sm text-primary">{question.question}</div>
+        <div class="flex flex-wrap gap-2">
+          {#each question.options as option (option.label)}
+            <button
+              type="button"
+              class={`min-w-0 max-w-full rounded-md border px-3 py-1.5 text-left transition disabled:cursor-not-allowed disabled:opacity-60 ${
+                isSelected(qIndex, option.label)
+                  ? "border-accent bg-accent text-white"
+                  : "border-edge bg-surface text-primary enabled:hover:bg-hover"
+              }`}
+              {disabled}
+              onclick={() => toggleOption(qIndex, option.label)}
+            >
+              <span class="block break-words font-medium">{option.label}</span>
+              {#if option.description}
+                <span class={`mt-0.5 block break-words text-[10px] ${isSelected(qIndex, option.label) ? "text-white/80" : "text-muted"}`}>
+                  {option.description}
+                </span>
+              {/if}
+            </button>
+          {/each}
+        </div>
+        <input
+          type="text"
+          class="w-full rounded-md border border-edge bg-surface px-3 py-1.5 text-xs text-primary outline-none transition placeholder:text-muted/70 focus:border-accent disabled:cursor-not-allowed disabled:opacity-60"
+          placeholder="Custom answer…"
+          value={customText[qIndex] ?? ""}
+          oninput={(event) => setCustom(qIndex, event.currentTarget.value)}
+          onkeydown={(event) => handleCustomKeydown(event, qIndex)}
+          {disabled}
+        />
+      </div>
+    {/each}
+  </div>
+
+  {#if !autoSend}
+    <div class="flex justify-end border-t border-edge/60 px-3 py-2">
+      <button
+        type="button"
+        class="rounded-md border border-accent bg-accent px-3 py-1.5 text-xs font-medium text-white transition enabled:hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-45"
+        onclick={submitAll}
+        disabled={!canSubmit}
+      >
+        Submit answer
+      </button>
+    </div>
+  {/if}
+</div>

--- a/frontend/src/lib/AskUserQuestionCard.test.ts
+++ b/frontend/src/lib/AskUserQuestionCard.test.ts
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AskUserQuestionCard from "./AskUserQuestionCard.svelte";
+import type { AskUserQuestionInput } from "./types";
+
+const singleSelect: AskUserQuestionInput = {
+  questions: [
+    {
+      question: "Do you prefer cats or dogs?",
+      header: "Pet type",
+      multiSelect: false,
+      options: [
+        { label: "Cats", description: "Independent." },
+        { label: "Dogs", description: "Loyal." },
+      ],
+    },
+  ],
+};
+
+const multiSelect: AskUserQuestionInput = {
+  questions: [
+    {
+      question: "Which toppings?",
+      header: "Toppings",
+      multiSelect: true,
+      options: [{ label: "Cheese" }, { label: "Olives" }],
+    },
+  ],
+};
+
+describe("AskUserQuestionCard", () => {
+  afterEach(() => cleanup());
+
+  it("renders the question, options and a custom input", () => {
+    render(AskUserQuestionCard, { props: { input: singleSelect, disabled: false, onSubmit: vi.fn() } });
+
+    expect(screen.getByText("Do you prefer cats or dogs?")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Cats/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Dogs/ })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Custom answer…")).toBeInTheDocument();
+  });
+
+  it("auto-sends a single-select answer on click", async () => {
+    const onSubmit = vi.fn();
+    render(AskUserQuestionCard, { props: { input: singleSelect, disabled: false, onSubmit } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /Cats/ }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("Pet type: Cats");
+  });
+
+  it("auto-sends a typed custom answer on Enter", async () => {
+    const onSubmit = vi.fn();
+    render(AskUserQuestionCard, { props: { input: singleSelect, disabled: false, onSubmit } });
+
+    const input = screen.getByPlaceholderText("Custom answer…");
+    await fireEvent.input(input, { target: { value: "A goldfish" } });
+    await fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSubmit).toHaveBeenCalledWith("Pet type: A goldfish");
+  });
+
+  it("uses a submit button for multi-select and joins selections", async () => {
+    const onSubmit = vi.fn();
+    render(AskUserQuestionCard, { props: { input: multiSelect, disabled: false, onSubmit } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Cheese" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Olives" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Submit answer" }));
+    expect(onSubmit).toHaveBeenCalledWith("Toppings: Cheese, Olives");
+  });
+
+  it("does not submit when disabled", async () => {
+    const onSubmit = vi.fn();
+    render(AskUserQuestionCard, { props: { input: singleSelect, disabled: true, onSubmit } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /Cats/ }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/MobileChatSurface.svelte
+++ b/frontend/src/lib/MobileChatSurface.svelte
@@ -280,37 +280,6 @@
     };
   });
 
-  // A freshly-created worktree runs Claude in the terminal (e.g. `claude -- "<prompt>"`),
-  // not the web `claude -p` socket, so those turns never publish live stream events.
-  // While that agent is actively working and we have no live stream, poll history so
-  // its messages — including a pending AskUserQuestion — show up in the web chat.
-  const agentWorking = $derived(worktree.agent === "working");
-
-  $effect(() => {
-    if (!agentWorking) return;
-
-    let requestInFlight = false;
-    const interval = window.setInterval(() => {
-      if (requestInFlight) return;
-      if (conversation?.provider !== "claudeCode") return;
-      if (hasActiveConversationStream(conversation.conversationId)) return;
-      requestInFlight = true;
-      void (async () => {
-        try {
-          applyConversationResponse(await requestConversation("history"));
-        } catch (error) {
-          conversationError = error instanceof Error ? error.message : String(error);
-        } finally {
-          requestInFlight = false;
-        }
-      })();
-    }, REFRESH_POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(interval);
-    };
-  });
-
   $effect(() => {
     const pollingState = refreshPollingState;
     if (!pollingState) return;

--- a/frontend/src/lib/MobileChatSurface.svelte
+++ b/frontend/src/lib/MobileChatSurface.svelte
@@ -280,6 +280,37 @@
     };
   });
 
+  // A freshly-created worktree runs Claude in the terminal (e.g. `claude -- "<prompt>"`),
+  // not the web `claude -p` socket, so those turns never publish live stream events.
+  // While that agent is actively working and we have no live stream, poll history so
+  // its messages — including a pending AskUserQuestion — show up in the web chat.
+  const agentWorking = $derived(worktree.agent === "working");
+
+  $effect(() => {
+    if (!agentWorking) return;
+
+    let requestInFlight = false;
+    const interval = window.setInterval(() => {
+      if (requestInFlight) return;
+      if (conversation?.provider !== "claudeCode") return;
+      if (hasActiveConversationStream(conversation.conversationId)) return;
+      requestInFlight = true;
+      void (async () => {
+        try {
+          applyConversationResponse(await requestConversation("history"));
+        } catch (error) {
+          conversationError = error instanceof Error ? error.message : String(error);
+        } finally {
+          requestInFlight = false;
+        }
+      })();
+    }, REFRESH_POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  });
+
   $effect(() => {
     const pollingState = refreshPollingState;
     if (!pollingState) return;

--- a/frontend/src/lib/MobileChatSurface.svelte
+++ b/frontend/src/lib/MobileChatSurface.svelte
@@ -38,6 +38,7 @@
   let conversationLoading = $state(false);
   let composerText = $state("");
   let isSending = $state(false);
+  let isAnsweringQuestion = $state(false);
   let refreshPollingState = $state<{
     token: number;
     baselineSignature: string | null;
@@ -200,25 +201,24 @@
     };
   }
 
-  async function sendSelectedConversationMessage(): Promise<void> {
-    if (!conversation) return;
+  async function sendConversationText(text: string): Promise<boolean> {
+    if (!conversation) return false;
     const baselineConversation = conversation;
-    const text = composerText.trim();
-    if (text.length === 0) return;
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return false;
 
     isSending = true;
     conversationError = null;
     try {
       syncConversationStream(true);
-      const response = await sendWorktreeConversationMessage(worktree.branch, { text });
-      composerText = "";
+      const response = await sendWorktreeConversationMessage(worktree.branch, { text: trimmed });
       if (conversation.conversationId !== response.conversationId) {
         conversation = {
           ...conversation,
           conversationId: response.conversationId,
         };
       }
-      conversation = markConversationTurnStarted(conversation, response.turnId, text);
+      conversation = markConversationTurnStarted(conversation, response.turnId, trimmed);
       if (response.streaming) {
         syncConversationStream();
       } else {
@@ -226,11 +226,19 @@
         startRefreshPolling(baselineConversation);
       }
       onConversationMessageSent();
+      return true;
     } catch (error) {
       conversationError = error instanceof Error ? error.message : String(error);
+      return false;
     } finally {
       isSending = false;
     }
+  }
+
+  async function sendSelectedConversationMessage(): Promise<void> {
+    if (composerText.trim().length === 0) return;
+    const sent = await sendConversationText(composerText);
+    if (sent) composerText = "";
   }
 
   async function interruptSelectedConversation(): Promise<void> {
@@ -246,6 +254,22 @@
       }
     } catch (error) {
       conversationError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  // Answering an AskUserQuestion is a new turn, so the run that asked it must end
+  // first. In headless `claude -p` the question is auto-dismissed and the turn
+  // keeps going, so interrupt the active run before sending the answer.
+  async function answerConversationQuestion(text: string): Promise<void> {
+    if (!conversation || isSending || isAnsweringQuestion) return;
+    isAnsweringQuestion = true;
+    try {
+      if (conversation.running) {
+        await interruptSelectedConversation();
+      }
+      await sendConversationText(text);
+    } finally {
+      isAnsweringQuestion = false;
     }
   }
 
@@ -300,4 +324,5 @@
   onInterrupt={() => void interruptSelectedConversation()}
   onRefresh={() => void loadConversation("history")}
   onSend={() => void sendSelectedConversationMessage()}
+  onAnswerQuestion={(text) => void answerConversationQuestion(text)}
 />

--- a/frontend/src/lib/MobileChatSurface.test.ts
+++ b/frontend/src/lib/MobileChatSurface.test.ts
@@ -265,6 +265,64 @@ describe("MobileChatSurface", () => {
     await screen.findByText("Done from terminal");
   });
 
+  it("polls Claude history for a terminal-routed run while the agent is working", async () => {
+    vi.mocked(attachWorktreeConversation).mockResolvedValue(createConversationResponse("claudeCode"));
+    vi.mocked(fetchWorktreeConversationHistory).mockResolvedValue(createConversationResponse("claudeCode", {
+      messages: [
+        {
+          id: "ask-1",
+          turnId: "turn-1",
+          order: 0,
+          role: "assistant",
+          kind: "toolUse",
+          toolName: "AskUserQuestion",
+          toolCallId: "ask-1",
+          text: JSON.stringify({
+            questions: [
+              {
+                question: "Cats or dogs?",
+                header: "Pet type",
+                multiSelect: false,
+                options: [{ label: "Cats" }, { label: "Dogs" }],
+              },
+            ],
+          }),
+          status: "completed",
+          createdAt: "2026-05-28T10:00:00.000Z",
+        },
+      ],
+    }));
+
+    render(MobileChatSurface, {
+      props: {
+        worktree: createWorktree({ agent: "working" }),
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await waitFor(() => {
+      expect(fetchWorktreeConversationHistory).toHaveBeenCalledWith("feature/mobile-chat");
+    });
+    await screen.findByRole("button", { name: "Cats" });
+  });
+
+  it("does not poll history for an idle Claude worktree on mount", async () => {
+    vi.mocked(attachWorktreeConversation).mockResolvedValue(createConversationResponse("claudeCode"));
+    vi.mocked(fetchWorktreeConversationHistory).mockResolvedValue(createConversationResponse("claudeCode"));
+
+    render(MobileChatSurface, {
+      props: {
+        worktree: createWorktree({ agent: "waiting" }),
+      },
+    });
+
+    await screen.findByText("No messages yet. Send the first prompt to start this chat.");
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(fetchWorktreeConversationHistory).not.toHaveBeenCalled();
+  });
+
   it("does not poll Codex history after sending when the websocket stream is active", async () => {
     vi.mocked(attachWorktreeConversation).mockResolvedValue(createConversationResponse("codexAppServer"));
     vi.mocked(sendWorktreeConversationMessage).mockResolvedValue({

--- a/frontend/src/lib/MobileChatSurface.test.ts
+++ b/frontend/src/lib/MobileChatSurface.test.ts
@@ -265,64 +265,6 @@ describe("MobileChatSurface", () => {
     await screen.findByText("Done from terminal");
   });
 
-  it("polls Claude history for a terminal-routed run while the agent is working", async () => {
-    vi.mocked(attachWorktreeConversation).mockResolvedValue(createConversationResponse("claudeCode"));
-    vi.mocked(fetchWorktreeConversationHistory).mockResolvedValue(createConversationResponse("claudeCode", {
-      messages: [
-        {
-          id: "ask-1",
-          turnId: "turn-1",
-          order: 0,
-          role: "assistant",
-          kind: "toolUse",
-          toolName: "AskUserQuestion",
-          toolCallId: "ask-1",
-          text: JSON.stringify({
-            questions: [
-              {
-                question: "Cats or dogs?",
-                header: "Pet type",
-                multiSelect: false,
-                options: [{ label: "Cats" }, { label: "Dogs" }],
-              },
-            ],
-          }),
-          status: "completed",
-          createdAt: "2026-05-28T10:00:00.000Z",
-        },
-      ],
-    }));
-
-    render(MobileChatSurface, {
-      props: {
-        worktree: createWorktree({ agent: "working" }),
-      },
-    });
-
-    await vi.advanceTimersByTimeAsync(1000);
-
-    await waitFor(() => {
-      expect(fetchWorktreeConversationHistory).toHaveBeenCalledWith("feature/mobile-chat");
-    });
-    await screen.findByRole("button", { name: "Cats" });
-  });
-
-  it("does not poll history for an idle Claude worktree on mount", async () => {
-    vi.mocked(attachWorktreeConversation).mockResolvedValue(createConversationResponse("claudeCode"));
-    vi.mocked(fetchWorktreeConversationHistory).mockResolvedValue(createConversationResponse("claudeCode"));
-
-    render(MobileChatSurface, {
-      props: {
-        worktree: createWorktree({ agent: "waiting" }),
-      },
-    });
-
-    await screen.findByText("No messages yet. Send the first prompt to start this chat.");
-    await vi.advanceTimersByTimeAsync(3000);
-
-    expect(fetchWorktreeConversationHistory).not.toHaveBeenCalled();
-  });
-
   it("does not poll Codex history after sending when the websocket stream is active", async () => {
     vi.mocked(attachWorktreeConversation).mockResolvedValue(createConversationResponse("codexAppServer"));
     vi.mocked(sendWorktreeConversationMessage).mockResolvedValue({

--- a/frontend/src/lib/WorktreeConversationPanel.svelte
+++ b/frontend/src/lib/WorktreeConversationPanel.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import { tick } from "svelte";
-  import type { AgentsUiConversationMessage, AgentsUiConversationState, WorktreeInfo } from "./types";
+  import AskUserQuestionCard from "./AskUserQuestionCard.svelte";
+  import { ASK_USER_QUESTION_TOOL_NAME, parseAskUserQuestion } from "./ask-user-question";
+  import type {
+    AgentsUiConversationMessage,
+    AgentsUiConversationState,
+    AskUserQuestionInput,
+    WorktreeInfo,
+  } from "./types";
 
   interface Props {
     worktree: WorktreeInfo;
@@ -14,10 +21,18 @@
     onInterrupt: () => void;
     onRefresh: () => void;
     onSend: () => void;
+    onAnswerQuestion: (text: string) => void;
   }
 
   type TranscriptItem =
     | { type: "message"; key: string; message: AgentsUiConversationMessage }
+    | {
+      type: "question";
+      key: string;
+      tool: AgentsUiConversationMessage;
+      input: AskUserQuestionInput;
+      answered: boolean;
+    }
     | {
       type: "tool";
       key: string;
@@ -37,6 +52,7 @@
     onInterrupt,
     onRefresh,
     onSend,
+    onAnswerQuestion,
   }: Props = $props();
 
   const agentLabel = $derived(worktree.agentLabel ?? (worktree.agentName === "claude" ? "Claude" : "Codex"));
@@ -128,6 +144,15 @@
     return messages.flatMap((message): TranscriptItem[] => {
       const kind = messageKind(message);
       if (kind === "toolUse") {
+        if (message.toolName === ASK_USER_QUESTION_TOOL_NAME) {
+          const input = parseAskUserQuestion(message.text);
+          if (input) {
+            const answered = messages.some((other) =>
+              other.role === "user" && messageKind(other) === "text" && other.order > message.order
+            );
+            return [{ type: "question", key: message.id, tool: message, input, answered }];
+          }
+        }
         return [{
           type: "tool",
           key: message.id,
@@ -268,6 +293,12 @@
                   <div class="mt-2 uppercase tracking-[0.12em]">working</div>
                 {/if}
               </div>
+            {:else if item.type === "question"}
+              <AskUserQuestionCard
+                input={item.input}
+                disabled={item.answered}
+                onSubmit={onAnswerQuestion}
+              />
             {:else if item.type === "tool"}
               {@const message = item.tool}
               {@const result = item.result}

--- a/frontend/src/lib/WorktreeConversationPanel.test.ts
+++ b/frontend/src/lib/WorktreeConversationPanel.test.ts
@@ -52,12 +52,14 @@ function renderPanel({
   conversationError = null,
   composerText = "",
   isSending = false,
+  onAnswerQuestion = vi.fn(),
 }: {
   worktree?: WorktreeInfo;
   conversation?: AgentsUiConversationState | null;
   conversationError?: string | null;
   composerText?: string;
   isSending?: boolean;
+  onAnswerQuestion?: (text: string) => void;
 } = {}) {
   const onInterrupt = vi.fn();
 
@@ -74,10 +76,11 @@ function renderPanel({
       onInterrupt,
       onRefresh: vi.fn(),
       onSend: vi.fn(),
+      onAnswerQuestion,
     },
   });
 
-  return { onInterrupt };
+  return { onInterrupt, onAnswerQuestion };
 }
 
 describe("WorktreeConversationPanel", () => {
@@ -193,6 +196,104 @@ describe("WorktreeConversationPanel", () => {
     expect(toolBlock).toHaveTextContent("ls");
     expect(toolBlock).toHaveTextContent("README.md");
     expect(toolBlock?.querySelector("details")).toBeNull();
+  });
+
+  it("renders an AskUserQuestion tool as a clickable question card", () => {
+    renderPanel({
+      conversation: createConversation({
+        messages: [
+          {
+            id: "ask-1",
+            turnId: "turn-1",
+            order: 0,
+            role: "assistant",
+            kind: "toolUse",
+            toolName: "AskUserQuestion",
+            toolCallId: "ask-1",
+            text: JSON.stringify({
+              questions: [
+                {
+                  question: "Do you prefer cats or dogs?",
+                  header: "Pet type",
+                  multiSelect: false,
+                  options: [{ label: "Cats" }, { label: "Dogs" }],
+                },
+              ],
+            }),
+            status: "completed",
+            createdAt: null,
+          },
+          {
+            id: "tool_result:ask-1",
+            turnId: "turn-1",
+            order: 1,
+            role: "user",
+            kind: "toolResult",
+            toolCallId: "ask-1",
+            text: "Answer questions?",
+            status: "failed",
+            createdAt: null,
+          },
+        ],
+      }),
+    });
+
+    expect(screen.getByText("Do you prefer cats or dogs?")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cats" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dogs" })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Custom answer…")).toBeInTheDocument();
+    expect(screen.queryByText("Answer questions?")).not.toBeInTheDocument();
+    expect(screen.queryByText("Failed AskUserQuestion")).not.toBeInTheDocument();
+  });
+
+  function askQuestionConversation(running: boolean): AgentsUiConversationState {
+    return createConversation({
+      running,
+      activeTurnId: running ? "turn-1" : null,
+      messages: [
+        {
+          id: "ask-1",
+          turnId: "turn-1",
+          order: 0,
+          role: "assistant",
+          kind: "toolUse",
+          toolName: "AskUserQuestion",
+          toolCallId: "ask-1",
+          text: JSON.stringify({
+            questions: [
+              {
+                question: "Do you prefer cats or dogs?",
+                header: "Pet type",
+                multiSelect: false,
+                options: [{ label: "Cats" }, { label: "Dogs" }],
+              },
+            ],
+          }),
+          status: "completed",
+          createdAt: null,
+        },
+      ],
+    });
+  }
+
+  it("answers through onAnswerQuestion when a question option is clicked", async () => {
+    const onAnswerQuestion = vi.fn();
+    renderPanel({ onAnswerQuestion, conversation: askQuestionConversation(false) });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Cats" }));
+
+    expect(onAnswerQuestion).toHaveBeenCalledWith("Pet type: Cats");
+  });
+
+  it("keeps the question card answerable while the turn is still running", async () => {
+    const onAnswerQuestion = vi.fn();
+    renderPanel({ onAnswerQuestion, conversation: askQuestionConversation(true) });
+
+    const option = screen.getByRole("button", { name: "Cats" });
+    expect(option).not.toBeDisabled();
+
+    await fireEvent.click(option);
+    expect(onAnswerQuestion).toHaveBeenCalledWith("Pet type: Cats");
   });
 
   it("shows a processing indicator before visible progress arrives", () => {

--- a/frontend/src/lib/ask-user-question.test.ts
+++ b/frontend/src/lib/ask-user-question.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { formatAskUserQuestionAnswer, parseAskUserQuestion } from "./ask-user-question";
+
+describe("parseAskUserQuestion", () => {
+  it("parses a valid single-question payload", () => {
+    const text = JSON.stringify({
+      questions: [
+        {
+          question: "Do you prefer cats or dogs?",
+          header: "Pet type",
+          multiSelect: false,
+          options: [
+            { label: "Cats", description: "Independent." },
+            { label: "Dogs", description: "Loyal." },
+          ],
+        },
+      ],
+    });
+
+    const parsed = parseAskUserQuestion(text);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.questions).toHaveLength(1);
+    expect(parsed?.questions[0]?.header).toBe("Pet type");
+    expect(parsed?.questions[0]?.multiSelect).toBe(false);
+    expect(parsed?.questions[0]?.options.map((option) => option.label)).toEqual(["Cats", "Dogs"]);
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseAskUserQuestion("{not json")).toBeNull();
+  });
+
+  it("returns null when questions is missing", () => {
+    expect(parseAskUserQuestion(JSON.stringify({ foo: 1 }))).toBeNull();
+  });
+
+  it("returns null when a question has no options", () => {
+    const text = JSON.stringify({ questions: [{ question: "q", header: "h", options: [] }] });
+    expect(parseAskUserQuestion(text)).toBeNull();
+  });
+
+  it("returns null when an option is missing a label", () => {
+    const text = JSON.stringify({ questions: [{ question: "q", header: "h", options: [{ description: "x" }] }] });
+    expect(parseAskUserQuestion(text)).toBeNull();
+  });
+});
+
+describe("formatAskUserQuestionAnswer", () => {
+  it("formats a single answer as one line", () => {
+    expect(formatAskUserQuestionAnswer([{ header: "Pet type", values: ["Cats"] }])).toBe("Pet type: Cats");
+  });
+
+  it("joins multiple values and questions", () => {
+    expect(
+      formatAskUserQuestionAnswer([
+        { header: "Pet type", values: ["Cats", "Dogs"] },
+        { header: "Size", values: ["Large"] },
+      ]),
+    ).toBe("Pet type: Cats, Dogs\nSize: Large");
+  });
+
+  it("drops questions with no values", () => {
+    expect(
+      formatAskUserQuestionAnswer([
+        { header: "Pet type", values: ["Cats"] },
+        { header: "Size", values: [] },
+      ]),
+    ).toBe("Pet type: Cats");
+  });
+});

--- a/frontend/src/lib/ask-user-question.ts
+++ b/frontend/src/lib/ask-user-question.ts
@@ -1,0 +1,74 @@
+import type { AskUserQuestionInput, AskUserQuestionItem, AskUserQuestionOption } from "./types";
+
+export const ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseOption(value: unknown): AskUserQuestionOption | null {
+  if (!isRecord(value) || typeof value.label !== "string" || value.label.length === 0) {
+    return null;
+  }
+  return {
+    label: value.label,
+    ...(typeof value.description === "string" ? { description: value.description } : {}),
+  };
+}
+
+function parseQuestion(value: unknown): AskUserQuestionItem | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.question !== "string" || typeof value.header !== "string") return null;
+  if (!Array.isArray(value.options)) return null;
+
+  const options: AskUserQuestionOption[] = [];
+  for (const rawOption of value.options) {
+    const option = parseOption(rawOption);
+    if (!option) return null;
+    options.push(option);
+  }
+  if (options.length === 0) return null;
+
+  return {
+    question: value.question,
+    header: value.header,
+    ...(typeof value.multiSelect === "boolean" ? { multiSelect: value.multiSelect } : {}),
+    options,
+  };
+}
+
+// Parses the `toolUse.text` payload of an AskUserQuestion call (the compact JSON
+// the backend forwards verbatim) into a validated structure. Returns null on any
+// shape mismatch so callers can fall back to the generic tool rendering.
+export function parseAskUserQuestion(text: string): AskUserQuestionInput | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.questions)) return null;
+
+  const questions: AskUserQuestionItem[] = [];
+  for (const rawQuestion of parsed.questions) {
+    const question = parseQuestion(rawQuestion);
+    if (!question) return null;
+    questions.push(question);
+  }
+  if (questions.length === 0) return null;
+
+  return { questions };
+}
+
+// Builds the follow-up message text sent back to Claude when the user answers.
+// Each answered question becomes a `${header}: ${values}` line; empty questions
+// are dropped.
+export function formatAskUserQuestionAnswer(
+  answers: Array<{ header: string; values: string[] }>,
+): string {
+  return answers
+    .filter((answer) => answer.values.length > 0)
+    .map((answer) => `${answer.header}: ${answer.values.join(", ")}`)
+    .join("\n");
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -78,6 +78,22 @@ export interface FileUploadResult {
   files: Array<{ path: string }>;
 }
 
+export interface AskUserQuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface AskUserQuestionItem {
+  question: string;
+  header: string;
+  multiSelect?: boolean;
+  options: AskUserQuestionOption[];
+}
+
+export interface AskUserQuestionInput {
+  questions: AskUserQuestionItem[];
+}
+
 export interface DiffDialogProps {
   branch: string;
   cursorUrl?: string | null;


### PR DESCRIPTION
## Summary

When Claude calls its `AskUserQuestion` tool in the **web chat**, the UI used to render it as a generic, collapsed tool block paired with a **Failed** result reading `Answer questions?` — there was no way to answer. This PR renders the question as a card with clickable options plus a custom-answer input, and wires the answer back into the conversation.

### How the tool actually behaves (reproduced)
Running the exact backend invocation (`claude -p --output-format stream-json …`, prompt on stdin), the `AskUserQuestion` `tool_use` carries `{ questions: [{ question, header, multiSelect, options: [{ label, description }] }] }`. In headless `-p` the CLI **auto-dismisses** the prompt in ~2 ms (`tool_result {is_error:true, "Answer questions?"}`) and cannot be answered in the same turn — confirmed even with `--input-format stream-json`. So the answer is delivered as a **follow-up message that resumes the session**. The backend already forwards the full question payload verbatim, so no backend/contract change was needed.

## Changes
- **`ask-user-question.ts`** (new): pure `parseAskUserQuestion()` (validates the tool payload, `null` → graceful fallback) and `formatAskUserQuestionAnswer()`.
- **`AskUserQuestionCard.svelte`** (new): renders each question's choices as buttons + a custom input. Single-select sends on click (or Enter in the custom field); multi-select / multiple questions use a Submit button.
- **`WorktreeConversationPanel.svelte`**: detects `toolName === "AskUserQuestion"`, renders the card instead of the generic tool block (the `Answer questions?` error result is suppressed); the card stays answerable even while the turn is running.
- **`MobileChatSurface.svelte`**: answering interrupts the active (already auto-dismissed) turn, then sends the answer as a follow-up that resumes the session; shared `sendConversationText()` (no duplicated send logic).
- **`types.ts`**: `AskUserQuestion*` interfaces.
- **`bin/src/oneshot.ts`**: CLI transcript prints the question headers (e.g. `AskUserQuestion(Pet type)`) instead of empty parens.

## Test plan
- [x] `frontend bun run check` → 0 errors / 0 warnings
- [x] `frontend bun run test` → 133 pass (parse/format, card click/Enter/multi-select/disabled/while-running, panel integration)
- [x] `bun test bin/src` → 173 pass
- [x] Live dogfood (web send → `claude -p` stream): card renders from the real tool payload, single-select click round-trips as `Test pick: Orange`

## Scope / known limitation
This handles `AskUserQuestion` for **web-chat-initiated** turns (the chat's own `claude -p` runs), which is the surface that lacked it.

It does **not** cover a question asked by an **interactive terminal** run (e.g. a freshly-created worktree whose first prompt runs `claude` in tmux). Verified via session-file inspection: while such a question is pending, Claude does **not** persist the assistant turn to the session `.jsonl` — it pauses for the answer in the TUI and only flushes once answered there. Since the web chat reconstructs conversations from the `.jsonl`, there is no data to surface, and the question is answered in the terminal. (An earlier polling attempt was reverted for this reason — it polled correctly but there was nothing to read.)

---
Generated with [Claude Code](https://claude.com/claude-code)