### PR TITLE
feat: set up a project on add (scaffold + analyze with Claude), observably

### DIFF
--- a/backend/src/__tests__/init-authoring.test.ts
+++ b/backend/src/__tests__/init-authoring.test.ts
@@ -2,14 +2,14 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadConfig } from "../../backend/src/adapters/config.ts";
+import { loadConfig } from "../adapters/config";
 import {
   buildInitAgentCommand,
   buildInitPromptSpec,
   buildStarterTemplate,
   detectInitProjectContext,
   parseInitAgentStreamLine,
-} from "./init-helpers.ts";
+} from "../services/init-authoring";
 
 describe("buildInitAgentCommand", () => {
   const prompt = {

--- a/backend/src/__tests__/project-init-service.test.ts
+++ b/backend/src/__tests__/project-init-service.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ProjectInitTracker,
+  runProjectInit,
+  type ProjectInitDeps,
+} from "../services/project-init-service";
+
+describe("ProjectInitTracker", () => {
+  it("upserts phase transitions and carries prefix/name into ready", () => {
+    const tracker = new ProjectInitTracker();
+    tracker.set("/repo/a", { phase: "creating_config" });
+    expect(tracker.isActive("/repo/a")).toBe(true);
+
+    tracker.set("/repo/a", { phase: "analyzing" });
+    tracker.set("/repo/a", { phase: "ready", prefix: "a", name: "A" });
+
+    const state = tracker.get("/repo/a");
+    expect(state).toMatchObject({ phase: "ready", prefix: "a", name: "A", error: null });
+    expect(tracker.isActive("/repo/a")).toBe(false);
+  });
+
+  it("evicts terminal entries past the TTL but keeps in-flight ones", () => {
+    let clock = 1000;
+    const tracker = new ProjectInitTracker({ ttlMs: 100, now: () => clock });
+
+    tracker.set("/repo/done", { phase: "ready", prefix: "done", name: "Done" });
+    tracker.set("/repo/busy", { phase: "analyzing" });
+
+    clock = 1050; // within TTL — both visible
+    expect(tracker.list().map((s) => s.path).sort()).toEqual(["/repo/busy", "/repo/done"]);
+
+    clock = 1200; // terminal entry now past TTL; in-flight stays
+    expect(tracker.list().map((s) => s.path)).toEqual(["/repo/busy"]);
+  });
+});
+
+function makeDeps(overrides: Partial<ProjectInitDeps> & { calls?: string[] } = {}): ProjectInitDeps {
+  const calls = overrides.calls ?? [];
+  return {
+    analyzerAvailable: overrides.analyzerAvailable ?? ((): boolean => true),
+    scaffold: overrides.scaffold ?? (async (): Promise<void> => { calls.push("scaffold"); }),
+    analyze: overrides.analyze ?? (async (): Promise<void> => { calls.push("analyze"); }),
+    register: overrides.register ?? ((): { prefix: string; name: string } => {
+      calls.push("register");
+      return { prefix: "a", name: "A" };
+    }),
+  };
+}
+
+describe("runProjectInit", () => {
+  it("scaffolds, analyzes, registers, then marks ready (in order)", async () => {
+    const calls: string[] = [];
+    const tracker = new ProjectInitTracker();
+    await runProjectInit(tracker, "/repo/a", makeDeps({ calls }));
+
+    expect(calls).toEqual(["scaffold", "analyze", "register"]);
+    expect(tracker.get("/repo/a")).toMatchObject({ phase: "ready", prefix: "a", name: "A" });
+  });
+
+  it("skips analysis when no analyzer is available but still registers", async () => {
+    const calls: string[] = [];
+    const tracker = new ProjectInitTracker();
+    await runProjectInit(tracker, "/repo/a", makeDeps({ calls, analyzerAvailable: () => false }));
+
+    expect(calls).toEqual(["scaffold", "register"]);
+    expect(tracker.get("/repo/a")?.phase).toBe("ready");
+  });
+
+  it("registers anyway when analysis throws (best-effort enrichment)", async () => {
+    const calls: string[] = [];
+    const tracker = new ProjectInitTracker();
+    await runProjectInit(tracker, "/repo/a", makeDeps({
+      calls,
+      analyze: async () => { throw new Error("claude blew up"); },
+    }));
+
+    expect(calls).toEqual(["scaffold", "register"]);
+    expect(tracker.get("/repo/a")?.phase).toBe("ready");
+  });
+
+  it("marks failed and does not register when scaffold throws", async () => {
+    const calls: string[] = [];
+    const tracker = new ProjectInitTracker();
+    await runProjectInit(tracker, "/repo/a", makeDeps({
+      calls,
+      scaffold: async () => { throw new Error("cannot write .webmux.yaml"); },
+    }));
+
+    expect(calls).toEqual([]);
+    expect(tracker.get("/repo/a")).toMatchObject({ phase: "failed", error: "cannot write .webmux.yaml" });
+  });
+});

--- a/backend/src/lib/shell.ts
+++ b/backend/src/lib/shell.ts
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+export interface RunResult {
+  success: boolean;
+  stdout: Buffer;
+  stderr: Buffer;
+}
+
+/** Run a command synchronously and capture its output. Shared by the CLI
+ *  (re-exported from bin/src/shared.ts) and backend code that needs to shell
+ *  out (e.g. repo detection for project setup). */
+export function run(cmd: string, args: string[], opts?: { cwd?: string }): RunResult {
+  const result = Bun.spawnSync([cmd, ...args], { stdout: "pipe", stderr: "pipe", ...opts });
+  return {
+    success: result.success,
+    stdout: result.stdout as Buffer,
+    stderr: result.stderr as Buffer,
+  };
+}
+
+export function which(tool: string): boolean {
+  return run("which", [tool]).success;
+}
+
+export function getGitRoot(): string | null {
+  const result = run("git", ["rev-parse", "--show-toplevel"]);
+  if (!result.success) return null;
+  return result.stdout.toString().trim();
+}
+
+export function detectProjectName(gitRoot: string): string {
+  const pkgPath = join(gitRoot, "package.json");
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      if (pkg.name) return pkg.name;
+    } catch {} // malformed package.json, fall back to dir name
+  }
+  return basename(gitRoot);
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -54,6 +54,20 @@ import {
   type ProjectConfig,
 } from "./adapters/config";
 import { jsonResponse, errorResponse } from "./lib/http";
+import { which } from "./lib/shell";
+import {
+  buildInitAgentCommand,
+  buildInitPromptSpec,
+  buildStarterTemplate,
+  detectInitProjectContext,
+  runInitAgentCommand,
+  type InitAgent,
+} from "./services/init-authoring";
+import {
+  ProjectInitTracker,
+  runProjectInit,
+  type ProjectInitDeps,
+} from "./services/project-init-service";
 import { isRecord, isStringArray } from "./lib/type-guards";
 import { parseJsonBody, parseParams, parseQuery } from "./api-validation";
 import { hasRecentDashboardActivity, touchDashboardActivity } from "./services/dashboard-activity";
@@ -118,7 +132,7 @@ import { isValidBranchName, isValidWorktreeName } from "./domain/policies";
 import { createWebmuxRuntime, type WebmuxRuntime } from "./runtime";
 import { createInstanceRegistry, type InstanceEntry } from "./adapters/instance-registry";
 import { createProjectsRegistry } from "./adapters/projects-registry";
-import { ProjectManager, type ProjectLoopController } from "./services/project-manager";
+import { ProjectManager, type ManagedProject, type ProjectLoopController } from "./services/project-manager";
 
 const PORT = parseInt(Bun.env.PORT || "5111", 10);
 const STATIC_DIR = Bun.env.WEBMUX_STATIC_DIR || "";
@@ -2328,6 +2342,9 @@ const apps = new Map<string, ProjectApp>();
 // removed and track whether a project is currently being viewed (`active`).
 const openSockets = new Map<string, Set<ServerWebSocket<WsData>>>();
 const instanceRegistry = createInstanceRegistry();
+// Tracks on-add project setups (scaffold config → analyze with Claude → ready)
+// so the UI + CLI can show progress. Hub-level: one per machine, keyed by repo.
+const projectInitTracker = new ProjectInitTracker();
 let manager: ProjectManager;
 let server: Server<WsData>;
 let BOUND_PORT = 0;
@@ -2341,16 +2358,45 @@ async function catchingRoute(label: string, fn: () => Promise<Response>): Promis
   }
 }
 
-function apiListProjects(): Response {
-  return jsonResponse({
-    projects: manager.list().map((p) => ({
-      prefix: p.prefix,
-      name: p.entry.name,
-      path: p.entry.path,
-      active: p.active,
-    })),
-  });
+function toProjectSummary(p: ManagedProject): { prefix: string; name: string; path: string; active: boolean } {
+  return { prefix: p.prefix, name: p.entry.name, path: p.entry.path, active: p.active };
 }
+
+function apiListProjects(): Response {
+  return jsonResponse({ projects: manager.list().map(toProjectSummary) });
+}
+
+/** A repo is a webmux project once it has a config file. */
+function hasProjectConfig(root: string): boolean {
+  return existsSync(join(root, ".webmux.yaml")) || existsSync(join(root, ".webmux.local.yaml"));
+}
+
+/** Agent used to author config on setup: prefer Claude, fall back to Codex. */
+function authoringAgent(): InitAgent {
+  return which("claude") ? "claude" : "codex";
+}
+
+const ANALYZE_TIMEOUT_MS = 120_000;
+
+/** I/O for the on-add setup flow. The server is local, so it spawns the agent
+ *  with the repo as cwd to scaffold + flesh out `.webmux.yaml`, then registers. */
+const projectInitDeps: ProjectInitDeps = {
+  analyzerAvailable: () => which("claude") || which("codex"),
+  scaffold: async (root) => {
+    const context = detectInitProjectContext(root, authoringAgent());
+    await Bun.write(join(root, ".webmux.yaml"), buildStarterTemplate(context));
+  },
+  analyze: async (root) => {
+    const agent = authoringAgent();
+    const spec = buildInitAgentCommand(agent, buildInitPromptSpec(detectInitProjectContext(root, agent)));
+    await runInitAgentCommand(spec, root, { timeoutMs: ANALYZE_TIMEOUT_MS });
+  },
+  register: (root) => {
+    const project = manager.add(root);
+    reloadRoutes();
+    return { prefix: project.prefix, name: project.entry.name };
+  },
+};
 
 async function apiAddProject(req: BunRequest): Promise<Response> {
   const body: unknown = await req.json().catch(() => null);
@@ -2359,13 +2405,37 @@ async function apiAddProject(req: BunRequest): Promise<Response> {
   }
   const inputPath = body.path.trim();
   if (!isGitRepo(inputPath)) return errorResponse(`Not a git repository: ${inputPath}`, 400);
-  const project = manager.add(inputPath);
-  reloadRoutes();
+  const root = projectRoot(inputPath);
+
+  // Already served, or already a webmux project → register now, no setup job.
+  const existing = manager.getByPath(root);
+  if (existing) {
+    return jsonResponse({ initializing: false, path: root, project: toProjectSummary(existing) });
+  }
+  if (hasProjectConfig(root)) {
+    const project = manager.add(root);
+    reloadRoutes();
+    return jsonResponse({ initializing: false, path: root, project: toProjectSummary(project) });
+  }
+
+  // No config → scaffold + analyze + register asynchronously; the client polls
+  // `projectInits` for progress and the resulting prefix.
+  if (!projectInitTracker.isActive(root)) {
+    projectInitTracker.set(root, { phase: "creating_config" });
+    void runProjectInit(projectInitTracker, root, projectInitDeps);
+  }
+  return jsonResponse({ initializing: true, path: root, project: null });
+}
+
+function apiListProjectInits(): Response {
   return jsonResponse({
-    prefix: project.prefix,
-    name: project.entry.name,
-    path: project.entry.path,
-    active: project.active,
+    inits: projectInitTracker.list().map((s) => ({
+      path: s.path,
+      phase: s.phase,
+      prefix: s.prefix,
+      name: s.name,
+      error: s.error,
+    })),
   });
 }
 
@@ -2454,6 +2524,9 @@ function buildServeRoutes(): ProjectRoutes {
     [apiPaths.fetchProjects]: {
       GET: () => apiListProjects(),
       POST: (req) => catchingRoute("POST /api/projects", () => apiAddProject(req)),
+    },
+    [apiPaths.projectInits]: {
+      GET: () => apiListProjectInits(),
     },
     [apiPaths.migrateProjects]: {
       POST: (req) => catchingRoute("POST /api/projects/migrate", () => apiMigrateProjects(req)),

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2409,11 +2409,22 @@ async function apiAddProject(req: BunRequest): Promise<Response> {
   if (!isGitRepo(inputPath)) return errorResponse(`Not a git repository: ${inputPath}`, 400);
   const root = projectRoot(inputPath);
 
-  // Already served, or already a webmux project → register now, no setup job.
+  // Already served → register now, no setup job.
   const existing = manager.getByPath(root);
   if (existing) {
     return jsonResponse({ initializing: false, path: root, project: toProjectSummary(existing) });
   }
+
+  // A setup is already in flight for this repo (double-click / second tab):
+  // send the caller to the poller. Checked before `hasProjectConfig` because
+  // setup writes `.webmux.yaml` mid-run — without this guard a second request
+  // would see that half-written config and register from it before analysis
+  // finishes, bypassing the enriched result and the phase UI.
+  if (projectInitTracker.isActive(root)) {
+    return jsonResponse({ initializing: true, path: root, project: null });
+  }
+
+  // Already a webmux project → register immediately.
   if (hasProjectConfig(root)) {
     const project = manager.add(root);
     reloadRoutes();
@@ -2422,11 +2433,9 @@ async function apiAddProject(req: BunRequest): Promise<Response> {
 
   // No config → scaffold + analyze + register asynchronously; the client polls
   // `projectInits` for progress and the resulting prefix. runProjectInit sets
-  // the first phase synchronously before its first await, so the guard against
-  // a concurrent double-launch holds without setting it here too.
-  if (!projectInitTracker.isActive(root)) {
-    void runProjectInit(projectInitTracker, root, projectInitDeps);
-  }
+  // the first phase synchronously before its first await, so a concurrent
+  // request observes `isActive` above without setting it here too.
+  void runProjectInit(projectInitTracker, root, projectInitDeps);
   return jsonResponse({ initializing: true, path: root, project: null });
 }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2371,9 +2371,11 @@ function hasProjectConfig(root: string): boolean {
   return existsSync(join(root, ".webmux.yaml")) || existsSync(join(root, ".webmux.local.yaml"));
 }
 
-/** Agent used to author config on setup: prefer Claude, fall back to Codex. */
+/** Agent used to author config on setup. Prefer Claude; use Codex only when
+ *  it's the one actually installed. With neither present, default the
+ *  scaffolded config to Claude (analysis is skipped, but the file persists). */
 function authoringAgent(): InitAgent {
-  return which("claude") ? "claude" : "codex";
+  return which("codex") && !which("claude") ? "codex" : "claude";
 }
 
 const ANALYZE_TIMEOUT_MS = 120_000;
@@ -2419,9 +2421,10 @@ async function apiAddProject(req: BunRequest): Promise<Response> {
   }
 
   // No config → scaffold + analyze + register asynchronously; the client polls
-  // `projectInits` for progress and the resulting prefix.
+  // `projectInits` for progress and the resulting prefix. runProjectInit sets
+  // the first phase synchronously before its first await, so the guard against
+  // a concurrent double-launch holds without setting it here too.
   if (!projectInitTracker.isActive(root)) {
-    projectInitTracker.set(root, { phase: "creating_config" });
     void runProjectInit(projectInitTracker, root, projectInitDeps);
   }
   return jsonResponse({ initializing: true, path: root, project: null });

--- a/backend/src/services/init-authoring.ts
+++ b/backend/src/services/init-authoring.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { detectProjectName, run } from "./shared.ts";
+import { detectProjectName, run } from "../lib/shell";
 
 export type InitAuthoringChoice = "claude" | "codex" | "manual";
 export type InitAgent = Exclude<InitAuthoringChoice, "manual">;

--- a/backend/src/services/init-authoring.ts
+++ b/backend/src/services/init-authoring.ts
@@ -41,6 +41,9 @@ export interface InitAgentRunResult {
 
 export interface InitAgentRunHandlers {
   onEvent?: (event: InitAgentStreamEvent) => void;
+  /** Kill the agent if it runs longer than this (ms). Used server-side so a
+   *  hung analysis can't stall project setup forever. */
+  timeoutMs?: number;
 }
 
 interface InitAgentStreamState {
@@ -506,11 +509,31 @@ export async function runInitAgentCommand(
     stderr: "pipe",
   });
 
-  const [exitCode, stdoutResult, stderr] = await Promise.all([
-    proc.exited,
-    consumeStructuredStream(proc.stdout, spec.agent, handlers.onEvent),
-    consumeRawStream(proc.stderr),
-  ]);
+  const timeout = handlers.timeoutMs
+    ? setTimeout(() => {
+        try { proc.kill(); } catch { /* already exited */ }
+      }, handlers.timeoutMs)
+    : null;
+
+  try {
+    const [exitCode, stdoutResult, stderr] = await Promise.all([
+      proc.exited,
+      consumeStructuredStream(proc.stdout, spec.agent, handlers.onEvent),
+      consumeRawStream(proc.stderr),
+    ]);
+
+    return finalizeAgentRun(spec, exitCode, stdoutResult, stderr);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function finalizeAgentRun(
+  spec: InitAgentCommandSpec,
+  exitCode: number,
+  stdoutResult: { raw: string; assistantText: string },
+  stderr: string,
+): InitAgentRunResult {
 
   let summary = stdoutResult.assistantText.trim();
   if (spec.summaryPath && existsSync(spec.summaryPath)) {

--- a/backend/src/services/project-init-service.ts
+++ b/backend/src/services/project-init-service.ts
@@ -1,0 +1,111 @@
+import { log } from "../lib/log";
+
+export type ProjectInitPhase = "creating_config" | "analyzing" | "ready" | "failed";
+
+export interface ProjectInitState {
+  /** Canonical (git-root) path being set up — the tracker key. */
+  path: string;
+  phase: ProjectInitPhase;
+  /** Set once the project is registered (phase "ready"). */
+  prefix: string | null;
+  name: string | null;
+  /** Set when phase is "failed". */
+  error: string | null;
+  updatedAt: number;
+}
+
+const DEFAULT_TERMINAL_TTL_MS = 60_000;
+
+function isTerminal(phase: ProjectInitPhase): boolean {
+  return phase === "ready" || phase === "failed";
+}
+
+/** Hub-level record of in-flight (and recently-finished) on-add project setups,
+ *  so the UI and CLI can observe progress. Terminal entries (ready/failed) are
+ *  kept briefly so a poller can see the outcome, then evicted by TTL; in-flight
+ *  entries never expire. */
+export class ProjectInitTracker {
+  private readonly inits = new Map<string, ProjectInitState>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(opts: { ttlMs?: number; now?: () => number } = {}) {
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TERMINAL_TTL_MS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  set(path: string, update: { phase: ProjectInitPhase; prefix?: string; name?: string; error?: string }): void {
+    const existing = this.inits.get(path);
+    this.inits.set(path, {
+      path,
+      phase: update.phase,
+      prefix: update.prefix ?? existing?.prefix ?? null,
+      name: update.name ?? existing?.name ?? null,
+      error: update.error ?? (update.phase === "failed" ? existing?.error ?? null : null),
+      updatedAt: this.now(),
+    });
+  }
+
+  get(path: string): ProjectInitState | null {
+    return this.inits.get(path) ?? null;
+  }
+
+  /** True while a setup is mid-flight for `path` (not yet ready/failed). */
+  isActive(path: string): boolean {
+    const state = this.inits.get(path);
+    return state !== undefined && !isTerminal(state.phase);
+  }
+
+  /** Live view: drops terminal entries past their TTL so the map doesn't grow
+   *  unbounded across many project setups. */
+  list(): ProjectInitState[] {
+    const cutoff = this.now() - this.ttlMs;
+    for (const [path, state] of this.inits) {
+      if (isTerminal(state.phase) && state.updatedAt < cutoff) this.inits.delete(path);
+    }
+    return [...this.inits.values()];
+  }
+}
+
+/** I/O the orchestration needs, injected so it stays unit-testable. */
+export interface ProjectInitDeps {
+  /** Whether the agent CLI used for analysis is available on PATH. */
+  analyzerAvailable: () => boolean;
+  /** Write the starter .webmux.yaml at the repo root. */
+  scaffold: (root: string) => Promise<void>;
+  /** Run the headless agent to flesh out the scaffolded config. */
+  analyze: (root: string) => Promise<void>;
+  /** Register + persist the project (config is now on disk); returns its prefix/name. */
+  register: (root: string) => { prefix: string; name: string };
+}
+
+/** Drive an on-add project setup, updating `tracker` so the UI/CLI can watch:
+ *  scaffold the config → analyze the repo with the agent (best-effort; skipped
+ *  if unavailable, non-fatal on error so the starter config still ships) →
+ *  register the project → ready. A scaffold/register failure is terminal. */
+export async function runProjectInit(
+  tracker: ProjectInitTracker,
+  root: string,
+  deps: ProjectInitDeps,
+): Promise<void> {
+  try {
+    tracker.set(root, { phase: "creating_config" });
+    await deps.scaffold(root);
+
+    if (deps.analyzerAvailable()) {
+      tracker.set(root, { phase: "analyzing" });
+      try {
+        await deps.analyze(root);
+      } catch (err: unknown) {
+        // Analysis is a best-effort enrichment; keep the starter config and
+        // finish setup rather than stranding the user with no project.
+        log.error(`[project-init] analysis failed for ${root}, keeping starter config: ${String(err)}`);
+      }
+    }
+
+    const { prefix, name } = deps.register(root);
+    tracker.set(root, { phase: "ready", prefix, name });
+  } catch (err: unknown) {
+    tracker.set(root, { phase: "failed", error: err instanceof Error ? err.message : String(err) });
+  }
+}

--- a/backend/src/services/project-init-service.ts
+++ b/backend/src/services/project-init-service.ts
@@ -88,6 +88,7 @@ export async function runProjectInit(
   root: string,
   deps: ProjectInitDeps,
 ): Promise<void> {
+  log.info(`[project-init] setting up ${root}`);
   try {
     tracker.set(root, { phase: "creating_config" });
     await deps.scaffold(root);
@@ -98,14 +99,18 @@ export async function runProjectInit(
         await deps.analyze(root);
       } catch (err: unknown) {
         // Analysis is a best-effort enrichment; keep the starter config and
-        // finish setup rather than stranding the user with no project.
-        log.error(`[project-init] analysis failed for ${root}, keeping starter config: ${String(err)}`);
+        // finish setup rather than stranding the user with no project. Recoverable,
+        // so warn (not error) — setup still succeeds.
+        log.warn(`[project-init] analysis failed for ${root}, keeping starter config: ${String(err)}`);
       }
     }
 
     const { prefix, name } = deps.register(root);
     tracker.set(root, { phase: "ready", prefix, name });
+    log.info(`[project-init] ${root} ready as "${prefix}"`);
   } catch (err: unknown) {
-    tracker.set(root, { phase: "failed", error: err instanceof Error ? err.message : String(err) });
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(`[project-init] setup failed for ${root}: ${message}`);
+    tracker.set(root, { phase: "failed", error: message });
   }
 }

--- a/bin/src/init.ts
+++ b/bin/src/init.ts
@@ -13,7 +13,7 @@ import {
   type InitAgent,
   type InitAgentStreamEvent,
   type InitAuthoringChoice,
-} from "./init-helpers.ts";
+} from "../../backend/src/services/init-authoring.ts";
 
 // ── Dependency checks ───────────────────────────────────────────────────────
 

--- a/bin/src/migrate.ts
+++ b/bin/src/migrate.ts
@@ -145,7 +145,8 @@ export function warnIfOtherInstances(port: number, listLive: () => InstanceEntry
   }
   if (others.length === 0) return;
   const ports = others.map((entry) => entry.port).join(", ");
-  console.error(
-    `Warning: ${others.length} other webmux server(s) detected on port(s) ${ports}. Run \`webmux project migrate\` to consolidate them into this dashboard.`,
-  );
+  const message = `Warning: ${others.length} other webmux server(s) detected on port(s) ${ports}. Run \`webmux project migrate\` to consolidate them into this dashboard.`;
+  // Amber, not red — this is a nudge, not an error. Colorize only on a TTY so
+  // piped/redirected stderr stays plain (no escape codes in logs).
+  console.error(process.stderr.isTTY ? `\x1b[38;5;214m${message}\x1b[0m` : message);
 }

--- a/bin/src/project-commands.test.ts
+++ b/bin/src/project-commands.test.ts
@@ -74,7 +74,7 @@ describe("awaitProjectSetup", () => {
     expect(ready).toMatchObject({ phase: "ready", prefix: "a", name: "A" });
     expect(logs).toEqual([
       "  Creating .webmux.yaml…",
-      "  Analyzing project structure with Claude…",
+      "  Analyzing project structure…",
     ]);
   });
 

--- a/bin/src/project-commands.test.ts
+++ b/bin/src/project-commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { parseProjectArgs } from "./project-commands";
+import type { ProjectInitState } from "@webmux/api-contract";
+import { awaitProjectSetup, parseProjectArgs } from "./project-commands";
 import { CommandUsageError } from "./shared";
 
 describe("parseProjectArgs", () => {
@@ -46,5 +47,57 @@ describe("parseProjectArgs", () => {
 
   it("rejects unknown subcommands", () => {
     expect(() => parseProjectArgs(["frobnicate"])).toThrow(CommandUsageError);
+  });
+});
+
+function initState(over: Partial<ProjectInitState>): ProjectInitState {
+  return { path: "/repo/a", phase: "creating_config", prefix: null, name: null, error: null, ...over };
+}
+
+describe("awaitProjectSetup", () => {
+  it("logs each phase once and resolves with the ready state", async () => {
+    const logs: string[] = [];
+    const frames: ProjectInitState[][] = [
+      [initState({ phase: "creating_config" })],
+      [initState({ phase: "creating_config" })], // unchanged → not logged again
+      [initState({ phase: "analyzing" })],
+      [initState({ phase: "ready", prefix: "a", name: "A" })],
+    ];
+    let i = 0;
+
+    const ready = await awaitProjectSetup("/repo/a", {
+      poll: async () => frames[Math.min(i++, frames.length - 1)],
+      sleep: async () => {},
+      log: (m) => logs.push(m),
+    });
+
+    expect(ready).toMatchObject({ phase: "ready", prefix: "a", name: "A" });
+    expect(logs).toEqual([
+      "  Creating .webmux.yaml…",
+      "  Analyzing project structure with Claude…",
+    ]);
+  });
+
+  it("throws with the server error when setup fails", async () => {
+    await expect(
+      awaitProjectSetup("/repo/a", {
+        poll: async () => [initState({ phase: "failed", error: "no git" })],
+        sleep: async () => {},
+        log: () => {},
+      }),
+    ).rejects.toThrow("no git");
+  });
+
+  it("throws on timeout when the job never appears", async () => {
+    let clock = 0;
+    await expect(
+      awaitProjectSetup("/repo/a", {
+        poll: async () => [],
+        sleep: async () => { clock += 1000; },
+        now: () => clock,
+        timeoutMs: 1500,
+        log: () => {},
+      }),
+    ).rejects.toThrow("timed out");
   });
 });

--- a/bin/src/project-commands.ts
+++ b/bin/src/project-commands.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import { createApi, type ProjectInitPhase, type ProjectInitState } from "@webmux/api-contract";
 import { CommandUsageError, formatServerError } from "./shared";
-import { runMigrate, warnIfOtherInstances } from "./migrate.ts";
+import { runMigrate } from "./migrate.ts";
 
 const PROJECT_SETUP_POLL_INTERVAL_MS = 700;
 const PROJECT_SETUP_TIMEOUT_MS = 5 * 60_000;
@@ -123,9 +123,6 @@ export async function runProjectCommand(args: string[], port: number): Promise<n
   if (parsed.subcommand === "migrate") {
     return runMigrate(port);
   }
-
-  // Nudge toward consolidation when other servers are still running.
-  warnIfOtherInstances(port);
 
   const api = createApi(`http://localhost:${port}`);
   try {

--- a/bin/src/project-commands.ts
+++ b/bin/src/project-commands.ts
@@ -37,7 +37,14 @@ export async function awaitProjectSetup(path: string, deps: ProjectSetupPoller):
   let lastPhase: ProjectInitPhase | null = null;
 
   while (now() < deadline) {
-    const state = (await deps.poll()).find((init) => init.path === path);
+    // A transient poll failure shouldn't abort the flow — the backend job keeps
+    // running, so just retry until the deadline.
+    let state: ProjectInitState | undefined;
+    try {
+      state = (await deps.poll()).find((init) => init.path === path);
+    } catch {
+      state = undefined;
+    }
     if (state && state.phase !== lastPhase) {
       lastPhase = state.phase;
       if (state.phase !== "ready" && state.phase !== "failed") {
@@ -167,4 +174,3 @@ export async function runProjectCommand(args: string[], port: number): Promise<n
     return 1;
   }
 }
-

--- a/bin/src/project-commands.ts
+++ b/bin/src/project-commands.ts
@@ -1,7 +1,55 @@
 import { resolve } from "node:path";
-import { createApi } from "@webmux/api-contract";
+import { createApi, type ProjectInitPhase, type ProjectInitState } from "@webmux/api-contract";
 import { CommandUsageError, formatServerError } from "./shared";
 import { runMigrate, warnIfOtherInstances } from "./migrate.ts";
+
+const PROJECT_SETUP_POLL_INTERVAL_MS = 700;
+const PROJECT_SETUP_TIMEOUT_MS = 5 * 60_000;
+
+function projectSetupPhaseLabel(phase: ProjectInitPhase): string {
+  switch (phase) {
+    case "creating_config":
+      return "Creating .webmux.yaml";
+    case "analyzing":
+      return "Analyzing project structure with Claude";
+    case "ready":
+      return "Project ready";
+    case "failed":
+      return "Setup failed";
+  }
+}
+
+export interface ProjectSetupPoller {
+  poll: () => Promise<ProjectInitState[]>;
+  sleep: (ms: number) => Promise<void>;
+  log?: (message: string) => void;
+  now?: () => number;
+  timeoutMs?: number;
+}
+
+/** Follow an in-progress on-add project setup to completion, printing each
+ *  phase as it changes. Resolves with the ready state (carrying the prefix) or
+ *  throws on failure/timeout. Poller is injected so it's testable. */
+export async function awaitProjectSetup(path: string, deps: ProjectSetupPoller): Promise<ProjectInitState> {
+  const log = deps.log ?? ((message: string): void => console.log(message));
+  const now = deps.now ?? Date.now;
+  const deadline = now() + (deps.timeoutMs ?? PROJECT_SETUP_TIMEOUT_MS);
+  let lastPhase: ProjectInitPhase | null = null;
+
+  while (now() < deadline) {
+    const state = (await deps.poll()).find((init) => init.path === path);
+    if (state && state.phase !== lastPhase) {
+      lastPhase = state.phase;
+      if (state.phase !== "ready" && state.phase !== "failed") {
+        log(`  ${projectSetupPhaseLabel(state.phase)}…`);
+      }
+    }
+    if (state?.phase === "ready") return state;
+    if (state?.phase === "failed") throw new Error(state.error ?? "Project setup failed.");
+    await deps.sleep(PROJECT_SETUP_POLL_INTERVAL_MS);
+  }
+  throw new Error("Project setup timed out.");
+}
 
 export type ParsedProjectCommand =
   | { subcommand: "ls" }
@@ -96,8 +144,21 @@ export async function runProjectCommand(args: string[], port: number): Promise<n
 
     if (parsed.subcommand === "add") {
       const absolute = resolve(process.cwd(), parsed.path);
-      const project = await api.addProject({ body: { path: absolute } });
-      console.log(`Added ${project.name} (${project.prefix}) — ${project.path}`);
+      const res = await api.addProject({ body: { path: absolute } });
+      if (!res.initializing) {
+        if (!res.project) {
+          console.error("Server accepted the project but returned nothing to open.");
+          return 1;
+        }
+        console.log(`Added ${res.project.name} (${res.project.prefix}) — ${res.project.path}`);
+        return 0;
+      }
+      // Repo had no .webmux.yaml — webmux is setting it up. Show the phases.
+      const ready = await awaitProjectSetup(res.path, {
+        poll: async () => (await api.projectInits()).inits,
+        sleep: (ms) => Bun.sleep(ms),
+      });
+      console.log(`Added ${ready.name ?? ready.prefix} (${ready.prefix}) — ${res.path}`);
       return 0;
     }
 
@@ -109,3 +170,4 @@ export async function runProjectCommand(args: string[], port: number): Promise<n
     return 1;
   }
 }
+

--- a/bin/src/project-commands.ts
+++ b/bin/src/project-commands.ts
@@ -11,7 +11,7 @@ function projectSetupPhaseLabel(phase: ProjectInitPhase): string {
     case "creating_config":
       return "Creating .webmux.yaml";
     case "analyzing":
-      return "Analyzing project structure with Claude";
+      return "Analyzing project structure";
     case "ready":
       return "Project ready";
     case "failed":

--- a/bin/src/shared.ts
+++ b/bin/src/shared.ts
@@ -1,31 +1,12 @@
-import { existsSync, readFileSync, realpathSync } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { realpathSync } from "node:fs";
 import { createApi } from "@webmux/api-contract";
+import { run } from "../../backend/src/lib/shell";
 
-export interface RunResult {
-  success: boolean;
-  stdout: Buffer;
-  stderr: Buffer;
-}
-
-export function run(cmd: string, args: string[], opts?: { cwd?: string }): RunResult {
-  const result = Bun.spawnSync([cmd, ...args], { stdout: "pipe", stderr: "pipe", ...opts });
-  return {
-    success: result.success,
-    stdout: result.stdout as Buffer,
-    stderr: result.stderr as Buffer,
-  };
-}
-
-export function which(tool: string): boolean {
-  return run("which", [tool]).success;
-}
-
-export function getGitRoot(): string | null {
-  const result = run("git", ["rev-parse", "--show-toplevel"]);
-  if (!result.success) return null;
-  return result.stdout.toString().trim();
-}
+// Generic process/git/repo primitives live in the backend lib so backend code
+// (e.g. project setup) can share them; re-export here so existing CLI imports
+// from "./shared" keep working.
+export { run, which, getGitRoot, detectProjectName, type RunResult } from "../../backend/src/lib/shell";
 
 /**
  * Thrown by argparse functions to signal usage errors (e.g. missing flag value,
@@ -33,17 +14,6 @@ export function getGitRoot(): string | null {
  * help banner alongside the message.
  */
 export class CommandUsageError extends Error {}
-
-export function detectProjectName(gitRoot: string): string {
-  const pkgPath = join(gitRoot, "package.json");
-  if (existsSync(pkgPath)) {
-    try {
-      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-      if (pkg.name) return pkg.name;
-    } catch {} // malformed package.json, fall back to dir name
-  }
-  return basename(gitRoot);
-}
 
 /**
  * When the webmux server isn't reachable the bare error message is unhelpful to

--- a/bin/src/webmux.test.ts
+++ b/bin/src/webmux.test.ts
@@ -174,10 +174,16 @@ describe("webmux entrypoint", () => {
     const nestedDir = join(repoRoot, "nested", "dir");
     await mkdir(nestedDir, { recursive: true });
 
+    // Isolate HOME so the migration-warning's registry read (~/.webmux/instances)
+    // sees an empty dir, not the dev machine's real running instances.
+    const home = await mkdtemp(join(tmpdir(), "webmux-home-"));
+    tempDirs.push(home);
+
     const result = Bun.spawnSync(["bun", webmuxEntry, "open", "missing-branch"], {
       cwd: nestedDir,
       stdout: "pipe",
       stderr: "pipe",
+      env: { ...process.env, HOME: home },
     });
     const stderr = decoder.decode(result.stderr).trim();
 
@@ -211,12 +217,18 @@ describe("webmux entrypoint", () => {
     const worktreePath = join(worktreesRoot, "feature-self-remove");
     runOrThrow(["git", "worktree", "add", "-b", "feature-self-remove", worktreePath], repoRoot);
 
+    // Isolate HOME so the migration-warning's registry read sees an empty dir,
+    // keeping stderr clean regardless of what's running on the dev machine.
+    const home = await mkdtemp(join(tmpdir(), "webmux-home-"));
+    tempDirs.push(home);
+
     const result = Bun.spawnSync(["bun", webmuxEntry, "remove", "feature-self-remove"], {
       cwd: worktreePath,
       stdout: "pipe",
       stderr: "pipe",
       env: {
         ...process.env,
+        HOME: home,
         PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
       },
     });

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -353,6 +353,21 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
     }
   }
 
+  // Nudge toward consolidation when other webmux servers are running — on the
+  // occasional management commands (oneshot/linear/project), but NOT the
+  // high-frequency worktree commands (list/open/send/…) where a per-invocation
+  // warning would be noisy, nor `project migrate` (which consolidates them
+  // itself). Cheap: a local registry read, silent unless peers exist, and to
+  // stderr so it never pollutes piped output.
+  const isProjectMigrate = parsed.command === "project" && parsed.commandArgs[0] === "migrate";
+  const isOccasionalServerCommand = parsed.command === "oneshot"
+    || parsed.command === "linear"
+    || parsed.command === "project";
+  if (isOccasionalServerCommand && !isProjectMigrate) {
+    const { warnIfOtherInstances } = await import("./migrate.ts");
+    warnIfOtherInstances(effectivePort);
+  }
+
   if (parsed.command === "oneshot") {
     const { runOneshotCommand } = await import("./oneshot.ts");
     const exitCode = await runOneshotCommand(parsed.commandArgs, effectivePort);

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -353,17 +353,17 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
     }
   }
 
-  // Nudge toward consolidation when other webmux servers are running — on the
-  // occasional management commands (oneshot/linear/project), but NOT the
-  // high-frequency worktree commands (list/open/send/…) where a per-invocation
-  // warning would be noisy, nor `project migrate` (which consolidates them
-  // itself). Cheap: a local registry read, silent unless peers exist, and to
-  // stderr so it never pollutes piped output.
+  // Nudge toward consolidation when other webmux servers are running, on any
+  // command that reaches a project (everything dispatched below) except
+  // `project migrate`, which consolidates them itself. Cheap: a local registry
+  // read, silent unless peers exist, and to stderr so it never pollutes piped
+  // output. Only relevant before the user has consolidated, so it's transient.
   const isProjectMigrate = parsed.command === "project" && parsed.commandArgs[0] === "migrate";
-  const isOccasionalServerCommand = parsed.command === "oneshot"
+  const reachesAProject = parsed.command === "oneshot"
     || parsed.command === "linear"
-    || parsed.command === "project";
-  if (isOccasionalServerCommand && !isProjectMigrate) {
+    || parsed.command === "project"
+    || isWorktreeCommand(parsed.command);
+  if (reachesAProject && !isProjectMigrate) {
     const { warnIfOtherInstances } = await import("./migrate.ts");
     warnIfOtherInstances(effectivePort);
   }

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -131,7 +131,7 @@ vi.mock("./lib/api", () => ({
   apiBase: "",
   fetchProjects: vi.fn(async () => []),
   fetchInstances: vi.fn(async () => []),
-  addProject: vi.fn(),
+  setUpProject: vi.fn(),
   removeProject: vi.fn(),
 }));
 

--- a/frontend/src/lib/EmptyProjects.svelte
+++ b/frontend/src/lib/EmptyProjects.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { addProject } from "./api";
-  import { applyTheme, loadSavedTheme } from "./utils";
+  import { setUpProject } from "./api";
+  import { applyTheme, loadSavedTheme, projectInitPhaseLabel } from "./utils";
+  import type { ProjectInitPhase } from "./types";
 
   let path = $state("");
   let error = $state<string | null>(null);
   let busy = $state(false);
+  let phase = $state<ProjectInitPhase | null>(null);
 
   onMount(() => {
     applyTheme(loadSavedTheme());
@@ -16,12 +18,14 @@
     if (!target || busy) return;
     busy = true;
     error = null;
+    phase = null;
     try {
-      const project = await addProject(target);
-      window.location.assign(`/${project.prefix}/`);
+      const { prefix } = await setUpProject(target, (next) => (phase = next));
+      window.location.assign(`/${prefix}/`);
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
       busy = false;
+      phase = null;
     }
   }
 
@@ -37,18 +41,19 @@
   <div class="w-full max-w-md">
     <h1 class="text-lg font-semibold mb-2">No projects yet</h1>
     <p class="text-sm text-muted mb-4">
-      webmux serves every project from this one dashboard. Run
-      <code class="text-primary">webmux init</code> in a git repo to create a
-      <code class="text-primary">.webmux.yaml</code>, then start webmux there — or add an
-      existing webmux project below.
+      webmux serves every project from this one dashboard. Add a git repo below
+      and webmux sets it up for you — scaffolding a
+      <code class="text-primary">.webmux.yaml</code> and analyzing the project
+      with Claude.
     </p>
     <div class="flex gap-2">
       <input
         type="text"
         bind:value={path}
         onkeydown={onKeydown}
-        placeholder="Path to a git repo with .webmux.yaml"
-        class="flex-1 min-w-0 px-3 py-2 text-sm rounded border border-edge bg-surface text-primary placeholder:text-muted"
+        placeholder="Path to a git repo"
+        disabled={busy}
+        class="flex-1 min-w-0 px-3 py-2 text-sm rounded border border-edge bg-surface text-primary placeholder:text-muted disabled:opacity-50"
       />
       <button
         type="button"
@@ -59,6 +64,12 @@
         Add
       </button>
     </div>
+    {#if busy && phase}
+      <div class="mt-3 flex items-center gap-2 text-sm text-muted">
+        <span class="spinner"></span>
+        {projectInitPhaseLabel(phase)}…
+      </div>
+    {/if}
     {#if error}
       <div class="mt-2 text-sm text-red-400 break-words">{error}</div>
     {/if}

--- a/frontend/src/lib/EmptyProjects.svelte
+++ b/frontend/src/lib/EmptyProjects.svelte
@@ -44,7 +44,7 @@
       webmux serves every project from this one dashboard. Add a git repo below
       and webmux sets it up for you — scaffolding a
       <code class="text-primary">.webmux.yaml</code> and analyzing the project
-      with Claude.
+      to fill it in.
     </p>
     <div class="flex gap-2">
       <input

--- a/frontend/src/lib/ProjectSwitcher.svelte
+++ b/frontend/src/lib/ProjectSwitcher.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { addProject, fetchProjects, removeProject } from "./api";
-  import type { ProjectSummary } from "./types";
+  import { fetchProjects, removeProject, setUpProject } from "./api";
+  import { projectInitPhaseLabel } from "./utils";
+  import type { ProjectInitPhase, ProjectSummary } from "./types";
 
   let { current }: { current: string } = $props();
 
@@ -10,6 +11,7 @@
   let addPath = $state("");
   let addError = $state<string | null>(null);
   let busy = $state(false);
+  let addPhase = $state<ProjectInitPhase | null>(null);
   let triggerEl: HTMLButtonElement | undefined = $state();
   let menuEl: HTMLDivElement | undefined = $state();
   let menuRect = $state<{ top: number; left: number; width: number }>({ top: 0, left: 0, width: 0 });
@@ -66,12 +68,14 @@
     if (!path || busy) return;
     busy = true;
     addError = null;
+    addPhase = null;
     try {
-      const project = await addProject(path);
-      window.location.assign(`/${project.prefix}/`);
+      const { prefix } = await setUpProject(path, (next) => (addPhase = next));
+      window.location.assign(`/${prefix}/`);
     } catch (error) {
       addError = error instanceof Error ? error.message : String(error);
       busy = false;
+      addPhase = null;
     }
   }
 
@@ -155,7 +159,8 @@
           bind:value={addPath}
           onkeydown={handleAddKeydown}
           placeholder="Path to a git repo…"
-          class="flex-1 min-w-0 px-2 py-1 text-[12px] rounded border border-edge bg-bg text-primary placeholder:text-muted"
+          disabled={busy}
+          class="flex-1 min-w-0 px-2 py-1 text-[12px] rounded border border-edge bg-bg text-primary placeholder:text-muted disabled:opacity-50"
         />
         <button
           type="button"
@@ -166,6 +171,12 @@
           Add
         </button>
       </div>
+      {#if busy && addPhase}
+        <div class="mt-1 flex items-center gap-1 text-[11px] text-muted">
+          <span class="spinner"></span>
+          {projectInitPhaseLabel(addPhase)}…
+        </div>
+      {/if}
       {#if addError}
         <div class="mt-1 text-[11px] text-red-400 break-words">{addError}</div>
       {/if}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -61,3 +61,76 @@ describe("project-prefixed network calls", () => {
     );
   });
 });
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function urlOf(input: string | URL | Request): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+describe("setUpProject", () => {
+  it("returns the prefix immediately when the repo is already a project", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      jsonResponse({
+        initializing: false,
+        path: "/repo/y",
+        project: { prefix: "y", name: "Y", path: "/repo/y", active: false },
+      }),
+    ));
+
+    const api = await loadApiAt("/y/");
+    const phases: string[] = [];
+    const result = await api.setUpProject("/repo/y", (phase) => phases.push(phase));
+
+    expect(result).toEqual({ prefix: "y" });
+    expect(phases).toEqual([]); // no setup needed → no phases
+  });
+
+  it("polls the setup tracker and resolves with the prefix when ready", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = urlOf(input);
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/projects") && method === "POST") {
+        return jsonResponse({ initializing: true, path: "/repo/x", project: null });
+      }
+      if (url.endsWith("/api/projects/init")) {
+        return jsonResponse({
+          inits: [{ path: "/repo/x", phase: "ready", prefix: "x", name: "X", error: null }],
+        });
+      }
+      throw new Error(`unexpected ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await loadApiAt("/x/");
+    const phases: string[] = [];
+    const result = await api.setUpProject("/repo/x", (phase) => phases.push(phase));
+
+    expect(result).toEqual({ prefix: "x" });
+    expect(phases).toEqual(["ready"]);
+  });
+
+  it("rejects with the server error when setup fails", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = urlOf(input);
+      const method = init?.method ?? "GET";
+      if (url.endsWith("/api/projects") && method === "POST") {
+        return jsonResponse({ initializing: true, path: "/repo/z", project: null });
+      }
+      return jsonResponse({
+        inits: [{ path: "/repo/z", phase: "failed", prefix: null, name: null, error: "not a git repo" }],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await loadApiAt("/x/");
+    await expect(api.setUpProject("/repo/z", () => {})).rejects.toThrow("not a git repo");
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   InstanceSummary,
   PostWorktreeToLinearResponse,
   PostWorktreeToLinearTarget,
+  ProjectInitPhase,
   ProjectSummary,
   ProjectWorktreeSnapshot,
   UpsertCustomAgentRequest,
@@ -229,8 +230,42 @@ export async function fetchProjects(): Promise<ProjectSummary[]> {
   return response.projects;
 }
 
-export async function addProject(path: string): Promise<ProjectSummary> {
-  return hubApi.addProject({ body: { path } });
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const SETUP_POLL_INTERVAL_MS = 600;
+const SETUP_TIMEOUT_MS = 5 * 60_000;
+
+/** Add a project and, when the repo has no `.webmux.yaml`, drive its setup
+ *  (scaffold → analyze with Claude → register) to completion, reporting each
+ *  phase via `onPhase`. Resolves with the project's prefix once it's ready. */
+export async function setUpProject(
+  path: string,
+  onPhase?: (phase: ProjectInitPhase) => void,
+): Promise<{ prefix: string }> {
+  const res = await hubApi.addProject({ body: { path } });
+  if (!res.initializing) {
+    if (!res.project) throw new Error("Server accepted the project but returned nothing to open.");
+    return { prefix: res.project.prefix };
+  }
+
+  const deadline = Date.now() + SETUP_TIMEOUT_MS;
+  let lastPhase: ProjectInitPhase | null = null;
+  while (Date.now() < deadline) {
+    const { inits } = await hubApi.projectInits();
+    const state = inits.find((entry) => entry.path === res.path);
+    if (state) {
+      if (state.phase !== lastPhase) {
+        lastPhase = state.phase;
+        onPhase?.(state.phase);
+      }
+      if (state.phase === "ready" && state.prefix) return { prefix: state.prefix };
+      if (state.phase === "failed") throw new Error(state.error ?? "Project setup failed.");
+    }
+    await delay(SETUP_POLL_INTERVAL_MS);
+  }
+  throw new Error("Project setup timed out.");
 }
 
 export async function removeProject(prefix: string): Promise<void> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   PostWorktreeToLinearResponse,
   PostWorktreeToLinearTarget,
   ProjectInitPhase,
+  ProjectInitState,
   ProjectSummary,
   ProjectWorktreeSnapshot,
   UpsertCustomAgentRequest,
@@ -253,7 +254,9 @@ export async function setUpProject(
   const deadline = Date.now() + SETUP_TIMEOUT_MS;
   let lastPhase: ProjectInitPhase | null = null;
   while (Date.now() < deadline) {
-    const { inits } = await hubApi.projectInits();
+    // A transient poll failure shouldn't fail the flow — the backend job keeps
+    // running, so swallow it and retry until the deadline.
+    const inits = await hubApi.projectInits().then((r) => r.inits).catch((): ProjectInitState[] => []);
     const state = inits.find((entry) => entry.path === res.path);
     if (state) {
       if (state.phase !== lastPhase) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -53,6 +53,8 @@ export type {
   PrComment,
   PrEntry,
   ProfileConfig,
+  ProjectInitPhase,
+  ProjectInitState,
   ProjectSnapshot,
   ProjectSummary,
   ProjectWorktreeSnapshot,

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -141,7 +141,7 @@ export function projectInitPhaseLabel(phase: ProjectInitPhase | null): string {
     case "creating_config":
       return "Creating .webmux.yaml";
     case "analyzing":
-      return "Analyzing project structure with Claude";
+      return "Analyzing project structure";
     case "ready":
       return "Project ready";
     case "failed":

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import type { PrEntry, WorktreeCreationPhase, WorktreeInfo } from "./types";
+import type { PrEntry, ProjectInitPhase, WorktreeCreationPhase, WorktreeInfo } from "./types";
 import { THEME_KEYS, getTheme } from "./themes";
 import type { ThemeKey } from "./themes";
 
@@ -133,6 +133,21 @@ export function worktreeCreationPhaseLabel(phase: WorktreeCreationPhase | null):
       return "Reconciling";
     default:
       return "Creating";
+  }
+}
+
+export function projectInitPhaseLabel(phase: ProjectInitPhase | null): string {
+  switch (phase) {
+    case "creating_config":
+      return "Creating .webmux.yaml";
+    case "analyzing":
+      return "Analyzing project structure with Claude";
+    case "ready":
+      return "Project ready";
+    case "failed":
+      return "Setup failed";
+    default:
+      return "Setting up";
   }
 }
 

--- a/packages/api-contract/src/contract.ts
+++ b/packages/api-contract/src/contract.ts
@@ -42,8 +42,9 @@ import {
   AutoNameConfigResponseSchema,
   InstancesResponseSchema,
   ProjectsResponseSchema,
-  ProjectSummarySchema,
   AddProjectRequestSchema,
+  AddProjectResponseSchema,
+  ProjectInitsResponseSchema,
   ProjectPrefixParamsSchema,
   MigrateProjectsRequestSchema,
   MigrateProjectsResponseSchema,
@@ -92,6 +93,7 @@ export const apiPaths = {
   fetchInstances: "/api/instances",
   fetchProjects: "/api/projects",
   addProject: "/api/projects",
+  projectInits: "/api/projects/init",
   migrateProjects: "/api/projects/migrate",
   removeProject: "/api/projects/:prefix",
 } as const;
@@ -473,8 +475,16 @@ export const apiContract = c.router({
     path: apiPaths.addProject,
     body: AddProjectRequestSchema,
     responses: {
-      200: ProjectSummarySchema,
+      200: AddProjectResponseSchema,
       400: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+  },
+  projectInits: {
+    method: "GET",
+    path: apiPaths.projectInits,
+    responses: {
+      200: ProjectInitsResponseSchema,
       500: ErrorResponseSchema,
     },
   },

--- a/packages/api-contract/src/schemas.ts
+++ b/packages/api-contract/src/schemas.ts
@@ -616,6 +616,40 @@ export const AddProjectRequestSchema = z.object({
   path: z.string().min(1),
 });
 
+/** Adding a repo that has no .webmux.yaml kicks off an async setup job
+ *  (scaffold config → analyze with Claude → register); the response says the
+ *  job started and the client polls `projectInits`. When the repo already has
+ *  config it's registered immediately and `project` is returned. */
+export const AddProjectResponseSchema = z.object({
+  initializing: z.boolean(),
+  path: z.string(),
+  project: ProjectSummarySchema.nullable(),
+});
+
+/** Phases of the on-add project setup, surfaced so the UI and CLI can show
+ *  progress: scaffold the .webmux.yaml → analyze the repo with Claude → ready
+ *  (registered). `failed` means setup errored before the project was usable. */
+export const ProjectInitPhaseSchema = z.enum([
+  "creating_config",
+  "analyzing",
+  "ready",
+  "failed",
+]);
+
+export const ProjectInitStateSchema = z.object({
+  path: z.string(),
+  phase: ProjectInitPhaseSchema,
+  /** Set once the project is registered (phase "ready") so the client can open it. */
+  prefix: z.string().nullable(),
+  name: z.string().nullable(),
+  /** Set when phase is "failed". */
+  error: z.string().nullable(),
+});
+
+export const ProjectInitsResponseSchema = z.object({
+  inits: z.array(ProjectInitStateSchema),
+});
+
 export const ProjectPrefixParamsSchema = z.object({
   prefix: z.string(),
 });
@@ -635,6 +669,10 @@ export const MigrateProjectsResponseSchema = z.object({
 export type ProjectSummary = z.infer<typeof ProjectSummarySchema>;
 export type ProjectsResponse = z.infer<typeof ProjectsResponseSchema>;
 export type AddProjectRequest = z.infer<typeof AddProjectRequestSchema>;
+export type AddProjectResponse = z.infer<typeof AddProjectResponseSchema>;
+export type ProjectInitPhase = z.infer<typeof ProjectInitPhaseSchema>;
+export type ProjectInitState = z.infer<typeof ProjectInitStateSchema>;
+export type ProjectInitsResponse = z.infer<typeof ProjectInitsResponseSchema>;
 export type MigrateProjectsRequest = z.infer<typeof MigrateProjectsRequestSchema>;
 export type MigrateProjectsResponse = z.infer<typeof MigrateProjectsResponseSchema>;
 


### PR DESCRIPTION
## Summary

Adding a repo that has no `.webmux.yaml` now **sets it up automatically** instead of registering an unconfigured project, and the setup is **observable** in both the dashboard and the CLI:

1. **Creating `.webmux.yaml`** — scaffold the starter config (the same template `webmux init` writes).
2. **Analyzing project structure** — run the agent (Claude, or Codex if that's what's installed) headlessly to fill in services/panes/ports by inspecting the repo (best-effort).
3. **Project ready** — register + persist, then open it.

Repos that already have a `.webmux.yaml` (or are already served) register immediately, unchanged.

## How it works

- **`ProjectInitTracker` + `runProjectInit`** (`backend/src/services/project-init-service.ts`): a hub-level tracker keyed by repo path drives `creating_config → analyzing → ready` (or `failed`). Analysis is best-effort — skipped if no agent is on PATH, non-fatal on error — so the starter config always ships. Terminal states expire via TTL so the map can't grow unbounded.
- **`apiAddProject`**: repos with config register immediately and return `{ initializing: false, project }`; repos without kick off the async setup job and return `{ initializing: true, path }`. New `GET /api/projects/init` reports progress; the client polls it.
- **Reused, lifted helpers**: the scaffold + repo-detection + headless-agent-run helpers that `webmux init` uses moved from `bin/src/init-helpers.ts` to `backend/src/services/init-authoring.ts` (with the generic `run`/`which`/`getGitRoot`/`detectProjectName` primitives in `backend/src/lib/shell.ts`, re-exported from `bin/src/shared.ts`), so the server and the CLI share one implementation. `runInitAgentCommand` gained an optional timeout so a hung agent can't stall setup.
- **Frontend**: `setUpProject()` POSTs then polls `projectInits`, reporting each phase; `EmptyProjects` and the project switcher show the steps and navigate to the project once ready.
- **CLI**: `webmux project add` on an unconfigured repo prints the same phases (via a DI-seamed, tested `awaitProjectSetup`), then the added line.

## Observability choice

Phase-level progress over the existing poll pattern (matching worktree creation) rather than a live token stream — the project registers only once setup finishes, which avoids rebuilding a live project's runtime/sockets mid-flight.

## Security / trust model

Setup spawns a headless agent (`claude … --permission-mode bypassPermissions` / `codex … --sandbox workspace-write`) with the added repo as cwd, triggered by `POST /api/projects`. The dashboard already grants arbitrary shell via terminal panes to anyone who can reach it, so it assumes a trusted/localhost network — this on-add agent run stays within that existing model and does not add a new exposure class. (`Bun.serve` binds all interfaces; deployments are expected to be localhost or a trusted LAN / behind SSH, as today.)

## Also in this branch: broadened migration nudge

Tangential to setup-on-add but committed here. The "other webmux servers detected → run `webmux project migrate`" hint (from #271, which consolidated the old one-server-per-project model into a single dashboard) was `project`-only; it now fires on **every command that reaches a project** (`oneshot`/`linear`/`project` + worktree commands), except `project migrate` itself. It's a cheap local registry read, silent unless other servers exist, transient until you consolidate, on **stderr**, and **amber** (TTY only — plain when piped) to read as a nudge, not an error. The point is to push anyone still on the old per-project-server setup to update + consolidate.

## Changes

- **api-contract**: `AddProjectResponse`, `ProjectInitPhase`/`ProjectInitState` schemas, `projectInits` endpoint; `addProject` now returns `AddProjectResponse`.
- **backend**: `project-init-service.ts` (new) + wiring in `server.ts`; `init-authoring.ts` lift + run timeout; `lib/shell.ts` (new).
- **frontend**: `setUpProject` + `projectInitPhaseLabel`; `EmptyProjects`/`ProjectSwitcher` progress UI.
- **cli**: `webmux project add` phase output; broadened + amber migration nudge in the `webmux.ts` dispatch.

## Review polish (applied)

- Agent-neutral phase label/copy (setup may run Codex, so it no longer claims "Claude").
- Scaffolded `defaultAgent` falls back to `claude` (not `codex`) when neither agent is installed.
- Dropped a redundant `creating_config` tracker write in `apiAddProject`.

## Test plan

- [ ] `bun run test` — backend 479, contract 4, bin 176, frontend 140; `tsc --noEmit` (backend) + `svelte-check` clean; `bun run build` ok.
- [ ] Add a repo **with** a `.webmux.yaml` from the dashboard → registers immediately, opens.
- [ ] Add a repo **without** a `.webmux.yaml` → watch "Creating .webmux.yaml" → "Analyzing project structure" → opens; `.webmux.yaml` is written and fleshed out.
- [ ] `webmux project add <repo-without-config>` prints the same phases.
- [ ] With `claude`/`codex` not on PATH → setup skips analysis and still registers with the starter config.
- [ ] With another webmux server running, `webmux project ls` (and oneshot/linear/worktree commands) print the amber consolidation nudge on stderr; piping it shows plain text; `project migrate` does not print it.

> Note: the agent-analysis path makes a real headless agent run on the repo; it's the one part not covered by automated tests (which inject the agent run).

---
Generated with [Claude Code](https://claude.com/claude-code)