### PR TITLE
feat: prune only closed worktrees instead of all

### DIFF
--- a/backend/src/__tests__/lifecycle-service.test.ts
+++ b/backend/src/__tests__/lifecycle-service.test.ts
@@ -1709,7 +1709,7 @@ describe("LifecycleService", () => {
     expect(run(["git", "branch", "--list", "feature-ahead"], repoRoot)).toBe("");
   });
 
-  it("prunes all project worktrees", async () => {
+  it("prunes only closed worktrees, leaving open ones untouched", async () => {
     const repoRoot = await initRepo();
     const runtime = new ProjectRuntime();
     const tmux = new FakeTmuxGateway();
@@ -1719,24 +1719,38 @@ describe("LifecycleService", () => {
 
     await lifecycle.createWorktree({ branch: "feature-prune-host" });
     await lifecycle.createWorktree({ branch: "feature-prune-docker", profile: "sandbox" });
+    // feature-prune-host is closed (no tmux window); feature-prune-docker stays open.
     await lifecycle.closeWorktree("feature-prune-host");
 
     const result = await lifecycle.pruneWorktrees();
 
-    expect(result.removedBranches).toEqual([
-      "feature-prune-docker",
-      "feature-prune-host",
-    ]);
-    expect(hooks.calls.filter((call) => call.name === "preRemove").map((call) => call.cwd).sort()).toEqual([
-      join(repoRoot, "__worktrees", "feature-prune-docker"),
+    expect(result.removedBranches).toEqual(["feature-prune-host"]);
+    expect(hooks.calls.filter((call) => call.name === "preRemove").map((call) => call.cwd)).toEqual([
       join(repoRoot, "__worktrees", "feature-prune-host"),
     ]);
-    expect(docker.removed).toEqual(["feature-prune-docker"]);
-    expect(new BunGitGateway().listWorktrees(repoRoot).filter((entry) => entry.path !== repoRoot)).toEqual([]);
+    expect(docker.removed).toEqual([]);
+    expect(new BunGitGateway().listWorktrees(repoRoot).filter((entry) => entry.path !== repoRoot).map((entry) => entry.branch)).toEqual([
+      "feature-prune-docker",
+    ]);
     expect(run(["git", "branch", "--list", "feature-prune-host"], repoRoot)).toBe("");
-    expect(run(["git", "branch", "--list", "feature-prune-docker"], repoRoot)).toBe("");
-    expect(tmux.listWindows()).toEqual([]);
-    expect(runtime.listWorktrees()).toEqual([]);
+    expect(run(["git", "branch", "--list", "feature-prune-docker"], repoRoot)).not.toBe("");
+    expect(runtime.listWorktrees().map((entry) => entry.branch)).toEqual(["feature-prune-docker"]);
+  });
+
+  it("prunes nothing when all worktrees are open", async () => {
+    const repoRoot = await initRepo();
+    const runtime = new ProjectRuntime();
+    const tmux = new FakeTmuxGateway();
+    const docker = new FakeDockerGateway();
+    const hooks = new FakeHookRunner();
+    const lifecycle = makeLifecycleService(repoRoot, tmux, runtime, docker, hooks);
+
+    await lifecycle.createWorktree({ branch: "feature-open" });
+
+    const result = await lifecycle.pruneWorktrees();
+
+    expect(result.removedBranches).toEqual([]);
+    expect(runtime.listWorktrees().map((entry) => entry.branch)).toEqual(["feature-open"]);
   });
 
   it("removes the sandbox container before deleting a docker worktree", async () => {

--- a/backend/src/services/lifecycle-service.ts
+++ b/backend/src/services/lifecycle-service.ts
@@ -690,10 +690,14 @@ export class LifecycleService {
   async pruneWorktrees(): Promise<PruneWorktreesResult> {
     try {
       const resolvedWorktrees = await this.resolveAllWorktrees();
+      const sessionName = buildProjectSessionName(this.deps.projectRoot);
       const removedBranches: string[] = [];
 
       for (const resolved of resolvedWorktrees) {
         const branch = resolved.entry.branch ?? resolved.entry.path;
+        if (this.deps.tmux.hasWindow(sessionName, buildWorktreeWindowName(branch))) {
+          continue;
+        }
         await this.removeResolvedWorktree(resolved);
         removedBranches.push(branch);
       }

--- a/bin/src/completions.test.ts
+++ b/bin/src/completions.test.ts
@@ -122,7 +122,7 @@ describe("runCompletionCommand", () => {
     expect(output).toContain("archive:Hide a worktree from the default list");
     expect(output).toContain("refresh:Refresh a Codex agent terminal");
     expect(output).toContain("label:Set or clear a workspace label");
-    expect(output).toContain("prune:Remove all worktrees in the current project");
+    expect(output).toContain("prune:Remove all closed (not open) worktrees in the current project");
     expect(output).not.toContain('_webmux "$@"');
     spy.mockRestore();
   });

--- a/bin/src/completions.ts
+++ b/bin/src/completions.ts
@@ -133,7 +133,7 @@ _webmux() {
     'remove:Remove a worktree'
     'merge:Merge a worktree into main'
     'send:Send a prompt to a running worktree agent'
-    'prune:Remove all worktrees in the current project'
+    'prune:Remove all closed (not open) worktrees in the current project'
     'linear:Post a worktree conversation to a Linear issue/team'
     'project:List, add, or remove projects served by the dashboard'
     'completion:Generate shell completion script'

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -32,7 +32,7 @@ Usage:
   webmux merge        Merge a worktree into the main branch and remove it
   webmux send         Send a prompt to a running worktree agent
   webmux tab          List, create, switch, or close agent tabs in a worktree
-  webmux prune        Remove all worktrees in the current project
+  webmux prune        Remove all closed (not open) worktrees in the current project
   webmux linear       Post a worktree conversation to a Linear issue/team
   webmux project      List, add, or remove projects served by the dashboard
   webmux completion   Generate shell completion script (bash, zsh)

--- a/bin/src/worktree-commands.test.ts
+++ b/bin/src/worktree-commands.test.ts
@@ -629,7 +629,7 @@ describe("runWorktreeCommand", () => {
     expect(stdout).toEqual(["Merged feature/search into develop"]);
   });
 
-  it("prunes all worktrees after confirmation", async () => {
+  it("prunes closed worktrees after confirmation", async () => {
     const { runtime, calls } = makeRuntime();
     runtime.git = stubGit([
       { path: "/repo", branch: "main", bare: false },
@@ -660,6 +660,71 @@ describe("runWorktreeCommand", () => {
     expect(confirmCalls).toEqual([2]);
     expect(calls).toEqual([{ method: "pruneWorktrees", value: null }]);
     expect(stdout).toEqual(["Pruned 2 worktrees: feature/search, feature/api"]);
+  });
+
+  it("counts only closed worktrees toward the prune confirmation", async () => {
+    const { runtime, calls } = makeRuntime();
+    runtime.git = stubGit([
+      { path: "/repo", branch: "main", bare: false },
+      { path: "/repo/.worktrees/feature-search", branch: "feature/search", bare: false },
+      { path: "/repo/.worktrees/feature-api", branch: "feature/api", bare: false },
+    ]);
+    runtime.tmux = stubTmux([
+      { sessionName: buildProjectSessionName("/repo"), windowName: buildWorktreeWindowName("feature/api") },
+    ]);
+    const stdout: string[] = [];
+    const confirmCalls: number[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      {
+        command: "prune",
+        args: [],
+        projectDir: "/repo",
+        port: 5111,
+      },
+      {
+        createRuntime: () => runtime,
+        confirmPrune: async (count) => {
+          confirmCalls.push(count);
+          return true;
+        },
+        stdout: (message) => stdout.push(message),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(confirmCalls).toEqual([1]);
+    expect(calls).toEqual([{ method: "pruneWorktrees", value: null }]);
+  });
+
+  it("does not prune when every worktree is open", async () => {
+    const { runtime, calls } = makeRuntime();
+    runtime.git = stubGit([
+      { path: "/repo", branch: "main", bare: false },
+      { path: "/repo/.worktrees/feature-search", branch: "feature/search", bare: false },
+    ]);
+    runtime.tmux = stubTmux([
+      { sessionName: buildProjectSessionName("/repo"), windowName: buildWorktreeWindowName("feature/search") },
+    ]);
+    const stdout: string[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      {
+        command: "prune",
+        args: [],
+        projectDir: "/repo",
+        port: 5111,
+      },
+      {
+        createRuntime: () => runtime,
+        confirmPrune: async () => true,
+        stdout: (message) => stdout.push(message),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([]);
+    expect(stdout).toEqual(["No closed worktrees to prune."]);
   });
 
   it("aborts prune when confirmation is declined", async () => {

--- a/bin/src/worktree-commands.ts
+++ b/bin/src/worktree-commands.ts
@@ -582,9 +582,24 @@ function listProjectWorktrees(
     .filter((entry) => !entry.bare && resolve(entry.path) !== projectDir);
 }
 
+function buildOpenWorktreeWindowSet(runtime: WorktreeRuntimeLike): Set<string> {
+  const sessionName = buildProjectSessionName(resolve(runtime.projectDir));
+  let windows: Array<{ sessionName: string; windowName: string }> = [];
+  try {
+    windows = runtime.tmux.listWindows();
+  } catch {
+    windows = [];
+  }
+  return new Set(
+    windows
+      .filter((w) => w.sessionName === sessionName)
+      .map((w) => w.windowName),
+  );
+}
+
 async function defaultConfirmPrune(worktreeCount: number): Promise<boolean> {
   const response = await p.confirm({
-    message: `Prune all ${worktreeCount} worktree${worktreeCount === 1 ? "" : "s"}? This action cannot be undone.`,
+    message: `Prune ${worktreeCount} closed worktree${worktreeCount === 1 ? "" : "s"}? This action cannot be undone.`,
     initialValue: false,
   });
   return !p.isCancel(response) && response;
@@ -647,19 +662,7 @@ async function listWorktrees(
     return;
   }
 
-  const sessionName = buildProjectSessionName(projectDir);
-  let windows: Array<{ sessionName: string; windowName: string }> = [];
-  try {
-    windows = runtime.tmux.listWindows();
-  } catch {
-    windows = [];
-  }
-
-  const openWindows = new Set(
-    windows
-      .filter((w) => w.sessionName === sessionName)
-      .map((w) => w.windowName),
-  );
+  const openWindows = buildOpenWorktreeWindowSet(runtime);
 
   const projectGitDir = runtime.git.resolveWorktreeGitDir(projectDir);
   const archivedPaths = buildArchivedWorktreePathSet(await readWorktreeArchiveState(projectGitDir));
@@ -832,14 +835,23 @@ export async function runWorktreeCommand(
         return 0;
       }
 
-      if (!await confirmPrune(worktrees.length)) {
+      const openWindows = buildOpenWorktreeWindowSet(runtime);
+      const closedWorktrees = worktrees.filter(
+        (entry) => !openWindows.has(buildWorktreeWindowName(entry.branch ?? basename(entry.path))),
+      );
+      if (closedWorktrees.length === 0) {
+        stdout("No closed worktrees to prune.");
+        return 0;
+      }
+
+      if (!await confirmPrune(closedWorktrees.length)) {
         stdout("Aborted.");
         return 0;
       }
 
       const result = await runtime.lifecycleService.pruneWorktrees();
       if (result.removedBranches.length === 0) {
-        stdout("No worktrees found.");
+        stdout("No closed worktrees to prune.");
         return 0;
       }
       stdout(


### PR DESCRIPTION
## Summary
`webmux prune` previously removed **all** worktrees in the project, including ones that were currently open/active. This changes prune to only remove **closed** worktrees (those without a live tmux window in the project session), leaving open ones untouched.

## Changes
- **Backend** (`lifecycle-service.ts`): `pruneWorktrees()` now skips any worktree whose tmux window still exists (`tmux.hasWindow(...)`), making this the source-of-truth filter.
- **CLI** (`worktree-commands.ts`): extracted shared `buildOpenWorktreeWindowSet(runtime)` helper (reused by `list` and `prune`); prune confirms with the closed count and prints `No closed worktrees to prune.` when everything is open; updated confirmation message.
- **Help/completions** (`webmux.ts`, `completions.ts`): descriptions now read "Remove all closed (not open) worktrees in the current project".
- **Tests**: backend covers closed-only pruning and the all-open no-op; CLI covers closed count, mixed open/closed, and all-open paths.

## Test plan
- [ ] `bun test backend/src/__tests__/lifecycle-service.test.ts` passes
- [ ] `bun test bin/src` passes
- [ ] `bun run --cwd backend check` (tsc) is clean
- [ ] Manually: open one worktree, leave another closed, run `webmux prune` → only the closed one is removed

---
Generated with [Claude Code](https://claude.com/claude-code)