### PR TITLE
feat: periodically save open sessions and add webmux restore

### DIFF
--- a/backend/src/__tests__/session-restore-service.test.ts
+++ b/backend/src/__tests__/session-restore-service.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildOpenSessionsState,
+  computeOpenBranches,
+  saveOpenSessionsSnapshot,
+} from "../services/session-restore-service";
+import { buildProjectSessionName, buildWorktreeWindowName } from "../adapters/tmux";
+import { OPEN_SESSIONS_STATE_VERSION, type OpenSessionsState } from "../domain/model";
+import type { GitWorktreeEntry } from "../adapters/git";
+import type { TmuxWindowSummary } from "../adapters/tmux";
+
+const PROJECT_DIR = "/repo";
+const SESSION = buildProjectSessionName(PROJECT_DIR);
+
+function worktree(path: string, branch: string | null): GitWorktreeEntry {
+  return { path, branch, head: null, detached: false, bare: false };
+}
+
+function window(windowName: string, sessionName = SESSION): TmuxWindowSummary {
+  return { sessionName, windowName, paneCount: 1 };
+}
+
+describe("computeOpenBranches", () => {
+  it("returns only branches whose worktree window is open in the project session", () => {
+    const branches = computeOpenBranches({
+      worktrees: [
+        worktree(PROJECT_DIR, "main"),
+        worktree("/repo/wt/feature-a", "feature-a"),
+        worktree("/repo/wt/feature-b", "feature-b"),
+        worktree("/repo/wt/feature-c", "feature-c"),
+      ],
+      windows: [
+        window(buildWorktreeWindowName("feature-a")),
+        window(buildWorktreeWindowName("feature-c")),
+        window(buildWorktreeWindowName("feature-b"), "some-other-session"),
+      ],
+      sessionName: SESSION,
+      projectDir: PROJECT_DIR,
+    });
+
+    expect(branches).toEqual(["feature-a", "feature-c"]);
+  });
+
+  it("excludes the project root worktree and bare entries", () => {
+    const bare: GitWorktreeEntry = { path: "/repo/.bare", branch: null, head: null, detached: false, bare: true };
+    const branches = computeOpenBranches({
+      worktrees: [worktree(PROJECT_DIR, "main"), bare],
+      windows: [window(buildWorktreeWindowName("main"))],
+      sessionName: SESSION,
+      projectDir: PROJECT_DIR,
+    });
+
+    expect(branches).toEqual([]);
+  });
+
+  it("falls back to the directory name when a worktree has no branch", () => {
+    const branches = computeOpenBranches({
+      worktrees: [worktree("/repo/wt/detached", null)],
+      windows: [window(buildWorktreeWindowName("detached"))],
+      sessionName: SESSION,
+      projectDir: PROJECT_DIR,
+    });
+
+    expect(branches).toEqual(["detached"]);
+  });
+});
+
+describe("buildOpenSessionsState", () => {
+  it("stamps the schema version and savedAt", () => {
+    const state = buildOpenSessionsState(["a", "b"], new Date("2026-06-27T12:00:00.000Z"));
+    expect(state).toEqual({
+      schemaVersion: OPEN_SESSIONS_STATE_VERSION,
+      savedAt: "2026-06-27T12:00:00.000Z",
+      branches: ["a", "b"],
+    });
+  });
+});
+
+describe("saveOpenSessionsSnapshot", () => {
+  function makeDeps(windows: TmuxWindowSummary[]) {
+    const writes: Array<{ gitDir: string; state: OpenSessionsState }> = [];
+    return {
+      writes,
+      deps: {
+        git: {
+          listLiveWorktrees: () => [
+            worktree(PROJECT_DIR, "main"),
+            worktree("/repo/wt/feature-a", "feature-a"),
+          ],
+          resolveWorktreeGitDir: (cwd: string) => `${cwd}/.git`,
+        },
+        tmux: { listWindows: () => windows },
+        projectRoot: PROJECT_DIR,
+        now: () => new Date("2026-06-27T12:00:00.000Z"),
+        writeState: async (gitDir: string, state: OpenSessionsState) => {
+          writes.push({ gitDir, state });
+        },
+      },
+    };
+  }
+
+  it("writes the open branches when at least one session is open", async () => {
+    const { writes, deps } = makeDeps([window(buildWorktreeWindowName("feature-a"))]);
+    const branches = await saveOpenSessionsSnapshot(deps);
+
+    expect(branches).toEqual(["feature-a"]);
+    expect(writes).toEqual([
+      {
+        gitDir: `${PROJECT_DIR}/.git`,
+        state: {
+          schemaVersion: OPEN_SESSIONS_STATE_VERSION,
+          savedAt: "2026-06-27T12:00:00.000Z",
+          branches: ["feature-a"],
+        },
+      },
+    ]);
+  });
+
+  it("does not overwrite the snapshot when nothing is open (reboot safety)", async () => {
+    const { writes, deps } = makeDeps([]);
+    const branches = await saveOpenSessionsSnapshot(deps);
+
+    expect(branches).toBeNull();
+    expect(writes).toEqual([]);
+  });
+});

--- a/backend/src/adapters/fs.ts
+++ b/backend/src/adapters/fs.ts
@@ -6,6 +6,7 @@ import type {
   CiCheck,
   CodexWorktreeConversationMeta,
   ControlEnvMap,
+  OpenSessionsState,
   PrComment,
   PrEntry,
   WorktreeConversationMeta,
@@ -14,7 +15,7 @@ import type {
   WorktreeStoragePaths,
   WorktreeTab,
 } from "../domain/model";
-import { conversationSessionId, ROOT_TAB_ID, WORKTREE_ARCHIVE_STATE_VERSION } from "../domain/model";
+import { conversationSessionId, OPEN_SESSIONS_STATE_VERSION, ROOT_TAB_ID, WORKTREE_ARCHIVE_STATE_VERSION } from "../domain/model";
 
 const SAFE_ENV_VALUE_RE = /^[A-Za-z0-9_./:@%+=,-]+$/;
 const DOTENV_LINE_RE = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)/;
@@ -72,6 +73,10 @@ export function getWorktreeStoragePaths(gitDir: string): WorktreeStoragePaths {
 
 export function getProjectArchiveStatePath(gitDir: string): string {
   return join(gitDir, "webmux", "archive.json");
+}
+
+export function getProjectOpenSessionsStatePath(gitDir: string): string {
+  return join(gitDir, "webmux", "open-sessions.json");
 }
 
 export async function ensureWorktreeStorageDirs(gitDir: string): Promise<WorktreeStoragePaths> {
@@ -134,6 +139,44 @@ export async function writeWorktreeArchiveState(gitDir: string, state: WorktreeA
   const archivePath = getProjectArchiveStatePath(gitDir);
   await ensureWorktreeStorageDirs(gitDir);
   await Bun.write(archivePath, JSON.stringify(state, null, 2) + "\n");
+}
+
+function emptyOpenSessionsState(): OpenSessionsState {
+  return {
+    schemaVersion: OPEN_SESSIONS_STATE_VERSION,
+    savedAt: "",
+    branches: [],
+  };
+}
+
+function isOpenSessionsState(raw: unknown): raw is OpenSessionsState {
+  return isRecord(raw)
+    && typeof raw.schemaVersion === "number"
+    && typeof raw.savedAt === "string"
+    && Array.isArray(raw.branches)
+    && raw.branches.every((branch) => typeof branch === "string");
+}
+
+export async function readOpenSessionsState(gitDir: string): Promise<OpenSessionsState> {
+  const statePath = getProjectOpenSessionsStatePath(gitDir);
+  try {
+    const raw: unknown = await Bun.file(statePath).json();
+    return isOpenSessionsState(raw)
+      ? {
+          schemaVersion: raw.schemaVersion,
+          savedAt: raw.savedAt,
+          branches: [...raw.branches],
+        }
+      : emptyOpenSessionsState();
+  } catch {
+    return emptyOpenSessionsState();
+  }
+}
+
+export async function writeOpenSessionsState(gitDir: string, state: OpenSessionsState): Promise<void> {
+  const statePath = getProjectOpenSessionsStatePath(gitDir);
+  await ensureWorktreeStorageDirs(gitDir);
+  await Bun.write(statePath, JSON.stringify(state, null, 2) + "\n");
 }
 
 export function buildRuntimeEnvMap(

--- a/backend/src/domain/model.ts
+++ b/backend/src/domain/model.ts
@@ -2,6 +2,7 @@ import type { AgentId, RuntimeKind } from "./config";
 
 export const WORKTREE_META_SCHEMA_VERSION = 1;
 export const WORKTREE_ARCHIVE_STATE_VERSION = 1;
+export const OPEN_SESSIONS_STATE_VERSION = 1;
 
 export type WorktreeConversationProvider = "codexAppServer" | "claudeCode";
 
@@ -97,6 +98,14 @@ export interface ArchivedWorktreeEntry {
 export interface WorktreeArchiveState {
   schemaVersion: number;
   entries: ArchivedWorktreeEntry[];
+}
+
+/** A periodically-saved snapshot of which worktree sessions were open, so
+ *  `webmux restore` can re-open them after a server restart or reboot. */
+export interface OpenSessionsState {
+  schemaVersion: number;
+  savedAt: string;
+  branches: string[];
 }
 
 export interface WorktreeStoragePaths {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -102,6 +102,7 @@ import { startLinearAutoCreateMonitor, resetProcessedIssues } from "./services/l
 import { startOneshotWatcher } from "./services/oneshot-watcher-service";
 import { runAutoRemove, type AutoRemoveDependencies } from "./services/auto-remove-service";
 import { pullMainBranch, forcePullMainBranch, startAutoPullMonitor } from "./services/auto-pull-service";
+import { startSessionSnapshotMonitor } from "./services/session-restore-service";
 import {
   AgentsConversationStreamSession,
   readAgentsNotificationThreadId,
@@ -234,6 +235,7 @@ let autoRemoveOnMergeEnabled = config.integrations.github.autoRemoveOnMerge;
 let stopPrMonitor: (() => void) | null = null;
 let stopOneshotWatcher: (() => void) | null = null;
 let stopAutoPullMonitor: (() => void) | null = null;
+let stopSessionSnapshot: (() => void) | null = null;
 
 /** Create a worktree in oneshot mode for the given Linear issue and arm the
  *  server-side watcher to post results back + close the session when done. Returns
@@ -2312,6 +2314,7 @@ function parseAgentIdParam(params: Record<string, string>):
         config.workspace.autoPull.intervalSeconds * 1000,
       );
     }
+    stopSessionSnapshot = startSessionSnapshotMonitor({ git, tmux, projectRoot: PROJECT_DIR });
   }
 
   function stopLight(): void {
@@ -2322,6 +2325,8 @@ function parseAgentIdParam(params: Record<string, string>):
     stopOneshotWatcher = null;
     stopAutoPullMonitor?.();
     stopAutoPullMonitor = null;
+    stopSessionSnapshot?.();
+    stopSessionSnapshot = null;
   }
 
   return { prefix: instancePrefix, routes, wsHandlers, startLight, stopLight };

--- a/backend/src/services/session-restore-service.ts
+++ b/backend/src/services/session-restore-service.ts
@@ -1,0 +1,117 @@
+import { basename, resolve } from "node:path";
+import type { GitGateway, GitWorktreeEntry } from "../adapters/git";
+import {
+  buildProjectSessionName,
+  buildWorktreeWindowName,
+  type TmuxGateway,
+  type TmuxWindowSummary,
+} from "../adapters/tmux";
+import { readOpenSessionsState, writeOpenSessionsState } from "../adapters/fs";
+import { OPEN_SESSIONS_STATE_VERSION, type OpenSessionsState } from "../domain/model";
+import { startSerializedInterval } from "../lib/async";
+import { log } from "../lib/log";
+
+/** The branch of a live worktree entry (mirrors the CLI/list convention of
+ *  falling back to the directory name when git can't report a branch). */
+function entryBranch(entry: Pick<GitWorktreeEntry, "path" | "branch">): string {
+  return entry.branch ?? basename(entry.path);
+}
+
+/** Compute the set of worktree branches that currently have an open tmux window
+ *  in the project session. Pure so it can be unit-tested without git/tmux. */
+export function computeOpenBranches(input: {
+  worktrees: Array<Pick<GitWorktreeEntry, "path" | "branch" | "bare">>;
+  windows: TmuxWindowSummary[];
+  sessionName: string;
+  projectDir: string;
+}): string[] {
+  const resolvedProjectDir = resolve(input.projectDir);
+  const openWindowNames = new Set(
+    input.windows
+      .filter((window) => window.sessionName === input.sessionName)
+      .map((window) => window.windowName),
+  );
+
+  return input.worktrees
+    .filter((entry) => !entry.bare && resolve(entry.path) !== resolvedProjectDir)
+    .map((entry) => entryBranch(entry))
+    .filter((branch) => openWindowNames.has(buildWorktreeWindowName(branch)))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export function buildOpenSessionsState(branches: string[], savedAt: Date): OpenSessionsState {
+  return {
+    schemaVersion: OPEN_SESSIONS_STATE_VERSION,
+    savedAt: savedAt.toISOString(),
+    branches,
+  };
+}
+
+export const DEFAULT_SESSION_SNAPSHOT_INTERVAL_MS = 30_000;
+
+export interface SessionSnapshotDependencies {
+  git: Pick<GitGateway, "listLiveWorktrees" | "resolveWorktreeGitDir">;
+  tmux: Pick<TmuxGateway, "listWindows">;
+  projectRoot: string;
+  now?: () => Date;
+  writeState?: (gitDir: string, state: OpenSessionsState) => Promise<void>;
+}
+
+/** Persist the currently-open worktree sessions for `webmux restore`.
+ *
+ *  Returns the branches written, or null when nothing was written.
+ *
+ *  An empty open set never overwrites the snapshot: on a reboot the server (and
+ *  the snapshot monitor) start before any session is re-opened, so writing an
+ *  empty list here would clobber the very data `restore` needs. Keeping the last
+ *  non-empty snapshot makes `restore` re-open your last working set. */
+export async function saveOpenSessionsSnapshot(
+  deps: SessionSnapshotDependencies,
+): Promise<string[] | null> {
+  const projectRoot = resolve(deps.projectRoot);
+  const sessionName = buildProjectSessionName(projectRoot);
+
+  let windows: TmuxWindowSummary[] = [];
+  try {
+    windows = deps.tmux.listWindows();
+  } catch {
+    windows = [];
+  }
+
+  const worktrees = deps.git.listLiveWorktrees(projectRoot);
+  const branches = computeOpenBranches({ worktrees, windows, sessionName, projectDir: projectRoot });
+  if (branches.length === 0) return null;
+
+  const now = deps.now ?? ((): Date => new Date());
+  const writeState = deps.writeState ?? writeOpenSessionsState;
+  const gitDir = deps.git.resolveWorktreeGitDir(projectRoot);
+  await writeState(gitDir, buildOpenSessionsState(branches, now()));
+  return branches;
+}
+
+/** Start periodically saving the open worktree sessions. Returns a cleanup
+ *  function that stops the monitor. */
+export function startSessionSnapshotMonitor(
+  deps: SessionSnapshotDependencies,
+  intervalMs: number = DEFAULT_SESSION_SNAPSHOT_INTERVAL_MS,
+): () => void {
+  log.info(`[session-snapshot] monitor started (interval: ${intervalMs}ms)`);
+
+  const run = async (): Promise<void> => {
+    try {
+      const branches = await saveOpenSessionsSnapshot(deps);
+      if (branches) {
+        log.debug(`[session-snapshot] saved ${branches.length} open session(s): ${branches.join(", ")}`);
+      }
+    } catch (error) {
+      log.warn(`[session-snapshot] save failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  return startSerializedInterval(run, intervalMs);
+}
+
+/** Read the saved open-sessions snapshot for a project. */
+export async function readOpenSessionsSnapshot(gitDir: string): Promise<OpenSessionsState> {
+  return await readOpenSessionsState(gitDir);
+}

--- a/bin/src/completions.ts
+++ b/bin/src/completions.ts
@@ -134,6 +134,7 @@ _webmux() {
     'merge:Merge a worktree into main'
     'send:Send a prompt to a running worktree agent'
     'prune:Remove all worktrees in the current project'
+    'restore:Re-open all worktree sessions that were open before'
     'linear:Post a worktree conversation to a Linear issue/team'
     'project:List, add, or remove projects served by the dashboard'
     'completion:Generate shell completion script'
@@ -205,7 +206,7 @@ const BASH_SCRIPT = `_webmux() {
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
-    COMPREPLY=($(compgen -W "serve init service update add oneshot list open close refresh archive unarchive label remove merge send prune linear project completion" -- "\${cur}"))
+    COMPREPLY=($(compgen -W "serve init service update add oneshot list open close refresh archive unarchive label remove merge send prune restore linear project completion" -- "\${cur}"))
     return
   fi
 

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -33,6 +33,7 @@ Usage:
   webmux send         Send a prompt to a running worktree agent
   webmux tab          List, create, switch, or close agent tabs in a worktree
   webmux prune        Remove all worktrees in the current project
+  webmux restore      Re-open all worktree sessions that were open before
   webmux linear       Post a worktree conversation to a Linear issue/team
   webmux project      List, add, or remove projects served by the dashboard
   webmux completion   Generate shell completion script (bash, zsh)
@@ -50,7 +51,7 @@ Environment:
 `);
 }
 
-type RootCommand = "serve" | "init" | "service" | "update" | "add" | "oneshot" | "list" | "open" | "close" | "refresh" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "tab" | "prune" | "linear" | "project" | "completion" | null;
+type RootCommand = "serve" | "init" | "service" | "update" | "add" | "oneshot" | "list" | "open" | "close" | "refresh" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "tab" | "prune" | "restore" | "linear" | "project" | "completion" | null;
 
 interface ParsedRootArgs {
   port: number;
@@ -83,6 +84,7 @@ function isRootCommand(value: string): value is NonNullable<RootCommand> {
     || value === "send"
     || value === "tab"
     || value === "prune"
+    || value === "restore"
     || value === "linear"
     || value === "project"
     || value === "completion";
@@ -162,7 +164,7 @@ export function parseRootArgs(args: string[]): ParsedRootArgs {
   };
 }
 
-function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "open" | "close" | "refresh" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "tab" | "prune" {
+function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "open" | "close" | "refresh" | "archive" | "unarchive" | "label" | "remove" | "merge" | "send" | "tab" | "prune" | "restore" {
   return command === "add"
     || command === "list"
     || command === "open"
@@ -175,7 +177,8 @@ function isWorktreeCommand(command: RootCommand): command is "add" | "list" | "o
     || command === "merge"
     || command === "send"
     || command === "tab"
-    || command === "prune";
+    || command === "prune"
+    || command === "restore";
 }
 
 // ── Load env files from CWD (.env.local overrides .env) ─────────────────────

--- a/bin/src/worktree-commands.test.ts
+++ b/bin/src/worktree-commands.test.ts
@@ -1033,3 +1033,156 @@ describe("runWorktreeCommand", () => {
     });
   });
 });
+
+describe("runWorktreeCommand restore", () => {
+  const SESSION = buildProjectSessionName("/repo");
+
+  function makeRestoreRuntime(options: {
+    worktrees?: Array<{ path: string; branch: string | null; bare: boolean }>;
+    windows?: Array<{ sessionName: string; windowName: string }>;
+    openWorktree?: (branch: string) => Promise<{ branch: string; worktreeId: string }>;
+  }) {
+    const opened: string[] = [];
+    return {
+      opened,
+      runtime: {
+        projectDir: "/repo",
+        config: { workspace: { mainBranch: "main" } },
+        git: {
+          listWorktrees: () => options.worktrees ?? [],
+          resolveWorktreeGitDir: (cwd: string) => `${cwd}/.git`,
+        },
+        tmux: { listWindows: () => options.windows ?? [] },
+        lifecycleService: {
+          async openWorktree(branch: string): Promise<{ branch: string; worktreeId: string }> {
+            if (options.openWorktree) return options.openWorktree(branch);
+            opened.push(branch);
+            return { branch, worktreeId: `wt-${branch}` };
+          },
+        },
+      },
+    };
+  }
+
+  it("re-opens saved sessions that are not already open", async () => {
+    const { runtime, opened } = makeRestoreRuntime({
+      worktrees: [
+        { path: "/repo", branch: "main", bare: false },
+        { path: "/repo/wt/feature-a", branch: "feature-a", bare: false },
+        { path: "/repo/wt/feature-b", branch: "feature-b", bare: false },
+      ],
+      windows: [{ sessionName: SESSION, windowName: buildWorktreeWindowName("feature-b") }],
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const switchCalls: Array<{ projectDir: string; branch: string }> = [];
+
+    const exitCode = await runWorktreeCommand(
+      { command: "restore", args: [], projectDir: "/repo", port: 5111 },
+      {
+        createRuntime: () => runtime,
+        stdout: (m) => stdout.push(m),
+        stderr: (m) => stderr.push(m),
+        switchToTmuxWindow: (projectDir, branch) => switchCalls.push({ projectDir, branch }),
+        readOpenSessions: async () => ({
+          schemaVersion: 1,
+          savedAt: "2026-06-27T12:00:00.000Z",
+          branches: ["feature-a", "feature-b"],
+        }),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(opened).toEqual(["feature-a"]);
+    expect(stdout).toEqual([
+      "Restored feature-a",
+      "Already open: feature-b",
+      "Restored 1 session, skipped 1.",
+    ]);
+    expect(stderr).toEqual([]);
+    expect(switchCalls).toEqual([{ projectDir: "/repo", branch: "feature-a" }]);
+  });
+
+  it("reports when there are no saved sessions", async () => {
+    const { runtime } = makeRestoreRuntime({});
+    const stdout: string[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      { command: "restore", args: [], projectDir: "/repo", port: 5111 },
+      {
+        createRuntime: () => runtime,
+        stdout: (m) => stdout.push(m),
+        switchToTmuxWindow: () => {},
+        readOpenSessions: async () => ({ schemaVersion: 1, savedAt: "", branches: [] }),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toEqual(["No saved sessions to restore."]);
+  });
+
+  it("skips saved branches whose worktree no longer exists", async () => {
+    const { runtime, opened } = makeRestoreRuntime({
+      worktrees: [{ path: "/repo", branch: "main", bare: false }],
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      { command: "restore", args: [], projectDir: "/repo", port: 5111 },
+      {
+        createRuntime: () => runtime,
+        stdout: (m) => stdout.push(m),
+        stderr: (m) => stderr.push(m),
+        switchToTmuxWindow: () => {},
+        readOpenSessions: async () => ({ schemaVersion: 1, savedAt: "x", branches: ["gone"] }),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(opened).toEqual([]);
+    expect(stderr).toEqual(["Skipping gone: worktree no longer exists"]);
+    expect(stdout).toEqual(["Restored 0 sessions, skipped 1."]);
+  });
+
+  it("returns exit code 1 and reports when a restore fails", async () => {
+    const { runtime } = makeRestoreRuntime({
+      worktrees: [
+        { path: "/repo", branch: "main", bare: false },
+        { path: "/repo/wt/feature-a", branch: "feature-a", bare: false },
+      ],
+      openWorktree: async (branch) => { throw new Error(`boom ${branch}`); },
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const exitCode = await runWorktreeCommand(
+      { command: "restore", args: [], projectDir: "/repo", port: 5111 },
+      {
+        createRuntime: () => runtime,
+        stdout: (m) => stdout.push(m),
+        stderr: (m) => stderr.push(m),
+        switchToTmuxWindow: () => {},
+        readOpenSessions: async () => ({ schemaVersion: 1, savedAt: "x", branches: ["feature-a"] }),
+      },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toEqual(["Failed to restore feature-a: boom feature-a"]);
+    expect(stdout).toEqual(["Restored 0 sessions, 1 failed."]);
+  });
+
+  it("prints restore help with --help", async () => {
+    const stdout: string[] = [];
+    const exitCode = await runWorktreeCommand(
+      { command: "restore", args: ["--help"], projectDir: "/repo", port: 5111 },
+      {
+        createRuntime: () => { throw new Error("unexpected"); },
+        stdout: (m) => stdout.push(m),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout[0]).toContain("webmux restore");
+  });
+});

--- a/bin/src/worktree-commands.ts
+++ b/bin/src/worktree-commands.ts
@@ -3,7 +3,8 @@ import { createApi } from "@webmux/api-contract";
 import { basename, resolve } from "node:path";
 import { buildSeedFromLinear, defaultSeedFromLinearDeps } from "../../backend/src/services/conversation-export-service";
 import { CommandUsageError, resolveProjectBaseUrl, withServerConnection } from "./shared";
-import { readWorktreeArchiveState, readWorktreeMeta } from "../../backend/src/adapters/fs";
+import { readOpenSessionsState, readWorktreeArchiveState, readWorktreeMeta } from "../../backend/src/adapters/fs";
+import type { OpenSessionsState } from "../../backend/src/domain/model";
 import { buildProjectSessionName, buildWorktreeWindowName } from "../../backend/src/adapters/tmux";
 import type { AgentId } from "../../backend/src/domain/config";
 import type { WorktreeCreationPhase } from "../../backend/src/domain/model";
@@ -20,7 +21,7 @@ const PHASE_LABELS: Record<WorktreeCreationPhase, string> = {
   reconciling: "Reconciling",
 };
 
-export type WorktreeSubcommand = "add" | "list" | "open" | "close" | "refresh" | "remove" | "merge" | "send" | "prune" | "archive" | "unarchive" | "label" | "tab";
+export type WorktreeSubcommand = "add" | "list" | "open" | "close" | "refresh" | "remove" | "merge" | "send" | "prune" | "restore" | "archive" | "unarchive" | "label" | "tab";
 
 type WorktreeListMode = "active" | "all" | "archived";
 
@@ -74,6 +75,9 @@ interface WorktreeCommandDependencies {
   /** Resolve the project-scoped base URL for server-backed commands (send/tab).
    *  Injectable so tests can exercise the HTTP shape without a live server. */
   resolveBaseUrl?: (port: number, projectDir: string) => Promise<string>;
+  /** Read the saved open-sessions snapshot (used by `restore`). Injectable so
+   *  tests can drive restore without touching the filesystem. */
+  readOpenSessions?: (gitDir: string) => Promise<OpenSessionsState>;
 }
 
 export function getWorktreeCommandUsage(command: WorktreeSubcommand): string {
@@ -143,6 +147,8 @@ export function getWorktreeCommandUsage(command: WorktreeSubcommand): string {
       ].join("\n");
     case "prune":
       return "Usage:\n  webmux prune";
+    case "restore":
+      return "Usage:\n  webmux restore\n\nRe-open every worktree session that was open the last time sessions were saved.";
     case "tab":
       return [
         "Usage:",
@@ -533,6 +539,22 @@ function parsePruneCommandArgs(args: string[]): boolean {
   return true;
 }
 
+function parseRestoreCommandArgs(args: string[]): boolean {
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      return false;
+    }
+
+    if (arg.startsWith("-")) {
+      throw new CommandUsageError(`Unknown option: ${arg}`);
+    }
+
+    throw new CommandUsageError(`Unexpected argument: ${arg}`);
+  }
+
+  return true;
+}
+
 export function parseListCommandArgs(args: string[]): ParsedListCommand | null {
   let mode: WorktreeListMode = "active";
   let search = "";
@@ -743,6 +765,7 @@ export async function runWorktreeCommand(
   const resolveBaseUrl = deps.resolveBaseUrl ?? resolveProjectBaseUrl;
   const switchToTmuxWindow = deps.switchToTmuxWindow ?? defaultSwitchToTmuxWindow;
   const confirmPrune = deps.confirmPrune ?? defaultConfirmPrune;
+  const readOpenSessions = deps.readOpenSessions ?? readOpenSessionsState;
 
   try {
     if (context.command === "add") {
@@ -848,6 +871,79 @@ export async function runWorktreeCommand(
       return 0;
     }
 
+    if (context.command === "restore") {
+      if (!parseRestoreCommandArgs(context.args)) {
+        stdout(getWorktreeCommandUsage("restore"));
+        return 0;
+      }
+
+      const runtime = createRuntime({
+        projectDir: context.projectDir,
+        port: context.port,
+      });
+      const projectDir = resolve(runtime.projectDir);
+      const gitDir = runtime.git.resolveWorktreeGitDir(projectDir);
+      const state = await readOpenSessions(gitDir);
+
+      if (state.branches.length === 0) {
+        stdout("No saved sessions to restore.");
+        return 0;
+      }
+
+      const sessionName = buildProjectSessionName(projectDir);
+      let openWindows = new Set<string>();
+      try {
+        openWindows = new Set(
+          runtime.tmux.listWindows()
+            .filter((w) => w.sessionName === sessionName)
+            .map((w) => w.windowName),
+        );
+      } catch {
+        openWindows = new Set();
+      }
+
+      const existingBranches = new Set(
+        listProjectWorktrees(runtime).map((entry) => entry.branch ?? basename(entry.path)),
+      );
+
+      let restored = 0;
+      let skipped = 0;
+      let failed = 0;
+      let firstRestored: string | null = null;
+
+      for (const branch of state.branches) {
+        if (openWindows.has(buildWorktreeWindowName(branch))) {
+          stdout(`Already open: ${branch}`);
+          skipped++;
+          continue;
+        }
+        if (!existingBranches.has(branch)) {
+          stderr(`Skipping ${branch}: worktree no longer exists`);
+          skipped++;
+          continue;
+        }
+        try {
+          await runtime.lifecycleService.openWorktree(branch);
+          stdout(`Restored ${branch}`);
+          restored++;
+          if (!firstRestored) firstRestored = branch;
+        } catch (error) {
+          stderr(`Failed to restore ${branch}: ${error instanceof Error ? error.message : String(error)}`);
+          failed++;
+        }
+      }
+
+      const summaryParts = [`Restored ${restored} session${restored === 1 ? "" : "s"}`];
+      if (skipped > 0) summaryParts.push(`skipped ${skipped}`);
+      if (failed > 0) summaryParts.push(`${failed} failed`);
+      stdout(`${summaryParts.join(", ")}.`);
+
+      if (firstRestored) {
+        switchToTmuxWindow(runtime.projectDir, firstRestored);
+      }
+      return failed > 0 ? 1 : 0;
+    }
+
     if (context.command === "send") {
       const parsed = parseSendCommandArgs(context.args);
       if (!parsed) {
@@ -928,7 +1024,7 @@ export async function runWorktreeCommand(
       return 0;
     }
 
-    const command: Exclude<WorktreeSubcommand, "add" | "list" | "send" | "prune" | "label" | "tab"> = context.command;
+    const command: Exclude<WorktreeSubcommand, "add" | "list" | "send" | "prune" | "restore" | "label" | "tab"> = context.command;
     const branch = parseBranchCommandArgs(context.args);
     if (!branch) {
       stdout(getWorktreeCommandUsage(command));


### PR DESCRIPTION
## Summary
Adds an automatic, periodic snapshot of which worktree sessions are currently open per project, plus a new `webmux restore` command that re-opens every session that was open the last time a snapshot was saved. This recovers your working set after a server restart, machine reboot, or tmux server loss.

## Changes
- **Domain/persistence**: new `OpenSessionsState` type (`OPEN_SESSIONS_STATE_VERSION`) and `readOpenSessionsState`/`writeOpenSessionsState` in the fs adapter, stored at `<gitDir>/webmux/open-sessions.json` (alongside `archive.json`).
- **Backend service** (`session-restore-service.ts`):
  - `computeOpenBranches` — pure: which worktree branches have an open tmux window in the project session.
  - `saveOpenSessionsSnapshot` / `startSessionSnapshotMonitor` — periodically (30s) persist the open set via `startSerializedInterval`.
  - **Reboot safety**: an empty open set never overwrites the snapshot, so the server starting before any session is re-opened won't clobber the data `restore` needs.
- **Server wiring**: the snapshot monitor runs per project inside the existing light background loops (`startLight`/`stopLight` in `createProjectApp`).
- **CLI**: new `webmux restore` subcommand — reads the snapshot, skips already-open and no-longer-existing worktrees, re-opens the rest via the lifecycle service, switches to the first restored window, and reports a summary. Wired into `webmux.ts` dispatch/usage and shell completions (bash + zsh).
- **Tests**: unit tests for the pure selection logic, snapshot save (including the skip-empty behavior), and the `restore` CLI handler (restore, already-open, missing worktree, failure exit code, help).

## Test plan
- [ ] `bun test bin/src/worktree-commands.test.ts backend/src/__tests__/session-restore-service.test.ts` passes
- [ ] `bun run --cwd backend check` passes (typecheck)
- [ ] With the server running and 2+ worktree sessions open, wait ~30s, confirm `<gitDir>/webmux/open-sessions.json` lists them
- [ ] Close the sessions (or restart the server), run `webmux restore`, confirm the sessions re-open and it switches to the first one
- [ ] Run `webmux restore` with no snapshot → "No saved sessions to restore."

## Notes
- Surface scope: the periodic save is a server background loop (no UI), and the user-facing action is the `webmux restore` CLI command as requested. A dashboard "restore" button was intentionally left out to keep the change minimal — easy to add later if desired.

---
Generated with [Claude Code](https://claude.com/claude-code)