### PR TITLE
feat: let webmux service run anywhere and add non-interactive install

### DIFF
--- a/bin/src/service-restart.test.ts
+++ b/bin/src/service-restart.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -229,6 +230,41 @@ describe("updateInstalledService", () => {
       { bin: "systemctl", args: ["--user", "restart", "webmux-orch"] },
     ]);
     expect(await Bun.file(service.filePath).text()).toContain("/new/path/webmux");
+  });
+
+  it("migrates the old unit's served repo before regenerating, and surfaces it", async () => {
+    const { service, dir } = await setupSystemdService();
+    const servedRepo = join(dir, "served-repo");
+    // Rewrite the on-disk unit to the OLD format that pinned a served repo via
+    // WEBMUX_PROJECT_DIR, so regeneration drops it.
+    await writeFile(
+      service.filePath,
+      [
+        "[Unit]",
+        "Description=webmux dashboard — served",
+        "",
+        "[Service]",
+        "ExecStart=/old/path/webmux serve --port 5500",
+        `WorkingDirectory=${servedRepo}`,
+        `Environment=WEBMUX_PROJECT_DIR=${servedRepo}`,
+        "",
+      ].join("\n"),
+    );
+    const { runner } = makeRecorder(() => okResult);
+    let contentAtMigrate: string | null = null;
+    const migrate = (filePath: string): string | null => {
+      contentAtMigrate = readFileSync(filePath, "utf8");
+      return servedRepo;
+    };
+
+    const outcome = await updateInstalledService(service, "/new/path/webmux", runner, migrate);
+
+    expect(outcome.regenerated).toBe(true);
+    expect(outcome.migratedProject).toBe(servedRepo);
+    // Migration ran against the OLD content, before the rewrite.
+    expect(contentAtMigrate).toContain(`WEBMUX_PROJECT_DIR=${servedRepo}`);
+    // The regenerated unit no longer pins the repo.
+    expect(await Bun.file(service.filePath).text()).not.toContain("WEBMUX_PROJECT_DIR");
   });
 
   it("does not attempt a restart when daemon-reload fails", async () => {

--- a/bin/src/service-restart.test.ts
+++ b/bin/src/service-restart.test.ts
@@ -98,10 +98,8 @@ describe("parseInstalledServiceConfig", () => {
     const filePath = join(dir, "webmux-roundtrip.service");
     const original: ServiceConfig = {
       platform: "linux",
-      projectName: "roundtrip",
       serviceName: "webmux-roundtrip",
       webmuxPath: "/usr/local/bin/webmux",
-      projectDir: dir,
       port: 5117,
       envVars: {},
     };
@@ -111,7 +109,6 @@ describe("parseInstalledServiceConfig", () => {
 
     expect(parsed).not.toBeNull();
     expect(parsed?.port).toBe(5117);
-    expect(parsed?.projectDir).toBe(dir);
     expect(parsed?.serviceName).toBe("webmux-roundtrip");
     // webmuxPath comes from the caller (post-upgrade `which webmux`), not the unit.
     expect(parsed?.webmuxPath).toBe("/new/path/webmux");
@@ -122,10 +119,8 @@ describe("parseInstalledServiceConfig", () => {
     const filePath = join(dir, "com.webmux.webmux-roundtrip.plist");
     const original: ServiceConfig = {
       platform: "darwin",
-      projectName: "roundtrip",
       serviceName: "webmux-roundtrip",
       webmuxPath: "/usr/local/bin/webmux",
-      projectDir: dir,
       port: 5222,
       envVars: {},
     };
@@ -135,7 +130,6 @@ describe("parseInstalledServiceConfig", () => {
 
     expect(parsed).not.toBeNull();
     expect(parsed?.port).toBe(5222);
-    expect(parsed?.projectDir).toBe(dir);
     expect(parsed?.serviceName).toBe("webmux-roundtrip");
   });
 
@@ -150,18 +144,11 @@ describe("parseInstalledServiceConfig", () => {
 describe("generateServiceFile → parseInstalledServiceConfig → generateServiceFile is idempotent", () => {
   it("regenerated content matches the original for systemd units", async () => {
     const dir = await makeTempDir();
-    // `detectProjectName` reads package.json's `name` first, so seeding one
-    // with a stable name guarantees the re-derived `projectName` matches the
-    // original — otherwise it would fall back to the random temp-dir basename
-    // and the round-trip would diverge on the `Description=` line.
-    await writeFile(join(dir, "package.json"), JSON.stringify({ name: "idempotent" }));
     const filePath = join(dir, "webmux-idempotent.service");
     const original: ServiceConfig = {
       platform: "linux",
-      projectName: "idempotent",
       serviceName: "webmux-idempotent",
       webmuxPath: "/usr/local/bin/webmux",
-      projectDir: dir,
       port: 5333,
       envVars: {},
     };
@@ -184,10 +171,8 @@ describe("updateInstalledService", () => {
     const filePath = join(dir, "webmux-orch.service");
     const original: ServiceConfig = {
       platform: "linux",
-      projectName: "orch",
       serviceName: "webmux-orch",
       webmuxPath: "/old/path/webmux",
-      projectDir: dir,
       port: 5500,
       envVars: {},
     };
@@ -275,10 +260,8 @@ describe("updateInstalledService", () => {
     const filePath = join(dir, "com.webmux.webmux-darwin-orch.plist");
     const original: ServiceConfig = {
       platform: "darwin",
-      projectName: "darwin-orch",
       serviceName: "webmux-darwin-orch",
       webmuxPath: "/old/path/webmux",
-      projectDir: dir,
       port: 5600,
       envVars: {},
     };

--- a/bin/src/service-restart.ts
+++ b/bin/src/service-restart.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { run, type RunResult } from "./shared.ts";
-import { generateServiceFile, parseInstalledServiceConfig, type Platform } from "./service.ts";
+import { generateServiceFile, migrateServedRepoFromUnit, parseInstalledServiceConfig, type Platform } from "./service.ts";
 
 export type ServicePlatform = Platform;
 
@@ -109,6 +109,9 @@ export interface UpdateOutcome {
   service: InstalledService;
   regenerated: boolean;
   restarted: boolean;
+  /** Path of a repo the old unit served via WEBMUX_PROJECT_DIR that was carried
+   *  forward into projects.json before regeneration, if any. */
+  migratedProject?: string;
   error?: string;
 }
 
@@ -149,6 +152,7 @@ export async function updateInstalledService(
   service: InstalledService,
   webmuxPath: string,
   runner: ServiceRunner = defaultRunner,
+  migrate: (filePath: string, platform: Platform) => string | null = migrateServedRepoFromUnit,
 ): Promise<UpdateOutcome> {
   // Empty webmuxPath would write `ExecStart=  serve --port N` into the unit
   // and silently break the next restart. Happens when `which webmux` returns
@@ -160,6 +164,7 @@ export async function updateInstalledService(
     ? parseInstalledServiceConfig(service.filePath, service.platform, webmuxPath)
     : null;
   let regenerated = false;
+  let migratedProject: string | undefined;
 
   if (config !== null) {
     let currentContent = "";
@@ -170,6 +175,9 @@ export async function updateInstalledService(
     }
     const expected = generateServiceFile(config);
     if (currentContent !== expected) {
+      // The regenerated unit drops WEBMUX_PROJECT_DIR; carry the repo it served
+      // implicitly into projects.json first so it doesn't vanish on restart.
+      migratedProject = migrate(service.filePath, service.platform) ?? undefined;
       try {
         await Bun.write(service.filePath, expected);
         regenerated = true;
@@ -178,6 +186,7 @@ export async function updateInstalledService(
           service,
           regenerated: false,
           restarted: false,
+          migratedProject,
           error: `could not rewrite ${service.filePath}: ${String(err)}`,
         };
       }
@@ -187,13 +196,13 @@ export async function updateInstalledService(
   if (regenerated) {
     const reload = reloadAfterRegenerate(service, runner);
     if (!reload.ok) {
-      return { service, regenerated, restarted: false, error: reload.error };
+      return { service, regenerated, restarted: false, migratedProject, error: reload.error };
     }
     // On launchd the load step already (re)started the service. systemd
     // still needs an explicit restart so an already-running process picks
     // up the new ExecStart.
     if (service.platform === "darwin") {
-      return { service, regenerated, restarted: true };
+      return { service, regenerated, restarted: true, migratedProject };
     }
   }
 
@@ -201,6 +210,7 @@ export async function updateInstalledService(
   return {
     service,
     regenerated,
+    migratedProject,
     restarted: outcome.ok,
     error: outcome.error,
   };

--- a/bin/src/service.test.ts
+++ b/bin/src/service.test.ts
@@ -5,7 +5,9 @@ import {
   parseInstalledServiceConfig,
   readEnvVarsFromUnit,
   readPortFromUnit,
+  resolveConfirmDecision,
   resolveEnvVars,
+  shouldPersistCwdProject,
   type ServiceConfig,
 } from "./service.ts";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -20,6 +22,39 @@ async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
     await rm(dir, { recursive: true, force: true });
   }
 }
+
+describe("resolveConfirmDecision", () => {
+  it("proceeds outright with --yes, regardless of TTY", () => {
+    expect(resolveConfirmDecision(true, true)).toBe("proceed");
+    expect(resolveConfirmDecision(true, false)).toBe("proceed");
+  });
+
+  it("prompts in an interactive shell without --yes", () => {
+    expect(resolveConfirmDecision(false, true)).toBe("prompt");
+  });
+
+  it("bails in a non-interactive shell without --yes", () => {
+    expect(resolveConfirmDecision(false, false)).toBe("abort-noninteractive");
+  });
+});
+
+describe("shouldPersistCwdProject", () => {
+  it("persists a webmux repo that isn't registered yet", () => {
+    expect(shouldPersistCwdProject("/some/repo", true, ["/other/repo"])).toBe(true);
+  });
+
+  it("does not persist when not in a git repo", () => {
+    expect(shouldPersistCwdProject(null, true, [])).toBe(false);
+  });
+
+  it("does not persist a repo without a webmux config", () => {
+    expect(shouldPersistCwdProject("/some/repo", false, [])).toBe(false);
+  });
+
+  it("does not persist a repo that is already registered", () => {
+    expect(shouldPersistCwdProject("/some/repo", true, ["/some/repo"])).toBe(false);
+  });
+});
 
 describe("parseEnvCliArgs", () => {
   it("collects multiple --env KEY=VAL pairs", () => {
@@ -132,10 +167,8 @@ describe("generateServiceFile + readEnvVarsFromUnit (round-trip)", () => {
       const filePath = join(dir, "webmux-roundtrip.service");
       const config: ServiceConfig = {
         platform: "linux",
-        projectName: "roundtrip",
         serviceName: "webmux-roundtrip",
         webmuxPath: "/usr/local/bin/webmux",
-        projectDir: dir,
         port: 5111,
         envVars: { LINEAR_API_KEY: "lin_xyz", FOO: "bar=baz" },
       };
@@ -150,10 +183,8 @@ describe("generateServiceFile + readEnvVarsFromUnit (round-trip)", () => {
       const filePath = join(dir, "webmux-roundtrip.service");
       const config: ServiceConfig = {
         platform: "linux",
-        projectName: "roundtrip",
         serviceName: "webmux-roundtrip",
         webmuxPath: "/usr/local/bin/webmux",
-        projectDir: dir,
         port: 5111,
         envVars: { LINEAR_API_KEY: "x" },
       };
@@ -169,10 +200,8 @@ describe("generateServiceFile + readEnvVarsFromUnit (round-trip)", () => {
       const filePath = join(dir, "com.webmux.webmux-roundtrip.plist");
       const config: ServiceConfig = {
         platform: "darwin",
-        projectName: "roundtrip",
         serviceName: "webmux-roundtrip",
         webmuxPath: "/usr/local/bin/webmux",
-        projectDir: dir,
         port: 5222,
         envVars: { TOKEN: "needs <escaping> & a&mp", PLAIN: "ok" },
       };
@@ -188,10 +217,8 @@ describe("generateServiceFile + readEnvVarsFromUnit (round-trip)", () => {
       await writeFile(join(dir, "package.json"), JSON.stringify({ name: "roundtrip" }));
       const original: ServiceConfig = {
         platform: "linux",
-        projectName: "roundtrip",
         serviceName: "webmux-roundtrip",
         webmuxPath: "/usr/local/bin/webmux",
-        projectDir: dir,
         port: 5117,
         envVars: { LINEAR_API_KEY: "lin_xyz" },
       };
@@ -265,10 +292,8 @@ describe("readPortFromUnit", () => {
     await withTempDir(async (dir) => {
       const config: ServiceConfig = {
         platform: "linux",
-        projectName: "roundtrip",
         serviceName: "webmux",
         webmuxPath: "/usr/local/bin/webmux",
-        projectDir: "/home/x/proj",
         port: 5117,
         envVars: {},
       };
@@ -283,10 +308,8 @@ describe("readPortFromUnit", () => {
     await withTempDir(async (dir) => {
       const config: ServiceConfig = {
         platform: "darwin",
-        projectName: "roundtrip",
         serviceName: "webmux",
         webmuxPath: "/usr/local/bin/webmux",
-        projectDir: "/Users/x/proj",
         port: 5222,
         envVars: {},
       };

--- a/bin/src/service.test.ts
+++ b/bin/src/service.test.ts
@@ -1,18 +1,39 @@
 import { describe, expect, it } from "bun:test";
 import {
   generateServiceFile,
+  migrateServedRepoFromUnit,
   parseEnvCliArgs,
   parseInstalledServiceConfig,
   readEnvVarsFromUnit,
   readPortFromUnit,
   resolveConfirmDecision,
   resolveEnvVars,
-  shouldPersistCwdProject,
+  shouldPersistProject,
   type ServiceConfig,
 } from "./service.ts";
+import type { ProjectEntry } from "../../backend/src/domain/projects";
+import type { ProjectsRegistry } from "../../backend/src/adapters/projects-registry";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** In-memory ProjectsRegistry stub so the migration is testable without
+ *  touching ~/.webmux/projects.json. */
+function fakeRegistry(initial: ProjectEntry[] = []): ProjectsRegistry {
+  const entries = [...initial];
+  return {
+    list: () => [...entries],
+    add: (entry) => {
+      const idx = entries.findIndex((e) => e.path === entry.path);
+      if (idx >= 0) entries[idx] = entry;
+      else entries.push(entry);
+    },
+    remove: (path) => {
+      const idx = entries.findIndex((e) => e.path === path);
+      if (idx >= 0) entries.splice(idx, 1);
+    },
+  };
+}
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
   const dir = await mkdtemp(join(tmpdir(), "webmux-service-env-"));
@@ -38,21 +59,74 @@ describe("resolveConfirmDecision", () => {
   });
 });
 
-describe("shouldPersistCwdProject", () => {
+describe("shouldPersistProject", () => {
   it("persists a webmux repo that isn't registered yet", () => {
-    expect(shouldPersistCwdProject("/some/repo", true, ["/other/repo"])).toBe(true);
+    expect(shouldPersistProject("/some/repo", true, ["/other/repo"])).toBe(true);
   });
 
-  it("does not persist when not in a git repo", () => {
-    expect(shouldPersistCwdProject(null, true, [])).toBe(false);
+  it("does not persist when there's no path", () => {
+    expect(shouldPersistProject(null, true, [])).toBe(false);
   });
 
   it("does not persist a repo without a webmux config", () => {
-    expect(shouldPersistCwdProject("/some/repo", false, [])).toBe(false);
+    expect(shouldPersistProject("/some/repo", false, [])).toBe(false);
   });
 
   it("does not persist a repo that is already registered", () => {
-    expect(shouldPersistCwdProject("/some/repo", true, ["/some/repo"])).toBe(false);
+    expect(shouldPersistProject("/some/repo", true, ["/some/repo"])).toBe(false);
+  });
+});
+
+describe("migrateServedRepoFromUnit", () => {
+  it("persists the repo an old systemd unit served via WorkingDirectory", async () => {
+    await withTempDir(async (repo) => {
+      await writeFile(join(repo, ".webmux.yaml"), "name: served\n");
+      const unitPath = join(repo, "webmux.service");
+      await writeFile(unitPath, `[Service]\nWorkingDirectory=${repo}\nExecStart=/x serve --port 5111\n`);
+      const registry = fakeRegistry();
+
+      const migrated = migrateServedRepoFromUnit(unitPath, "linux", registry);
+
+      expect(migrated).toBe(repo);
+      expect(registry.list().map((e) => e.path)).toEqual([repo]);
+    });
+  });
+
+  it("is a no-op when the served dir has no webmux config (e.g. $HOME)", async () => {
+    await withTempDir(async (dir) => {
+      const unitPath = join(dir, "webmux.service");
+      await writeFile(unitPath, `[Service]\nWorkingDirectory=${dir}\n`);
+      const registry = fakeRegistry();
+
+      expect(migrateServedRepoFromUnit(unitPath, "linux", registry)).toBeNull();
+      expect(registry.list()).toEqual([]);
+    });
+  });
+
+  it("is a no-op when the served repo is already registered", async () => {
+    await withTempDir(async (repo) => {
+      await writeFile(join(repo, ".webmux.yaml"), "name: served\n");
+      const unitPath = join(repo, "webmux.service");
+      await writeFile(unitPath, `[Service]\nWorkingDirectory=${repo}\n`);
+      const registry = fakeRegistry([{ path: repo, name: "served", addedAt: 1 }]);
+
+      expect(migrateServedRepoFromUnit(unitPath, "linux", registry)).toBeNull();
+      expect(registry.list().length).toBe(1);
+    });
+  });
+
+  it("reads WorkingDirectory out of a launchd plist", async () => {
+    await withTempDir(async (repo) => {
+      await writeFile(join(repo, ".webmux.yaml"), "name: served\n");
+      const unitPath = join(repo, "com.webmux.webmux.plist");
+      await writeFile(
+        unitPath,
+        `<plist><dict>\n  <key>WorkingDirectory</key>\n  <string>${repo}</string>\n</dict></plist>\n`,
+      );
+      const registry = fakeRegistry();
+
+      expect(migrateServedRepoFromUnit(unitPath, "darwin", registry)).toBe(repo);
+    });
   });
 });
 

--- a/bin/src/service.ts
+++ b/bin/src/service.ts
@@ -4,7 +4,7 @@ import { basename, join } from "node:path";
 import { homedir } from "node:os";
 import { run, getGitRoot, detectProjectName } from "./shared.ts";
 import type { RunResult } from "./shared.ts";
-import { createProjectsRegistry } from "../../backend/src/adapters/projects-registry";
+import { createProjectsRegistry, type ProjectsRegistry } from "../../backend/src/adapters/projects-registry";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -44,31 +44,60 @@ function resolveWebmuxPath(): string | null {
   return result.stdout.toString().trim();
 }
 
-/** Decide whether `service install` should persist the current repo as a
- *  project. webmux is a single machine-wide service that serves everything in
- *  projects.json, so installing from a webmux project registers that repo the
- *  same way `webmux project add` would — replacing the old per-install
- *  WEBMUX_PROJECT_DIR auto-add with an explicit, persisted entry. Skipped when
- *  not in a git repo, when the repo has no webmux config, or when it is already
- *  registered. */
-export function shouldPersistCwdProject(
-  gitRoot: string | null,
+/** Decide whether a repo should be persisted to projects.json. webmux is a
+ *  single machine-wide service that serves everything in projects.json, so a
+ *  webmux project that isn't registered yet is registered the same way
+ *  `webmux project add` would. Used both by `service install` (the current repo)
+ *  and by the update/reinstall migration of a unit's previously-served repo.
+ *  Skipped when there's no path, when it has no webmux config, or when it is
+ *  already registered. */
+export function shouldPersistProject(
+  root: string | null,
   hasWebmuxConfig: boolean,
   existingPaths: string[],
 ): boolean {
-  if (!gitRoot || !hasWebmuxConfig) return false;
-  return !existingPaths.includes(gitRoot);
+  if (!root || !hasWebmuxConfig) return false;
+  return !existingPaths.includes(root);
 }
 
-/** I/O wrapper around shouldPersistCwdProject: the git root of the current repo
- *  when `service install` should register it, else null. */
+/** Whether `root` is a webmux project (carries a config file). */
+function hasWebmuxConfig(root: string): boolean {
+  return existsSync(join(root, ".webmux.yaml")) || existsSync(join(root, ".webmux.local.yaml"));
+}
+
+/** Register `root` as a project when eligible; returns the path if newly added,
+ *  else null. The registry is injectable so the migration is unit-testable. */
+function persistProject(root: string | null, registry: ProjectsRegistry): string | null {
+  if (!root) return null;
+  const existingPaths = registry.list().map((entry) => entry.path);
+  if (!shouldPersistProject(root, hasWebmuxConfig(root), existingPaths)) return null;
+  registry.add({ path: root, name: detectProjectName(root), addedAt: Date.now() });
+  return root;
+}
+
+/** I/O wrapper: the current repo when `service install` should register it,
+ *  else null. Decided ahead of the confirmation prompt for the plan preview;
+ *  the actual write happens after confirmation. */
 function cwdProjectToPersist(): string | null {
   const gitRoot = getGitRoot();
   if (!gitRoot) return null;
-  const hasConfig = existsSync(join(gitRoot, ".webmux.yaml"))
-    || existsSync(join(gitRoot, ".webmux.local.yaml"));
   const existingPaths = createProjectsRegistry().list().map((entry) => entry.path);
-  return shouldPersistCwdProject(gitRoot, hasConfig, existingPaths) ? gitRoot : null;
+  return shouldPersistProject(gitRoot, hasWebmuxConfig(gitRoot), existingPaths) ? gitRoot : null;
+}
+
+/** Carry a unit's previously-served repo forward into projects.json before the
+ *  unit is regenerated. Older units served one repo implicitly via
+ *  `WEBMUX_PROJECT_DIR` (added only ephemerally by the server), which the new
+ *  unit template drops — without this, that repo would silently vanish from the
+ *  dashboard on `webmux update` / reinstall. Idempotent: a regenerated unit's
+ *  `WorkingDirectory=$HOME` has no webmux config, and an already-registered repo
+ *  is skipped. Returns the migrated path, or null when there's nothing to do. */
+export function migrateServedRepoFromUnit(
+  filePath: string,
+  platform: Platform,
+  registry: ProjectsRegistry = createProjectsRegistry(),
+): string | null {
+  return persistProject(readWorkingDirFromUnit(filePath, platform), registry);
 }
 
 function formatCommand([bin, args]: Command): string {
@@ -181,11 +210,28 @@ export function generateServiceFile(config: ServiceConfig): string {
   return generateLaunchdPlist(config);
 }
 
+const SYSTEMD_WORKDIR_RE = /^WorkingDirectory=(.+)$/m;
+const LAUNCHD_WORKDIR_RE = /<key>WorkingDirectory<\/key>\s*<string>([^<]+)<\/string>/;
 const SYSTEMD_PORT_RE = /--port\s+(\d+)/;
 const LAUNCHD_PORT_RE = /<string>--port<\/string>\s*<string>(\d+)<\/string>/;
 const SYSTEMD_ENV_RE = /^Environment=([A-Za-z_][A-Za-z0-9_]*)=(.*)$/gm;
 const LAUNCHD_ENV_DICT_RE = /<key>EnvironmentVariables<\/key>\s*<dict>([\s\S]*?)<\/dict>/;
 const LAUNCHD_ENV_ENTRY_RE = /<key>([^<]+)<\/key>\s*<string>([^<]*)<\/string>/g;
+
+/** Read the `WorkingDirectory` an installed unit points at. Old units set this
+ *  to the served repo; new units set it to `$HOME`. Used to migrate a unit's
+ *  previously-served repo into projects.json before the unit is regenerated. */
+function readWorkingDirFromUnit(filePath: string, platform: Platform): string | null {
+  let text: string;
+  try {
+    text = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  const regex = platform === "linux" ? SYSTEMD_WORKDIR_RE : LAUNCHD_WORKDIR_RE;
+  const match = regex.exec(text);
+  return match ? match[1].trim() : null;
+}
 
 /** Parse the `--port N` value out of an installed unit file (systemd or
  *  launchd). Used to keep a reinstall idempotent (reuse the running port) and
@@ -477,7 +523,7 @@ async function install(
       displayContent,
       "Commands to run:",
       ...commands.map((c) => `  $ ${formatCommand(c)}`),
-      ...(persistPath ? ["", `Also registering this project: ${persistPath}`] : []),
+      ...(persistPath ? ["", `Will also register this project: ${persistPath}`] : []),
     ].join("\n"),
     "Install service",
   );
@@ -506,8 +552,15 @@ async function install(
     }
   }
 
-  // Tear the old unit down only once we're committed to reinstalling.
   if (alreadyInstalled) {
+    // Carry forward any repo the old unit served implicitly via
+    // WEBMUX_PROJECT_DIR before we overwrite it — the new template drops that
+    // env var, so otherwise the repo would silently vanish from the dashboard.
+    const migrated = migrateServedRepoFromUnit(filePath, config.platform);
+    if (migrated) {
+      p.log.success(`Migrated previously-served project ${detectProjectName(migrated)} (${migrated})`);
+    }
+    // Tear the old unit down only once we're committed to reinstalling.
     for (const cmd of uninstallCommands(config)) {
       runCommand(cmd);
     }

--- a/bin/src/service.ts
+++ b/bin/src/service.ts
@@ -4,6 +4,7 @@ import { basename, join } from "node:path";
 import { homedir } from "node:os";
 import { run, getGitRoot, detectProjectName } from "./shared.ts";
 import type { RunResult } from "./shared.ts";
+import { createProjectsRegistry } from "../../backend/src/adapters/projects-registry";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -12,14 +13,11 @@ type Command = [bin: string, args: string[]];
 
 export interface ServiceConfig {
   platform: Platform;
-  projectName: string;
   serviceName: string;
   webmuxPath: string;
-  projectDir: string;
   port: number;
   /** Extra environment variables to bake into the unit (LINEAR_API_KEY etc.).
-   *  PORT / WEBMUX_PROJECT_DIR / PATH are managed by the generator and must
-   *  not be passed here. */
+   *  PORT / PATH are managed by the generator and must not be passed here. */
   envVars: Record<string, string>;
 }
 
@@ -44,6 +42,33 @@ function resolveWebmuxPath(): string | null {
   const result = run("which", ["webmux"]);
   if (!result.success) return null;
   return result.stdout.toString().trim();
+}
+
+/** Decide whether `service install` should persist the current repo as a
+ *  project. webmux is a single machine-wide service that serves everything in
+ *  projects.json, so installing from a webmux project registers that repo the
+ *  same way `webmux project add` would — replacing the old per-install
+ *  WEBMUX_PROJECT_DIR auto-add with an explicit, persisted entry. Skipped when
+ *  not in a git repo, when the repo has no webmux config, or when it is already
+ *  registered. */
+export function shouldPersistCwdProject(
+  gitRoot: string | null,
+  hasWebmuxConfig: boolean,
+  existingPaths: string[],
+): boolean {
+  if (!gitRoot || !hasWebmuxConfig) return false;
+  return !existingPaths.includes(gitRoot);
+}
+
+/** I/O wrapper around shouldPersistCwdProject: the git root of the current repo
+ *  when `service install` should register it, else null. */
+function cwdProjectToPersist(): string | null {
+  const gitRoot = getGitRoot();
+  if (!gitRoot) return null;
+  const hasConfig = existsSync(join(gitRoot, ".webmux.yaml"))
+    || existsSync(join(gitRoot, ".webmux.local.yaml"));
+  const existingPaths = createProjectsRegistry().list().map((entry) => entry.path);
+  return shouldPersistCwdProject(gitRoot, hasConfig, existingPaths) ? gitRoot : null;
 }
 
 function formatCommand([bin, args]: Command): string {
@@ -85,16 +110,15 @@ function generateSystemdUnit(config: ServiceConfig): string {
     .map((key) => `Environment=${key}=${config.envVars[key]}`)
     .join("\n");
   return `[Unit]
-Description=webmux dashboard — ${config.projectName}
+Description=webmux dashboard
 
 [Service]
 Type=simple
 ExecStart=${config.webmuxPath} serve --port ${config.port}
-WorkingDirectory=${config.projectDir}
+WorkingDirectory=${homedir()}
 Restart=on-failure
 RestartSec=5
 Environment=PORT=${config.port}
-Environment=WEBMUX_PROJECT_DIR=${config.projectDir}
 Environment=PATH=${process.env.PATH}${extra ? "\n" + extra : ""}
 
 [Install]
@@ -128,7 +152,7 @@ function generateLaunchdPlist(config: ServiceConfig): string {
     <string>${config.port}</string>
   </array>
   <key>WorkingDirectory</key>
-  <string>${config.projectDir}</string>
+  <string>${homedir()}</string>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
@@ -144,8 +168,6 @@ function generateLaunchdPlist(config: ServiceConfig): string {
   <dict>
     <key>PORT</key>
     <string>${config.port}</string>
-    <key>WEBMUX_PROJECT_DIR</key>
-    <string>${config.projectDir}</string>
     <key>PATH</key>
     <string>${process.env.PATH}</string>${extra ? "\n" + extra : ""}
   </dict>
@@ -159,25 +181,11 @@ export function generateServiceFile(config: ServiceConfig): string {
   return generateLaunchdPlist(config);
 }
 
-const SYSTEMD_WORKDIR_RE = /^WorkingDirectory=(.+)$/m;
-const LAUNCHD_WORKDIR_RE = /<key>WorkingDirectory<\/key>\s*<string>([^<]+)<\/string>/;
 const SYSTEMD_PORT_RE = /--port\s+(\d+)/;
 const LAUNCHD_PORT_RE = /<string>--port<\/string>\s*<string>(\d+)<\/string>/;
 const SYSTEMD_ENV_RE = /^Environment=([A-Za-z_][A-Za-z0-9_]*)=(.*)$/gm;
 const LAUNCHD_ENV_DICT_RE = /<key>EnvironmentVariables<\/key>\s*<dict>([\s\S]*?)<\/dict>/;
 const LAUNCHD_ENV_ENTRY_RE = /<key>([^<]+)<\/key>\s*<string>([^<]*)<\/string>/g;
-
-function readWorkingDirFromUnit(filePath: string, platform: Platform): string | null {
-  let text: string;
-  try {
-    text = readFileSync(filePath, "utf8");
-  } catch {
-    return null;
-  }
-  const regex = platform === "linux" ? SYSTEMD_WORKDIR_RE : LAUNCHD_WORKDIR_RE;
-  const match = regex.exec(text);
-  return match ? match[1].trim() : null;
-}
 
 /** Parse the `--port N` value out of an installed unit file (systemd or
  *  launchd). Used to keep a reinstall idempotent (reuse the running port) and
@@ -231,11 +239,10 @@ export function readEnvVarsFromUnit(filePath: string, platform: Platform): Recor
 }
 
 /** Reconstruct a ServiceConfig from an installed unit file. The serviceName
- *  is taken from the file basename (not re-derived) so a renamed project dir
- *  doesn't change the launchd Label / systemd unit name that the OS is
- *  already tracking — only the regenerated *content* (description, paths,
- *  environment) reflects the current state. Returns null when the file is
- *  missing required fields. */
+ *  is taken from the file basename (not re-derived) so the launchd Label /
+ *  systemd unit name the OS is already tracking stays stable — only the
+ *  regenerated *content* (paths, environment) reflects the current template.
+ *  Returns null when the file is missing required fields. */
 export function parseInstalledServiceConfig(
   filePath: string,
   platform: Platform,
@@ -244,23 +251,17 @@ export function parseInstalledServiceConfig(
   const port = readPortFromUnit(filePath);
   if (port === null) return null;
 
-  const projectDir = readWorkingDirFromUnit(filePath, platform);
-  if (projectDir === null) return null;
-
   const fileBase = basename(filePath);
   const serviceName = platform === "linux"
     ? fileBase.replace(/\.service$/, "")
     : fileBase.replace(/^com\.webmux\./, "").replace(/\.plist$/, "");
 
-  const projectName = detectProjectName(projectDir);
   const envVars = readEnvVarsFromUnit(filePath, platform);
 
   return {
     platform,
-    projectName,
     serviceName,
     webmuxPath,
-    projectDir,
     port,
     envVars,
   };
@@ -410,24 +411,32 @@ function redactSecretsInUnit(content: string, envVars: Record<string, string>): 
   return out;
 }
 
+/** Whether we can prompt the user. In a non-TTY (CI, a pipe, a service runner)
+ *  stdin can't answer a confirm, so callers print the plan and bail with a
+ *  `--yes` hint instead of hanging on a prompt nobody can see. */
+function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY);
+}
+
+export type ConfirmDecision = "proceed" | "prompt" | "abort-noninteractive";
+
+/** Resolve how `service install` should confirm: `--yes` proceeds outright, an
+ *  interactive shell prompts, and a non-interactive shell without `--yes` bails
+ *  (the caller prints the plan + a `--yes` hint instead of hanging). */
+export function resolveConfirmDecision(autoConfirm: boolean, interactive: boolean): ConfirmDecision {
+  if (autoConfirm) return "proceed";
+  if (!interactive) return "abort-noninteractive";
+  return "prompt";
+}
+
 async function install(
   config: ServiceConfig,
   portExplicit: boolean,
   envVarNotes: string[],
+  autoConfirm: boolean,
 ): Promise<void> {
   const filePath = serviceFilePath(config);
   const alreadyInstalled = isInstalled(config);
-
-  if (alreadyInstalled) {
-    const reinstall = await p.confirm({ message: "Service is already installed. Reinstall?" });
-    if (p.isCancel(reinstall) || !reinstall) {
-      p.log.info("Aborted.");
-      return;
-    }
-    for (const cmd of uninstallCommands(config)) {
-      runCommand(cmd);
-    }
-  }
 
   // Pick the port for the unit. An explicit `--port` wins; otherwise, on
   // reinstall, reuse the existing unit's port so a bare re-run is idempotent;
@@ -450,18 +459,25 @@ async function install(
   const content = generateServiceFile(config);
   const commands = installCommands(config);
 
+  // The service serves every project in projects.json, so if we're installing
+  // from inside a webmux project, register it now — that repo then loads on the
+  // service's next start like any other persisted project.
+  const persistPath = cwdProjectToPersist();
+
   // Mask secret-shaped values in the preview so the dry-run note doesn't
   // splat tokens onto the terminal. The on-disk unit gets chmod 600 below.
   const displayContent = redactSecretsInUnit(content, config.envVars);
 
   p.note(
     [
+      ...(alreadyInstalled ? ["Service is already installed — this will reinstall it.", ""] : []),
       `File: ${filePath}`,
       "",
       "Contents:",
       displayContent,
       "Commands to run:",
       ...commands.map((c) => `  $ ${formatCommand(c)}`),
+      ...(persistPath ? ["", `Also registering this project: ${persistPath}`] : []),
     ].join("\n"),
     "Install service",
   );
@@ -471,10 +487,30 @@ async function install(
   }
   if (portNote) p.log.info(portNote);
 
-  const ok = await p.confirm({ message: "Proceed?" });
-  if (p.isCancel(ok) || !ok) {
-    p.log.info("Aborted.");
+  // Confirmation gate. `--yes` skips it; otherwise a TTY prompts and a non-TTY
+  // (CI, pipe, service runner) prints the plan above and bails with a hint
+  // rather than hanging on a confirm nobody can answer.
+  const decision = resolveConfirmDecision(autoConfirm, isInteractive());
+  if (decision === "abort-noninteractive") {
+    p.log.info(
+      `Non-interactive environment — not ${alreadyInstalled ? "reinstalling" : "installing"}. ` +
+        "Re-run with --yes to confirm and apply the plan above.",
+    );
     return;
+  }
+  if (decision === "prompt") {
+    const ok = await p.confirm({ message: alreadyInstalled ? "Reinstall?" : "Proceed?" });
+    if (p.isCancel(ok) || !ok) {
+      p.log.info("Aborted.");
+      return;
+    }
+  }
+
+  // Tear the old unit down only once we're committed to reinstalling.
+  if (alreadyInstalled) {
+    for (const cmd of uninstallCommands(config)) {
+      runCommand(cmd);
+    }
   }
 
   mkdirSync(filePath.substring(0, filePath.lastIndexOf("/")), { recursive: true });
@@ -488,6 +524,15 @@ async function install(
     }
   }
   p.log.success(`Wrote ${filePath}`);
+
+  if (persistPath) {
+    createProjectsRegistry().add({
+      path: persistPath,
+      name: detectProjectName(persistPath),
+      addedAt: Date.now(),
+    });
+    p.log.success(`Registered project ${detectProjectName(persistPath)} (${persistPath})`);
+  }
 
   for (const cmd of commands) {
     const result = runCommand(cmd);
@@ -610,6 +655,9 @@ Usage:
 Options:
   --port N                   Pin the service to a port (default: 5111). On
                              reinstall without --port the existing port is kept.
+  --yes, -y                  Skip the confirmation prompt and install. In a
+                             non-interactive shell (CI, pipe) install prints the
+                             plan and stops unless --yes is passed.
   --env KEY=VALUE            Bake an environment variable into the service
                              unit (repeatable). Reserved keys PORT,
                              WEBMUX_PROJECT_DIR, and PATH are rejected.
@@ -643,12 +691,6 @@ export default async function service(args: string[]): Promise<void> {
     return;
   }
 
-  const gitRoot = getGitRoot();
-  if (!gitRoot) {
-    p.log.error("Not inside a git repository.");
-    return;
-  }
-
   const serviceManager = platform === "linux" ? "systemctl" : "launchctl";
   const smResult = run("which", [serviceManager]);
   if (!smResult.success) {
@@ -665,6 +707,7 @@ export default async function service(args: string[]): Promise<void> {
   let port = parseInt(process.env.PORT || "5111");
   let portExplicit = false;
   let autoPickup = true;
+  let autoConfirm = false;
   for (let i = 1; i < args.length; i++) {
     if (args[i] === "--port" && args[i + 1]) {
       const parsed = parseInt(args[++i]);
@@ -676,6 +719,8 @@ export default async function service(args: string[]): Promise<void> {
       portExplicit = true;
     } else if (args[i] === "--no-auto-env") {
       autoPickup = false;
+    } else if (args[i] === "--yes" || args[i] === "-y") {
+      autoConfirm = true;
     }
   }
 
@@ -685,7 +730,6 @@ export default async function service(args: string[]): Promise<void> {
     return;
   }
 
-  const projectName = detectProjectName(gitRoot);
   // One multi-project service per machine, under a fixed name. (Older versions
   // installed one service per project as `webmux-<project>`; `webmux project
   // migrate` consolidates those into this single service.)
@@ -714,17 +758,15 @@ export default async function service(args: string[]): Promise<void> {
 
   const config: ServiceConfig = {
     platform,
-    projectName,
     serviceName,
     webmuxPath,
-    projectDir: gitRoot,
     port,
     envVars,
   };
 
   switch (action) {
     case "install":
-      await install(config, portExplicit, envVarNotes);
+      await install(config, portExplicit, envVarNotes, autoConfirm);
       break;
     case "uninstall":
       await uninstall(config);

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -326,6 +326,7 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
           const outcome = await updateInstalledService(svc, webmuxPath);
           const parts: string[] = [];
           if (outcome.regenerated) parts.push("regenerated unit");
+          if (outcome.migratedProject) parts.push(`migrated served project ${outcome.migratedProject}`);
           if (outcome.restarted) parts.push("restarted");
           if (!outcome.regenerated && !outcome.restarted && !outcome.error) parts.push("no change");
           const status = outcome.error


### PR DESCRIPTION
## Summary

`webmux service install` (and every `service` subcommand) used to refuse to run outside a git repository, and the install prompt would hang forever in a non-interactive shell (CI, a pipe, a remote tool run). Now that webmux is a single machine-wide, multi-project service, neither restriction makes sense. This PR removes the git-repo requirement, decouples the service unit from any single project, and makes install safe to run non-interactively.

## Changes

**Run from anywhere**
- Removed the hard `Not inside a git repository` gate that blocked all `service` subcommands (install/uninstall/status/logs).

**Decouple the service from a single project (C)**
- `ServiceConfig` no longer carries `projectName`/`projectDir`.
- systemd unit: `Description=webmux dashboard` (was `— <project>`), `WorkingDirectory=$HOME` (was the repo), and the `WEBMUX_PROJECT_DIR` env line is gone.
- launchd plist: same — `WorkingDirectory=$HOME`, no `WEBMUX_PROJECT_DIR`.
- Removed the now-dead `readWorkingDirFromUnit` + regexes; `parseInstalledServiceConfig` no longer reads a project dir. Existing installs auto-migrate to the new format on `webmux update`.

**Persist instead of env-var auto-add**
- On install from inside a webmux project (has `.webmux.yaml`/`.local.yaml`) that isn't already registered, the repo is written to `~/.webmux/projects.json` via the projects registry — so it loads on the service's next start like any other persisted project, replacing the old implicit `WEBMUX_PROJECT_DIR` auto-add. The install preview shows it and you get a `Registered project …` confirmation.

**Non-interactive install + `--yes`**
- New `--yes`/`-y` flag skips the confirmation prompt.
- In a non-TTY shell without `--yes`, install now prints the full plan (unit contents + commands) and exits cleanly with a hint to re-run with `--yes`, instead of hanging on a prompt nobody can answer.
- Consolidated the reinstall + proceed prompts into one confirmation gate; the teardown of an existing unit is deferred until after confirmation.
- Help text documents `--yes`.

**Note:** manual `webmux serve` still sets `WEBMUX_PROJECT_DIR=cwd`, so running it in a repo still auto-serves that repo and feeds the migrate sensor — only the *service unit* drops it.

## Test plan
- [x] `bun test bin/src` — 190 pass (added `resolveConfirmDecision`, `shouldPersistCwdProject` tests; updated `ServiceConfig` fixtures)
- [x] `webmux service status` runs from a non-git directory (previously errored)
- [x] Reproduced the before-hang: non-interactive `service install` blocks on `Proceed?` (killed by timeout)
- [x] After: non-interactive without `--yes` prints the plan + `--yes` hint and exits 0; with `--yes` it proceeds, writes the unit, runs install commands, exits 0 (verified in a sandboxed HOME + fake `systemctl`)
- [x] Rendered both unit types: static description, `WorkingDirectory=$HOME`, no `WEBMUX_PROJECT_DIR`

---
Generated with [Claude Code](https://claude.com/claude-code)