### PR TITLE
fix(linear): don't treat a linked github issue as a PR

### DIFF
--- a/backend/src/__tests__/linear-service.test.ts
+++ b/backend/src/__tests__/linear-service.test.ts
@@ -461,6 +461,21 @@ describe("findLinkedGitHubPr", () => {
     expect(result?.url).toBe("https://github.com/org/repo/pull/42");
     expect(result?.state).toBe("unknown");
   });
+
+  it("ignores a linked github issue tagged sourceType 'github' (not a PR)", () => {
+    // Linear's "GitHub Issues" sync attaches the source issue with
+    // sourceType "github" and an /issues/ URL. It must not be treated as a PR,
+    // else the oneshot seed resolves to a never-created branch.
+    const result = findLinkedGitHubPr({
+      attachments: [
+        attachment({
+          id: "1", url: "https://github.com/org/repo/issues/10105", title: "#10105 bug",
+          createdAt: "2026-05-01", sourceType: "github",
+        }),
+      ],
+    });
+    expect(result).toBeNull();
+  });
 });
 
 describe("buildLinearPickupMarkdown", () => {

--- a/backend/src/services/linear-service.ts
+++ b/backend/src/services/linear-service.ts
@@ -842,9 +842,13 @@ export function findLinkedGitHubPr(
   issue: { attachments: LinearAttachment[] },
 ): LinkedGitHubPr | null {
   const githubAttachments = issue.attachments.filter((a) => {
-    if (a.sourceType === "github" || a.sourceType === "githubPR" || a.sourceType === "github_pull_request") {
+    if (a.sourceType === "githubPR" || a.sourceType === "github_pull_request") {
       return true;
     }
+    // `sourceType: "github"` covers both linked PRs and linked issues, so it is
+    // not enough on its own — a synced GitHub *issue* (Linear's "GitHub Issues"
+    // team) would otherwise be treated as a PR, and the oneshot seed resolves to
+    // a branch that was never created ("Branch not found"). Only /pull/ URLs are PRs.
     return /github\.com\/.+\/pull\/\d+/i.test(a.url);
   });
   if (githubAttachments.length === 0) return null;


### PR DESCRIPTION
## Problem

Every `webmux_oneshot` issue on the **GIT** team (Linear's "GitHub Issues" sync) was silently dropped. The label was detected, but the oneshot launch failed:

```
[linear-auto-create] launching oneshot for GIT-920: bug: MCP token cannot call...
[linear-auto-create] failed to launch oneshot for GIT-920: Branch not found: ruben/git-920-...
```

## Root cause

`findLinkedGitHubPr` accepted any attachment with `sourceType: "github"` as a linked PR:

```js
if (a.sourceType === "github" || a.sourceType === "githubPR" || a.sourceType === "github_pull_request") {
  return true;
}
return /github\.com\/.+\/pull\/\d+/i.test(a.url);
```

Linear's "GitHub Issues" sync attaches the **source issue** (`.../issues/N`, no branch metadata) with `sourceType: "github"` — the same tag it uses for PRs. So `buildSeedFromLinear` saw a non-null `pr`, set `source: "github-integration"`, and resolved `branch` to `issue.branchName` (`inferPrBranchFromAttachment` returns null for an issue). `runOneshotForIssue` then picked `mode: "existing"` because `source !== "none"`, and `createWorktree` looked for a `ruben/git-920-...` branch that was never created → `Branch not found` (404). The issue was marked processed, so it never retried.

WIN issues worked because they have no GitHub attachment → `source: "none"` → `mode: "new"` → the branch is created fresh.

## Fix

Only trust the explicit PR source types (`githubPR`, `github_pull_request`). For the generic `github` type, require a `/pull/` URL. GitHub-issue attachments now fall through, so `findLinkedGitHubPr` returns null → `source: "none"` → `mode: "new"`, and webmux creates the branch like any other issue.

## Test

Added a regression test (`ignores a linked github issue tagged sourceType 'github'`). Verified it **fails** against the pre-fix code and **passes** after. Existing `findLinkedGitHubPr` tests (all `/pull/` URLs) still pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)