### PR TITLE
fix(auto-remove): sweep merged worktrees headlessly

### DIFF
--- a/backend/src/__tests__/auto-remove-service.test.ts
+++ b/backend/src/__tests__/auto-remove-service.test.ts
@@ -15,7 +15,7 @@ function worktree(branch: string): GitWorktreeEntry {
 /** Builds deps with fakes; records which branches got removed. */
 function makeDeps(opts: {
   worktrees: GitWorktreeEntry[];
-  states: Map<string, PrEntry["state"][]>;
+  states: Map<string, PrEntry["state"][]> | null;
   dirty?: Set<string>;
 }): { deps: AutoRemoveDependencies; removed: string[] } {
   const removed: string[] = [];
@@ -94,6 +94,16 @@ describe("runAutoRemove", () => {
   it("keeps a worktree that has no PR", async () => {
     const wt = worktree("feature");
     const { deps, removed } = makeDeps({ worktrees: [wt], states: new Map() });
+    await runAutoRemove(deps);
+    expect(removed).toEqual([]);
+  });
+
+  it("removes nothing when the PR state fetch is inconclusive", async () => {
+    // A failed repo query (null) must not be read as "merged with no other PRs":
+    // a transient gh failure on a linked repo could otherwise drop an open
+    // cross-repo PR and remove a still-live worktree.
+    const wt = worktree("feature");
+    const { deps, removed } = makeDeps({ worktrees: [wt], states: null });
     await runAutoRemove(deps);
     expect(removed).toEqual([]);
   });

--- a/backend/src/__tests__/auto-remove-service.test.ts
+++ b/backend/src/__tests__/auto-remove-service.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import type { GitGateway, GitWorktreeEntry } from "../adapters/git";
+import type { PrEntry } from "../domain/model";
+import {
+  runAutoRemove,
+  type AutoRemoveDependencies,
+} from "../services/auto-remove-service";
+
+const ROOT = "/repo";
+
+function worktree(branch: string): GitWorktreeEntry {
+  return { path: `/repo__wt/${branch}`, branch, bare: false } as GitWorktreeEntry;
+}
+
+/** Builds deps with fakes; records which branches got removed. */
+function makeDeps(opts: {
+  worktrees: GitWorktreeEntry[];
+  states: Map<string, PrEntry["state"][]>;
+  dirty?: Set<string>;
+}): { deps: AutoRemoveDependencies; removed: string[] } {
+  const removed: string[] = [];
+  const removing = new Set<string>();
+  const dirty = opts.dirty ?? new Set<string>();
+
+  const git = {
+    listLiveWorktrees: () => [{ path: ROOT, branch: "main", bare: false }, ...opts.worktrees],
+    readWorktreeStatus: (path: string) => ({
+      dirty: dirty.has(path),
+      aheadCount: 0,
+      currentCommit: null,
+    }),
+  } as unknown as GitGateway;
+
+  const deps: AutoRemoveDependencies = {
+    git,
+    projectRoot: ROOT,
+    lifecycleService: {
+      removeWorktree: async (branch: string) => {
+        removed.push(branch);
+      },
+    } as unknown as AutoRemoveDependencies["lifecycleService"],
+    notifications: { notify: () => {} } as unknown as AutoRemoveDependencies["notifications"],
+    isRemoving: (b) => removing.has(b),
+    markRemoving: (b) => removing.add(b),
+    unmarkRemoving: (b) => removing.delete(b),
+    getBranchPrStates: async () => opts.states,
+  };
+  return { deps, removed };
+}
+
+describe("runAutoRemove", () => {
+  it("removes a clean worktree whose PR is merged, without any prior open-state sync", async () => {
+    const wt = worktree("feature");
+    const { deps, removed } = makeDeps({
+      worktrees: [wt],
+      states: new Map([["feature", ["merged"]]]),
+    });
+    await runAutoRemove(deps);
+    expect(removed).toEqual(["feature"]);
+  });
+
+  it("keeps a worktree whose PR is still open", async () => {
+    const wt = worktree("feature");
+    const { deps, removed } = makeDeps({
+      worktrees: [wt],
+      states: new Map([["feature", ["open"]]]),
+    });
+    await runAutoRemove(deps);
+    expect(removed).toEqual([]);
+  });
+
+  it("keeps a worktree when any of its PRs across repos is not merged", async () => {
+    // Same branch has a merged PR in one repo and an open PR in a linked repo.
+    const wt = worktree("feature");
+    const { deps, removed } = makeDeps({
+      worktrees: [wt],
+      states: new Map([["feature", ["merged", "open"]]]),
+    });
+    await runAutoRemove(deps);
+    expect(removed).toEqual([]);
+  });
+
+  it("keeps a merged worktree that is dirty", async () => {
+    const wt = worktree("feature");
+    const { deps, removed } = makeDeps({
+      worktrees: [wt],
+      states: new Map([["feature", ["merged"]]]),
+      dirty: new Set([wt.path]),
+    });
+    await runAutoRemove(deps);
+    expect(removed).toEqual([]);
+  });
+
+  it("keeps a worktree that has no PR", async () => {
+    const wt = worktree("feature");
+    const { deps, removed } = makeDeps({ worktrees: [wt], states: new Map() });
+    await runAutoRemove(deps);
+    expect(removed).toEqual([]);
+  });
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -97,7 +97,12 @@ import {
 } from "./services/conversation-export-service";
 import { buildCreateWorktreeTargets, LifecycleError } from "./services/lifecycle-service";
 import { buildNativeTerminalLaunch, buildNativeTerminalTmuxCommand } from "./services/native-terminal-service";
-import { startPrMonitor, syncPrStatus } from "./services/pr-service";
+import {
+  fetchBranchPrStates,
+  startAutoRemoveMonitor,
+  startPrMonitor,
+  syncPrStatus,
+} from "./services/pr-service";
 import { startLinearAutoCreateMonitor, resetProcessedIssues } from "./services/linear-auto-create-service";
 import { startOneshotWatcher } from "./services/oneshot-watcher-service";
 import { runAutoRemove, type AutoRemoveDependencies } from "./services/auto-remove-service";
@@ -233,6 +238,7 @@ let linearAutoCreateEnabled = config.integrations.linear.autoCreateWorktrees;
 let stopLinearAutoCreate: (() => void) | null = null;
 let autoRemoveOnMergeEnabled = config.integrations.github.autoRemoveOnMerge;
 let stopPrMonitor: (() => void) | null = null;
+let stopAutoRemoveMonitor: (() => void) | null = null;
 let stopOneshotWatcher: (() => void) | null = null;
 let stopAutoPullMonitor: (() => void) | null = null;
 let stopSessionSnapshot: (() => void) | null = null;
@@ -350,6 +356,8 @@ const autoRemoveDeps: AutoRemoveDependencies = {
   isRemoving: (branch: string) => removingBranches.has(branch),
   markRemoving: (branch: string) => removingBranches.add(branch),
   unmarkRemoving: (branch: string) => removingBranches.delete(branch),
+  getBranchPrStates: () =>
+    fetchBranchPrStates(config.integrations.github.linkedRepos, PROJECT_DIR),
 };
 
 function getFrontendConfig(): {
@@ -2292,7 +2300,12 @@ function parseAgentIdParam(params: Record<string, string>):
   // auto-create, oneshot watcher, auto-pull). Heavy work (reconciliation,
   // terminal attach) is on-demand and therefore already active-only.
   function startLight(): void {
-    stopPrMonitor = startPrMonitor(getWorktreeGitDirs, config.integrations.github.linkedRepos, PROJECT_DIR, undefined, hasRecentDashboardActivity, async () => {
+    // Display sync (PR/CI status shown in the dashboard) stays gated on dashboard
+    // activity -- that data is only needed while someone is looking.
+    stopPrMonitor = startPrMonitor(getWorktreeGitDirs, config.integrations.github.linkedRepos, PROJECT_DIR, undefined, hasRecentDashboardActivity);
+    // Auto-remove is headless maintenance: it must run even when the dashboard is
+    // closed, so it gets its own ungated sweep instead of riding the display sync.
+    stopAutoRemoveMonitor = startAutoRemoveMonitor(async () => {
       if (autoRemoveOnMergeEnabled) {
         await runAutoRemove(autoRemoveDeps);
       }
@@ -2320,6 +2333,8 @@ function parseAgentIdParam(params: Record<string, string>):
   function stopLight(): void {
     stopPrMonitor?.();
     stopPrMonitor = null;
+    stopAutoRemoveMonitor?.();
+    stopAutoRemoveMonitor = null;
     stopLinearAutoCreateMonitor();
     stopOneshotWatcher?.();
     stopOneshotWatcher = null;

--- a/backend/src/services/auto-remove-service.ts
+++ b/backend/src/services/auto-remove-service.ts
@@ -14,8 +14,10 @@ export interface AutoRemoveDependencies {
   unmarkRemoving: (branch: string) => void;
   /** Authoritative PR states per branch across all configured repos. Queried live
    *  rather than read from the per-worktree PR cache, so a merge is detected even
-   *  when no open-state display sync ever ran (dashboard was never opened). */
-  getBranchPrStates: () => Promise<Map<string, PrEntry["state"][]>>;
+   *  when no open-state display sync ever ran (dashboard was never opened). Returns
+   *  null when the query was inconclusive (a repo fetch failed) -- removing on
+   *  partial state could drop an open cross-repo PR and remove a live worktree. */
+  getBranchPrStates: () => Promise<Map<string, PrEntry["state"][]> | null>;
 }
 
 /** Check all worktrees for merged PRs and remove clean ones. */
@@ -25,6 +27,10 @@ export async function runAutoRemove(deps: AutoRemoveDependencies): Promise<void>
   if (worktrees.length === 0) return;
 
   const branchStates = await deps.getBranchPrStates();
+  if (branchStates === null) {
+    log.debug("[auto-remove] skipping sweep: PR state fetch was inconclusive");
+    return;
+  }
 
   for (const entry of worktrees) {
     const branch = entry.branch!;

--- a/backend/src/services/auto-remove-service.ts
+++ b/backend/src/services/auto-remove-service.ts
@@ -1,5 +1,5 @@
-import { readWorktreePrs } from "../adapters/fs";
 import type { GitGateway } from "../adapters/git";
+import type { PrEntry } from "../domain/model";
 import { log } from "../lib/log";
 import type { LifecycleService } from "./lifecycle-service";
 import type { NotificationService } from "./notification-service";
@@ -12,21 +12,27 @@ export interface AutoRemoveDependencies {
   isRemoving: (branch: string) => boolean;
   markRemoving: (branch: string) => void;
   unmarkRemoving: (branch: string) => void;
+  /** Authoritative PR states per branch across all configured repos. Queried live
+   *  rather than read from the per-worktree PR cache, so a merge is detected even
+   *  when no open-state display sync ever ran (dashboard was never opened). */
+  getBranchPrStates: () => Promise<Map<string, PrEntry["state"][]>>;
 }
 
-/** Check all worktrees for merged PRs and remove clean ones.
- *  Called after PR sync completes -- reads the PR files that sync just wrote. */
+/** Check all worktrees for merged PRs and remove clean ones. */
 export async function runAutoRemove(deps: AutoRemoveDependencies): Promise<void> {
   const worktrees = deps.git.listLiveWorktrees(deps.projectRoot)
     .filter((e) => !e.bare && e.branch !== null && e.path !== deps.projectRoot);
+  if (worktrees.length === 0) return;
+
+  const branchStates = await deps.getBranchPrStates();
 
   for (const entry of worktrees) {
     const branch = entry.branch!;
     if (deps.isRemoving(branch)) continue;
 
-    const prs = await readWorktreePrs(deps.git.resolveWorktreeGitDir(entry.path));
-    if (prs.length === 0) continue;
-    if (!prs.every((pr) => pr.state === "merged")) continue;
+    const states = branchStates.get(branch);
+    if (!states || states.length === 0) continue;
+    if (!states.every((state) => state === "merged")) continue;
 
     if (deps.git.readWorktreeStatus(entry.path).dirty) {
       log.info(`[auto-remove] skipping dirty worktree: ${branch}`);

--- a/backend/src/services/pr-service.ts
+++ b/backend/src/services/pr-service.ts
@@ -492,7 +492,6 @@ export function startPrMonitor(
   projectDir?: string,
   intervalMs: number = 10_000,
   isActive?: () => boolean,
-  onAfterSync?: () => Promise<void>,
 ): () => void {
   const run = async (): Promise<void> => {
     if (isActive && !isActive()) {
@@ -504,11 +503,6 @@ export function startPrMonitor(
         log.error(`[pr] sync error: ${err}`);
       },
     );
-    if (onAfterSync) {
-      await onAfterSync().catch((err: unknown) => {
-        log.error(`[pr] after-sync hook error: ${err}`);
-      });
-    }
   };
 
   return startSerializedInterval(run, intervalMs);
@@ -517,19 +511,25 @@ export function startPrMonitor(
 /** Fetch the PR state for every branch across the current repo and all linked
  *  repos, one `gh pr list --state all` call per repo. Unlike the display sync
  *  (open-only), this sees merged/closed PRs, so the auto-remove sweep can detect a
- *  merge even when no earlier open-state sync ever recorded the PR. */
+ *  merge even when no earlier open-state sync ever recorded the PR.
+ *
+ *  Returns null if any repo query failed: a failed query is indistinguishable from
+ *  "this branch has no PR here", and since auto-remove reads this live (no persisted
+ *  fallback), proceeding on partial data could drop an open cross-repo PR and wrongly
+ *  remove a merged-in-main worktree. Callers must treat null as "skip this sweep". */
 export async function fetchBranchPrStates(
   linkedRepos: LinkedRepoConfig[],
   projectDir?: string,
-): Promise<Map<string, PrEntry["state"][]>> {
+): Promise<Map<string, PrEntry["state"][]> | null> {
   const perRepo = await Promise.all([
     fetchRepoBranchStates(undefined, projectDir),
     ...linkedRepos.map(({ repo }) => fetchRepoBranchStates(repo, projectDir)),
   ]);
+  if (perRepo.some((entries) => entries === null)) return null;
 
   const states = new Map<string, PrEntry["state"][]>();
   for (const entries of perRepo) {
-    for (const { branch, state } of entries) {
+    for (const { branch, state } of entries!) {
       const existing = states.get(branch) ?? [];
       existing.push(state);
       states.set(branch, existing);
@@ -538,10 +538,12 @@ export async function fetchBranchPrStates(
   return states;
 }
 
+/** Returns null (not []) on any failure so the caller can distinguish a failed
+ *  query from a repo that genuinely has no matching PRs. */
 async function fetchRepoBranchStates(
   repoSlug: string | undefined,
   cwd: string | undefined,
-): Promise<Array<{ branch: string; state: PrEntry["state"] }>> {
+): Promise<Array<{ branch: string; state: PrEntry["state"] }> | null> {
   const args = [
     "gh",
     "pr",
@@ -550,6 +552,9 @@ async function fetchRepoBranchStates(
     "all",
     "--json",
     "headRefName,state",
+    // Shares the display-sync limit. On a repo with heavy merged/closed history an
+    // older PR for a still-checked-out branch may fall outside the window and never
+    // be swept -- best-effort, but fails safe (a missed cleanup, never a wrong one).
     "--limit",
     String(PR_FETCH_LIMIT),
   ];
@@ -567,7 +572,7 @@ async function fetchRepoBranchStates(
   });
 
   const raceResult = await Promise.race([proc.exited, timeout]);
-  if (raceResult === "timeout" || raceResult !== 0) return [];
+  if (raceResult === "timeout" || raceResult !== 0) return null;
 
   try {
     const raw = JSON.parse(await new Response(proc.stdout).text()) as Array<{
@@ -579,7 +584,7 @@ async function fetchRepoBranchStates(
       state: r.state.toLowerCase() as PrEntry["state"],
     }));
   } catch {
-    return [];
+    return null;
   }
 }
 

--- a/backend/src/services/pr-service.ts
+++ b/backend/src/services/pr-service.ts
@@ -513,3 +513,87 @@ export function startPrMonitor(
 
   return startSerializedInterval(run, intervalMs);
 }
+
+/** Fetch the PR state for every branch across the current repo and all linked
+ *  repos, one `gh pr list --state all` call per repo. Unlike the display sync
+ *  (open-only), this sees merged/closed PRs, so the auto-remove sweep can detect a
+ *  merge even when no earlier open-state sync ever recorded the PR. */
+export async function fetchBranchPrStates(
+  linkedRepos: LinkedRepoConfig[],
+  projectDir?: string,
+): Promise<Map<string, PrEntry["state"][]>> {
+  const perRepo = await Promise.all([
+    fetchRepoBranchStates(undefined, projectDir),
+    ...linkedRepos.map(({ repo }) => fetchRepoBranchStates(repo, projectDir)),
+  ]);
+
+  const states = new Map<string, PrEntry["state"][]>();
+  for (const entries of perRepo) {
+    for (const { branch, state } of entries) {
+      const existing = states.get(branch) ?? [];
+      existing.push(state);
+      states.set(branch, existing);
+    }
+  }
+  return states;
+}
+
+async function fetchRepoBranchStates(
+  repoSlug: string | undefined,
+  cwd: string | undefined,
+): Promise<Array<{ branch: string; state: PrEntry["state"] }>> {
+  const args = [
+    "gh",
+    "pr",
+    "list",
+    "--state",
+    "all",
+    "--json",
+    "headRefName,state",
+    "--limit",
+    String(PR_FETCH_LIMIT),
+  ];
+  if (repoSlug) args.push("--repo", repoSlug);
+
+  const proc = Bun.spawn(args, {
+    stdout: "pipe",
+    stderr: "pipe",
+    ...(cwd ? { cwd } : {}),
+  });
+
+  const timeout = Bun.sleep(GH_TIMEOUT_MS).then(() => {
+    proc.kill();
+    return "timeout" as const;
+  });
+
+  const raceResult = await Promise.race([proc.exited, timeout]);
+  if (raceResult === "timeout" || raceResult !== 0) return [];
+
+  try {
+    const raw = JSON.parse(await new Response(proc.stdout).text()) as Array<{
+      headRefName: string;
+      state: string;
+    }>;
+    return raw.map((r) => ({
+      branch: r.headRefName,
+      state: r.state.toLowerCase() as PrEntry["state"],
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/** Periodically sweep merged worktrees. Runs independently of dashboard activity:
+ *  PRs merge while nobody is watching the dashboard, and cleanup must happen anyway. */
+export function startAutoRemoveMonitor(
+  run: () => Promise<void>,
+  intervalMs: number = 60_000,
+): () => void {
+  return startSerializedInterval(
+    () =>
+      run().catch((err: unknown) => {
+        log.error(`[auto-remove] sweep error: ${err}`);
+      }),
+    intervalMs,
+  );
+}


### PR DESCRIPTION
## Problem

`autoRemoveOnMerge` only fired opportunistically. Two coupled causes:

1. **Activity gate** — auto-remove rode the PR *display* sync, whose poll is skipped unless `hasRecentDashboardActivity()` is true (a **15s** window). With the dashboard closed, the sweep never ran.
2. **Open-only merge detection** — merge state was read from the per-worktree PR cache, which is only ever written for PRs seen while *open* (`fetchAllPrs` uses `gh pr list --state open`). A PR whose entire open→merged lifecycle happened while the dashboard was closed never got a cache entry, so `runAutoRemove` saw `prs.length === 0` and skipped it forever.

Net effect: only worktrees that happened to merge while someone was live on the dashboard got cleaned up. On one box, 24 clean, fully-merged worktrees had accumulated while a single cached entry existed across ~30 worktrees.

## Change

- **Decouple auto-remove from the display sync.** It now runs on its own ungated 60s sweep (`startAutoRemoveMonitor`) so cleanup happens even when the dashboard is closed. The display sync stays gated on dashboard activity — that data is only needed while someone is watching.
- **Make merge detection self-sufficient.** New `fetchBranchPrStates` queries `gh pr list --state all` (one call per configured repo) for authoritative per-branch states. `runAutoRemove` consumes those instead of the per-worktree cache, so a merge is detected regardless of whether any open-state sync ever ran.

Removal criteria are unchanged: a worktree is removed only when it has at least one PR, **every** PR across all repos is `merged`, and the working tree is clean.

## Tradeoffs

- Removal latency while the dashboard is open goes from ~10s to ≤60s (fine for merges).
- Adds ~1 `gh` call per configured repo per 60s per auto-remove-enabled project (well within rate limits).

## Tests

New `auto-remove-service.test.ts` pins the fixed behavior: merged→removed with no prior open-state sync, and kept when a PR is open / any cross-repo PR is unmerged / the tree is dirty / no PR exists. Full backend suite green (486 pass).