### PR TITLE
fix(tmux): force a UTF-8 locale for tmux control commands

### DIFF
--- a/backend/src/__tests__/tmux-adapter.test.ts
+++ b/backend/src/__tests__/tmux-adapter.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   buildProjectSessionName,
   buildWorktreeWindowName,
+  chooseUtf8Locale,
   parseWindowSummaries,
   pickTmuxLocale,
   sanitizeTmuxNameSegment,
@@ -179,24 +180,47 @@ describe("parseWindowSummaries", () => {
 });
 
 describe("pickTmuxLocale", () => {
-  it("pins C.UTF-8 when no locale is set", () => {
-    expect(pickTmuxLocale({})).toBe("C.UTF-8");
+  it("uses the host fallback when no locale is set", () => {
+    expect(pickTmuxLocale({}, "C.UTF-8")).toBe("C.UTF-8");
   });
 
-  it("pins C.UTF-8 when the inherited locale is not UTF-8", () => {
-    expect(pickTmuxLocale({ LANG: "C" })).toBe("C.UTF-8");
-    expect(pickTmuxLocale({ LC_ALL: "POSIX" })).toBe("C.UTF-8");
+  it("uses the host fallback when the inherited locale is not UTF-8", () => {
+    expect(pickTmuxLocale({ LANG: "C" }, "C.UTF-8")).toBe("C.UTF-8");
+    expect(pickTmuxLocale({ LC_ALL: "POSIX" }, "en_US.UTF-8")).toBe("en_US.UTF-8");
   });
 
-  it("keeps an inherited UTF-8 locale (any spelling)", () => {
-    expect(pickTmuxLocale({ LANG: "en_US.UTF-8" })).toBe("en_US.UTF-8");
-    expect(pickTmuxLocale({ LANG: "C.UTF-8" })).toBe("C.UTF-8");
-    expect(pickTmuxLocale({ LANG: "en_GB.utf8" })).toBe("en_GB.utf8");
+  it("keeps an inherited UTF-8 locale (any spelling), ignoring the fallback", () => {
+    expect(pickTmuxLocale({ LANG: "en_US.UTF-8" }, "C.UTF-8")).toBe("en_US.UTF-8");
+    expect(pickTmuxLocale({ LANG: "C.UTF-8" }, "en_US.UTF-8")).toBe("C.UTF-8");
+    expect(pickTmuxLocale({ LANG: "en_GB.utf8" }, "C.UTF-8")).toBe("en_GB.utf8");
   });
 
   it("prefers LC_ALL, then LC_CTYPE, then LANG", () => {
-    expect(pickTmuxLocale({ LC_ALL: "en_US.UTF-8", LANG: "C" })).toBe("en_US.UTF-8");
-    expect(pickTmuxLocale({ LC_CTYPE: "de_DE.UTF-8", LANG: "C" })).toBe("de_DE.UTF-8");
+    expect(pickTmuxLocale({ LC_ALL: "en_US.UTF-8", LANG: "C" }, "C.UTF-8")).toBe("en_US.UTF-8");
+    expect(pickTmuxLocale({ LC_CTYPE: "de_DE.UTF-8", LANG: "C" }, "C.UTF-8")).toBe("de_DE.UTF-8");
+  });
+});
+
+describe("chooseUtf8Locale", () => {
+  it("prefers a neutral C.UTF-8 when available (macOS spelling)", () => {
+    expect(chooseUtf8Locale(["C", "C.UTF-8", "en_US.UTF-8", "POSIX"])).toBe("C.UTF-8");
+  });
+
+  it("prefers C.utf8 (glibc spelling) and returns the exact listed name", () => {
+    expect(chooseUtf8Locale(["C", "C.utf8", "en_US.utf8"])).toBe("C.utf8");
+  });
+
+  it("falls back to en_US.UTF-8 when C.UTF-8 is absent (older macOS)", () => {
+    expect(chooseUtf8Locale(["C", "POSIX", "en_US.UTF-8", "fr_FR.UTF-8"])).toBe("en_US.UTF-8");
+  });
+
+  it("uses any UTF-8 locale when no preferred one is present", () => {
+    expect(chooseUtf8Locale(["C", "de_DE.UTF-8"])).toBe("de_DE.UTF-8");
+  });
+
+  it("last-resorts to C.UTF-8 when nothing UTF-8 is listed or the list is empty", () => {
+    expect(chooseUtf8Locale(["C", "POSIX"])).toBe("C.UTF-8");
+    expect(chooseUtf8Locale([])).toBe("C.UTF-8");
   });
 });
 

--- a/backend/src/__tests__/tmux-adapter.test.ts
+++ b/backend/src/__tests__/tmux-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   buildProjectSessionName,
   buildWorktreeWindowName,
   parseWindowSummaries,
+  pickTmuxLocale,
   sanitizeTmuxNameSegment,
 } from "../adapters/tmux";
 
@@ -174,6 +175,28 @@ describe("parseWindowSummaries", () => {
         paneCount: 3,
       },
     ]);
+  });
+});
+
+describe("pickTmuxLocale", () => {
+  it("pins C.UTF-8 when no locale is set", () => {
+    expect(pickTmuxLocale({})).toBe("C.UTF-8");
+  });
+
+  it("pins C.UTF-8 when the inherited locale is not UTF-8", () => {
+    expect(pickTmuxLocale({ LANG: "C" })).toBe("C.UTF-8");
+    expect(pickTmuxLocale({ LC_ALL: "POSIX" })).toBe("C.UTF-8");
+  });
+
+  it("keeps an inherited UTF-8 locale (any spelling)", () => {
+    expect(pickTmuxLocale({ LANG: "en_US.UTF-8" })).toBe("en_US.UTF-8");
+    expect(pickTmuxLocale({ LANG: "C.UTF-8" })).toBe("C.UTF-8");
+    expect(pickTmuxLocale({ LANG: "en_GB.utf8" })).toBe("en_GB.utf8");
+  });
+
+  it("prefers LC_ALL, then LC_CTYPE, then LANG", () => {
+    expect(pickTmuxLocale({ LC_ALL: "en_US.UTF-8", LANG: "C" })).toBe("en_US.UTF-8");
+    expect(pickTmuxLocale({ LC_CTYPE: "de_DE.UTF-8", LANG: "C" })).toBe("de_DE.UTF-8");
   });
 });
 

--- a/backend/src/adapters/tmux.ts
+++ b/backend/src/adapters/tmux.ts
@@ -43,6 +43,7 @@ export interface TmuxGateway {
 }
 
 let cachedTmuxSpawnEnv: Record<string, string> | null = null;
+let cachedUtf8Locale: string | null = null;
 let globalEnvScrubbed = false;
 
 /** Base environment for spawning tmux control commands, stripped of the launch
@@ -55,14 +56,51 @@ function tmuxSpawnEnv(): Record<string, string> {
   return (cachedTmuxSpawnEnv ??= stripProjectEnv(Bun.env));
 }
 
+/** Choose the best UTF-8 locale from a `locale -a` listing, used only when the
+ *  environment carries no UTF-8 locale of its own. Preference: a neutral
+ *  `C.UTF-8`/`C.utf8` (no locale-specific collation/messages leak into panes),
+ *  then `en_US.*`, then any UTF-8 locale the host reports. Returns the *exact*
+ *  listed name so `setlocale` accepts it. This keeps the fallback valid across
+ *  platforms — older macOS lacks `C.UTF-8` (but has `en_US.UTF-8`); minimal
+ *  Linux images often lack `en_US.UTF-8` (but glibc >= 2.35 ships `C.UTF-8`).
+ *  `C.UTF-8` is only the last-resort literal when nothing is listed. */
+export function chooseUtf8Locale(available: string[]): string {
+  const trimmed = available.map((entry) => entry.trim()).filter(Boolean);
+  const byLower = new Map(trimmed.map((entry) => [entry.toLowerCase(), entry]));
+  const preferred = ["c.utf-8", "c.utf8", "en_us.utf-8", "en_us.utf8"];
+  return (
+    preferred.map((key) => byLower.get(key)).find((entry): entry is string => Boolean(entry))
+    ?? trimmed.find((entry) => /\.utf-?8$/i.test(entry))
+    ?? "C.UTF-8"
+  );
+}
+
+/** Best UTF-8 locale actually installed on this host (from `locale -a`), cached
+ *  for the process lifetime. Falls back to a bare `C.UTF-8` if `locale(1)` can't
+ *  be run. */
+function detectUtf8Locale(): string {
+  if (cachedUtf8Locale) return cachedUtf8Locale;
+  let available: string[] = [];
+  try {
+    const result = Bun.spawnSync(["locale", "-a"], { stdout: "pipe", stderr: "pipe" });
+    if (result.exitCode === 0) {
+      available = new TextDecoder().decode(result.stdout).split("\n");
+    }
+  } catch {
+    // locale(1) unavailable — fall back to the literal in chooseUtf8Locale.
+  }
+  return (cachedUtf8Locale = chooseUtf8Locale(available));
+}
+
 /** Pick a UTF-8 locale for tmux. Under a non-UTF-8 locale — e.g. a macOS launchd
  *  agent that inherits no `LANG`/`LC_*` — tmux rewrites the TAB byte in `-F`
  *  output as `_`, which silently breaks webmux's tab-delimited parsing of
  *  `list-windows` (every window drops, so every session looks closed). Keep a
- *  UTF-8 locale the environment already provides; otherwise pin `C.UTF-8`. */
-export function pickTmuxLocale(env: Record<string, string | undefined>): string {
+ *  UTF-8 locale the environment already provides; otherwise use `fallback` (a
+ *  UTF-8 locale detected on the host). */
+export function pickTmuxLocale(env: Record<string, string | undefined>, fallback: string): string {
   const inherited = env.LC_ALL || env.LC_CTYPE || env.LANG || "";
-  return /utf-?8/i.test(inherited) ? inherited : "C.UTF-8";
+  return /utf-?8/i.test(inherited) ? inherited : fallback;
 }
 
 function runTmux(args: string[]): { stdout: string; stderr: string; exitCode: number } {
@@ -73,7 +111,7 @@ function runTmux(args: string[]): { stdout: string; stderr: string; exitCode: nu
   const result = Bun.spawnSync(["tmux", ...args], {
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...base, LC_ALL: pickTmuxLocale(base) },
+    env: { ...base, LC_ALL: pickTmuxLocale(base, detectUtf8Locale()) },
   });
 
   return {

--- a/backend/src/adapters/tmux.ts
+++ b/backend/src/adapters/tmux.ts
@@ -42,31 +42,38 @@ export interface TmuxGateway {
   killPane(target: string): void;
 }
 
-let cachedTmuxSpawnEnv: { value: Record<string, string> | undefined } | null = null;
+let cachedTmuxSpawnEnv: Record<string, string> | null = null;
 let globalEnvScrubbed = false;
 
-/** Environment for spawning tmux control commands, stripped of the launch
+/** Base environment for spawning tmux control commands, stripped of the launch
  *  project's `.env` keys (see {@link stripProjectEnv}). Whichever tmux command
  *  first starts the server fixes the global environment for the server's
- *  lifetime, so every tmux invocation must use the stripped env. Returns
- *  `undefined` (inherit the process env unchanged) on the common path where no
- *  project keys were loaded, so tmux spawns don't copy the whole env for
- *  nothing. */
-function tmuxSpawnEnv(): Record<string, string> | undefined {
-  if (cachedTmuxSpawnEnv) return cachedTmuxSpawnEnv.value;
-  const value = Bun.env.WEBMUX_PROJECT_ENV_KEYS ? stripProjectEnv(Bun.env) : undefined;
-  cachedTmuxSpawnEnv = { value };
-  return value;
+ *  lifetime, so every tmux invocation must use the stripped env. Cached — the
+ *  leaked keys are fixed at launch. When no project keys were loaded this is the
+ *  full parent env (nothing to strip). */
+function tmuxSpawnEnv(): Record<string, string> {
+  return (cachedTmuxSpawnEnv ??= stripProjectEnv(Bun.env));
+}
+
+/** Pick a UTF-8 locale for tmux. Under a non-UTF-8 locale — e.g. a macOS launchd
+ *  agent that inherits no `LANG`/`LC_*` — tmux rewrites the TAB byte in `-F`
+ *  output as `_`, which silently breaks webmux's tab-delimited parsing of
+ *  `list-windows` (every window drops, so every session looks closed). Keep a
+ *  UTF-8 locale the environment already provides; otherwise pin `C.UTF-8`. */
+export function pickTmuxLocale(env: Record<string, string | undefined>): string {
+  const inherited = env.LC_ALL || env.LC_CTYPE || env.LANG || "";
+  return /utf-?8/i.test(inherited) ? inherited : "C.UTF-8";
 }
 
 function runTmux(args: string[]): { stdout: string; stderr: string; exitCode: number } {
-  // Only pass `env` when we have a stripped copy: Bun.spawnSync treats an
-  // explicit `env: undefined` as an *empty* environment, not "inherit".
-  const spawnEnv = tmuxSpawnEnv();
+  // Pass an explicit env — Bun.spawnSync treats it as the *complete* child
+  // environment, not a merge — built from the project-stripped parent env, and
+  // pin a UTF-8 locale so tmux keeps the TAB separator in `-F` output.
+  const base = tmuxSpawnEnv();
   const result = Bun.spawnSync(["tmux", ...args], {
     stdout: "pipe",
     stderr: "pipe",
-    ...(spawnEnv ? { env: spawnEnv } : {}),
+    env: { ...base, LC_ALL: pickTmuxLocale(base) },
   });
 
   return {


### PR DESCRIPTION
## Problem

When webmux runs from an environment with an empty/non-UTF-8 locale — most commonly a **macOS launchd agent that inherits no `LANG`/`LC_*`** — the dashboard shows every worktree as `closed` and only ever offers **Open Session**; the terminal never renders, even though the tmux window exists and the agent is running. The same webmux run from a shell works fine.

## Root cause

Under a non-UTF-8 locale, tmux **rewrites the TAB byte in `-F` format output as `_`**:

```
tmux list-windows -a -F "#{session_name}\t#{window_name}\t#{window_panes}"
# UTF-8 locale (shell):     "wm-proj-ab12\twm-main\t2"   ← real tabs
# C/POSIX locale (launchd): "wm-proj-ab12_wm-main_2"     ← underscores
```

`parseWindowSummaries()` splits each line on `\t`, gets a single field, drops every row → `listWindows()` returns `[]` → `ReconciliationService` marks every session `exists: false` → snapshot reports `closed`. Verified byte-for-byte with the same binary: shell run (UTF-8 `LANG`) emits `0x09`; launchd run (`LANG` unset) emits `0x5f` (`_`). Setting a UTF-8 locale flips it back.

(Why launchd has no `LANG`: macOS stores locale as a preference — `AppleLocale` — read by Cocoa apps via `NSLocale`, and only exports `LANG` in interactive login shells / Terminal. A LaunchAgent runs no login shell and has no terminal, so it inherits none.)

## Fix

`runTmux` now builds the tmux spawn env explicitly (Bun.spawnSync **replaces** the env, it doesn't merge) and pins `LC_ALL` to a UTF-8 locale, so tmux keeps the tab separator regardless of how the server was launched. This hardens every tab-delimited tmux parse, not just `listWindows`.

The fallback locale is **detected from the host** rather than hardcoded, because no single literal is universally safe:

- older macOS lacks `C.UTF-8` (but ships `en_US.UTF-8`)
- minimal Linux images often lack `en_US.UTF-8` (but glibc >= 2.35 ships `C.UTF-8`)

`chooseUtf8Locale()` reads `locale -a` and picks a UTF-8 locale the host actually reports — neutral `C.UTF-8`/`C.utf8` first, then `en_US.*`, then any `.UTF-8` — returning the **exact listed name** so `setlocale` accepts it verbatim across glibc (`C.utf8`) and macOS (`en_US.UTF-8`) spellings. The fallback only fires when the environment carries no UTF-8 locale, so the common path (incl. a normal Linux box with `LANG` set) is unchanged.

Locale selection is split into pure, unit-tested functions (`pickTmuxLocale`, `chooseUtf8Locale`); the I/O boundaries (`detectUtf8Locale`, `runTmux`) stay thin.

## Testing

- `bun test src/__tests__/tmux-adapter.test.ts` — 20 pass (`pickTmuxLocale` precedence/pass-through + `chooseUtf8Locale` across glibc/macOS spellings, the older-macOS `en_US` fallback, and empty-list last-resort)
- `tsc --noEmit` clean
- Reproduced under a real macOS launchd agent: **before** → `mux:false` (tmux emits `_` separators); **after** (this change, no plist `LANG`, pure host detection) → `mux:true`, terminal renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)