### PR TITLE
feat: load global config env from ~/.config/webmux/.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,16 @@ Each issue is processed once while it stays in Todo + labeled. Remove the label 
 
 When the auto-create watcher picks up a `webmux_oneshot` issue, it posts a structured comment on the Linear issue (prefix `` **Webmux pickup — branch `<branch>`** ``) so external automation can track when the autonomous run starts. (Regular `webmux` pickups are user-driven and skip the comment.)
 
-**Setup — `LINEAR_API_KEY`.** Everything above needs a [Linear API key](https://linear.app/settings/account/security) in the server's environment. Because webmux runs as a single machine-wide service (started from your home directory, not any one repo), provide the key in one of these ways — the first one found wins:
+**Setup — `LINEAR_API_KEY`.** Everything above needs a [Linear API key](https://linear.app/settings/account/security) in the server's environment. webmux runs as a single machine-wide service started from your home directory, so put the key in `~/.config/webmux/.env` — a `KEY=value` file the server loads at startup regardless of which directory it runs from, so it survives `webmux update`:
 
-1. **`~/.config/webmux/.env`** *(recommended)* — a simple `KEY=value` file the server loads at startup no matter which directory it runs from, so the key survives `webmux update` without touching the service unit:
-   ```bash
-   mkdir -p ~/.config/webmux
-   echo 'LINEAR_API_KEY=lin_api_...' >> ~/.config/webmux/.env
-   chmod 600 ~/.config/webmux/.env
-   systemctl --user restart webmux    # macOS: launchctl kickstart -k gui/$UID/com.webmux.webmux
-   ```
-2. **Baked into the service unit** — `webmux service install` auto-picks up `LINEAR_API_KEY` from your shell, or pass it explicitly with `webmux service install --env LINEAR_API_KEY=lin_api_...`. Re-run after rotating the key.
-3. **A project `.env` / `.env.local`** in the directory you launch `webmux serve` from — loaded at startup, and overrides the global file above for that session. Handy for a foreground `webmux serve`, but not read by the background service (which runs from `$HOME`).
+```bash
+mkdir -p ~/.config/webmux
+echo 'LINEAR_API_KEY=lin_api_...' >> ~/.config/webmux/.env
+chmod 600 ~/.config/webmux/.env
+webmux service restart
+```
 
-If issues don't appear, confirm the running service actually sees the key — `systemctl --user show webmux -p Environment` (baked-in case) — or that `~/.config/webmux/.env` exists and the service was restarted after you wrote it.
+Your assigned issues appear in the dashboard once the service restarts.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ Each issue is processed once while it stays in Todo + labeled. Remove the label 
 
 When the auto-create watcher picks up a `webmux_oneshot` issue, it posts a structured comment on the Linear issue (prefix `` **Webmux pickup — branch `<branch>`** ``) so external automation can track when the autonomous run starts. (Regular `webmux` pickups are user-driven and skip the comment.)
 
+**Setup — `LINEAR_API_KEY`.** Everything above needs a [Linear API key](https://linear.app/settings/account/security) in the server's environment. Because webmux runs as a single machine-wide service (started from your home directory, not any one repo), provide the key in one of these ways — the first one found wins:
+
+1. **`~/.config/webmux/.env`** *(recommended)* — a simple `KEY=value` file the server loads at startup no matter which directory it runs from, so the key survives `webmux update` without touching the service unit:
+   ```bash
+   mkdir -p ~/.config/webmux
+   echo 'LINEAR_API_KEY=lin_api_...' >> ~/.config/webmux/.env
+   chmod 600 ~/.config/webmux/.env
+   systemctl --user restart webmux    # macOS: launchctl kickstart -k gui/$UID/com.webmux.webmux
+   ```
+2. **Baked into the service unit** — `webmux service install` auto-picks up `LINEAR_API_KEY` from your shell, or pass it explicitly with `webmux service install --env LINEAR_API_KEY=lin_api_...`. Re-run after rotating the key.
+3. **A project `.env` / `.env.local`** in the directory you launch `webmux serve` from — loaded at startup, and overrides the global file above for that session. Handy for a foreground `webmux serve`, but not read by the background service (which runs from `$HOME`).
+
+If issues don't appear, confirm the running service actually sees the key — `systemctl --user show webmux -p Environment` (baked-in case) — or that `~/.config/webmux/.env` exists and the service was restarted after you wrote it.
+
 ## Quick Start
 
 ```bash

--- a/backend/src/__tests__/webmux-paths.test.ts
+++ b/backend/src/__tests__/webmux-paths.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { webmuxConfigDir, webmuxConfigEnvPath } from "../adapters/webmux-paths";
+
+const originalHome = Bun.env.HOME;
+
+afterEach(() => {
+  if (originalHome === undefined) delete Bun.env.HOME;
+  else Bun.env.HOME = originalHome;
+});
+
+describe("webmuxConfigDir", () => {
+  it("resolves the XDG config dir under $HOME", () => {
+    Bun.env.HOME = "/home/alice";
+    expect(webmuxConfigDir()).toBe("/home/alice/.config/webmux");
+  });
+
+  it("falls back to /root when HOME is unset", () => {
+    delete Bun.env.HOME;
+    expect(webmuxConfigDir()).toBe("/root/.config/webmux");
+  });
+});
+
+describe("webmuxConfigEnvPath", () => {
+  it("points at .env inside the config dir", () => {
+    Bun.env.HOME = "/home/alice";
+    expect(webmuxConfigEnvPath()).toBe("/home/alice/.config/webmux/.env");
+  });
+});

--- a/backend/src/adapters/control-token.ts
+++ b/backend/src/adapters/control-token.ts
@@ -1,7 +1,8 @@
 import { chmod, mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
+import { webmuxConfigDir } from "./webmux-paths";
 
-const CONTROL_TOKEN_PATH = `${Bun.env.HOME ?? "/root"}/.config/webmux/control-token`;
+const CONTROL_TOKEN_PATH = join(webmuxConfigDir(), "control-token");
 
 let cachedToken: string | null = null;
 

--- a/backend/src/adapters/webmux-paths.ts
+++ b/backend/src/adapters/webmux-paths.ts
@@ -1,0 +1,16 @@
+import { join } from "node:path";
+
+/** webmux's XDG-style config directory (`~/.config/webmux`). Home to the
+ *  control token and the optional global env file. Distinct from the
+ *  `~/.webmux` runtime-state dir (projects registry, live-instance registry),
+ *  which holds transient state rather than user config. */
+export function webmuxConfigDir(): string {
+  return join(Bun.env.HOME ?? "/root", ".config", "webmux");
+}
+
+/** Optional global env file webmux reads at server startup for machine-wide
+ *  secrets (e.g. `LINEAR_API_KEY`). Loaded after the launch project's `.env`
+ *  so a project can still override a machine-wide default. */
+export function webmuxConfigEnvPath(): string {
+  return join(webmuxConfigDir(), ".env");
+}

--- a/bin/src/service.test.ts
+++ b/bin/src/service.test.ts
@@ -6,6 +6,7 @@ import {
   parseInstalledServiceConfig,
   readEnvVarsFromUnit,
   readPortFromUnit,
+  restartCommands,
   resolveConfirmDecision,
   resolveEnvVars,
   shouldPersistProject,
@@ -56,6 +57,29 @@ describe("resolveConfirmDecision", () => {
 
   it("bails in a non-interactive shell without --yes", () => {
     expect(resolveConfirmDecision(false, false)).toBe("abort-noninteractive");
+  });
+});
+
+describe("restartCommands", () => {
+  const base: ServiceConfig = {
+    platform: "linux",
+    serviceName: "webmux",
+    webmuxPath: "/usr/bin/webmux",
+    port: 5111,
+    envVars: {},
+  };
+
+  it("restarts the user unit on linux", () => {
+    expect(restartCommands(base)).toEqual([
+      ["systemctl", ["--user", "restart", "webmux"]],
+    ]);
+  });
+
+  it("kickstarts the labeled agent on darwin", () => {
+    const [[bin, args]] = restartCommands({ ...base, platform: "darwin" });
+    expect(bin).toBe("launchctl");
+    expect(args.slice(0, 2)).toEqual(["kickstart", "-k"]);
+    expect(args[2]).toMatch(/^gui\/\d+\/com\.webmux\.webmux$/);
   });
 });
 

--- a/bin/src/service.ts
+++ b/bin/src/service.ts
@@ -721,6 +721,10 @@ Options:
 
   When any env var is set, the unit file is written with mode 0600 so
   secrets are readable only by the installing user.
+
+  Alternatively, put machine-wide secrets (e.g. LINEAR_API_KEY) in
+  ~/.config/webmux/.env — the server loads it at startup regardless of which
+  directory it runs from, so they survive updates without re-baking the unit.
 `);
 }
 

--- a/bin/src/service.ts
+++ b/bin/src/service.ts
@@ -339,6 +339,14 @@ function uninstallCommands(config: ServiceConfig): Command[] {
   ];
 }
 
+export function restartCommands(config: ServiceConfig): Command[] {
+  if (config.platform === "linux") {
+    return [["systemctl", ["--user", "restart", config.serviceName]]];
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  return [["launchctl", ["kickstart", "-k", `gui/${uid}/com.webmux.${config.serviceName}`]]];
+}
+
 // ── Check if service exists ─────────────────────────────────────────────────
 
 function isInstalled(config: ServiceConfig): boolean {
@@ -650,6 +658,22 @@ async function uninstall(config: ServiceConfig): Promise<void> {
   p.log.success("Service uninstalled.");
 }
 
+function restart(config: ServiceConfig): void {
+  if (!isInstalled(config)) {
+    p.log.error("Service is not installed.");
+    return;
+  }
+
+  for (const cmd of restartCommands(config)) {
+    const result = runCommand(cmd);
+    if (!result.success) {
+      p.log.error(`Command failed: ${formatCommand(cmd)}\n${result.stderr.toString()}`);
+      return;
+    }
+  }
+  p.log.success("Service restarted.");
+}
+
 function status(config: ServiceConfig): void {
   if (!isInstalled(config)) {
     p.log.error("Service is not installed.");
@@ -702,6 +726,7 @@ add more projects from the dashboard or with \`webmux project add\`.
 Usage:
   webmux service install     Install, enable, and start the service
   webmux service uninstall   Stop, disable, and remove the service
+  webmux service restart     Restart the service (e.g. to reload config env)
   webmux service status      Show service status
   webmux service logs        Tail service logs
 
@@ -736,7 +761,7 @@ export default async function service(args: string[]): Promise<void> {
     return;
   }
 
-  if (!["install", "uninstall", "status", "logs"].includes(action)) {
+  if (!["install", "uninstall", "restart", "status", "logs"].includes(action)) {
     p.log.error(`Unknown action: ${action}`);
     usage();
     return;
@@ -827,6 +852,9 @@ export default async function service(args: string[]): Promise<void> {
       break;
     case "uninstall":
       await uninstall(config);
+      break;
+    case "restart":
+      restart(config);
       break;
     case "status":
       status(config);

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -350,6 +350,15 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
   for (const key of await loadEnvFile(resolve(process.cwd(), ".env.local"))) projectEnvKeys.add(key);
   for (const key of await loadEnvFile(resolve(process.cwd(), ".env"))) projectEnvKeys.add(key);
 
+  // webmux's own global config env (`~/.config/webmux/.env`): machine-wide
+  // secrets like LINEAR_API_KEY the single service reads regardless of which
+  // directory it runs from. Loaded last so an already-set value wins — the unit
+  // and the launch project's `.env` both take precedence. Its keys join
+  // projectEnvKeys so they're stripped from the tmux global environment like any
+  // other secret webmux loads, rather than leaking into every session and pane.
+  const { webmuxConfigEnvPath } = await import("../../backend/src/adapters/webmux-paths");
+  for (const key of await loadEnvFile(webmuxConfigEnvPath())) projectEnvKeys.add(key);
+
   // When the user didn't pin a port, point CLI commands at the live server for
   // this project rather than the 5111 default. `webmux serve` walks to a free
   // port when 5111 is taken, so the running instance is often elsewhere (e.g.

--- a/bin/src/webmux.ts
+++ b/bin/src/webmux.ts
@@ -5,6 +5,7 @@ import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { Subprocess } from "bun";
 import pkg from "../../package.json";
+import { webmuxConfigEnvPath } from "../../backend/src/adapters/webmux-paths";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -356,7 +357,6 @@ async function main(args: string[] = process.argv.slice(2)): Promise<void> {
   // and the launch project's `.env` both take precedence. Its keys join
   // projectEnvKeys so they're stripped from the tmux global environment like any
   // other secret webmux loads, rather than leaking into every session and pane.
-  const { webmuxConfigEnvPath } = await import("../../backend/src/adapters/webmux-paths");
   for (const key of await loadEnvFile(webmuxConfigEnvPath())) projectEnvKeys.add(key);
 
   // When the user didn't pin a port, point CLI commands at the live server for


### PR DESCRIPTION
## Summary

The machine-wide webmux service runs from `$HOME` (the single-dashboard template pins `WorkingDirectory=$HOME`), so the only env it sees is what's baked into the service unit — a repo's `.env.local` in a *different* directory (e.g. `LINEAR_API_KEY` in a sibling project) is never read at runtime. After `webmux update` regenerates a unit that previously ran from a project directory, Linear integration silently stops working because the key is no longer on the service's path.

This adds a global config env file, `~/.config/webmux/.env`, that `webmux serve` loads at startup regardless of which directory it runs from, plus a `webmux service restart` command so reloading it doesn't require dropping to `systemctl`/`launchctl`.

## Changes

- **`backend/src/adapters/webmux-paths.ts`** (new) — shared `webmuxConfigDir()` / `webmuxConfigEnvPath()` helpers so the `~/.config/webmux` path isn't hardcoded in multiple places.
- **`backend/src/adapters/control-token.ts`** — use the shared helper instead of its own inline `~/.config/webmux` string (DRY).
- **`bin/src/webmux.ts`** — load `~/.config/webmux/.env` after the launch project's `.env` (precedence: unit-baked env > project `.env(.local)` > global config file). Its keys join `projectEnvKeys` so they're stripped from the tmux global environment like every other secret webmux loads.
- **`bin/src/service.ts`** — new `webmux service restart` command (`restartCommands` builder + wrapper, usage/dispatch), and the install help points at the config file.
- **`README.md`** — new "Setup — `LINEAR_API_KEY`" subsection under Linear Integration documenting the single recommended method (`~/.config/webmux/.env` + `webmux service restart`).
- **Tests** — `backend/src/__tests__/webmux-paths.test.ts` (path helpers) and `restartCommands` cases in `bin/src/service.test.ts`.

## Test plan

- [ ] `bun test backend bin` — all green
- [ ] Write `LINEAR_API_KEY=...` to `~/.config/webmux/.env`, run `webmux service restart`, confirm assigned Linear issues appear in the dashboard
- [ ] Confirm a project `.env.local` in the `webmux serve` launch dir still overrides the global file for that session
- [ ] `webmux service restart` works on both systemd (Linux) and launchd (macOS)
- [ ] `control-token` still reads/writes at `~/.config/webmux/control-token`

---
Generated with [Claude Code](https://claude.com/claude-code)