### PR TITLE
feat: merge project name and switcher chevron into one button

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1149,9 +1149,8 @@
     >
       <div class="p-4 border-b border-edge">
         <div class="flex items-center justify-between">
-          <div class="flex items-center gap-1 min-w-0">
-            <h1 class="text-base font-semibold truncate">{config.name ?? "Dashboard"}</h1>
-            <ProjectSwitcher current={activePrefix} />
+          <div class="flex items-center min-w-0">
+            <ProjectSwitcher current={activePrefix} label={config.name ?? "Dashboard"} />
           </div>
           <div class="flex items-center gap-2">
             <button

--- a/frontend/src/lib/ProjectSwitcher.svelte
+++ b/frontend/src/lib/ProjectSwitcher.svelte
@@ -4,7 +4,7 @@
   import { projectInitPhaseLabel } from "./utils";
   import type { ProjectInitPhase, ProjectSummary } from "./types";
 
-  let { current }: { current: string } = $props();
+  let { current, label }: { current: string; label: string } = $props();
 
   let projects = $state<ProjectSummary[]>([]);
   let open = $state(false);
@@ -103,19 +103,22 @@
 
 <svelte:window onclick={handleDocumentClick} onkeydown={handleKeydown} onresize={() => open && positionMenu()} onscroll={() => open && positionMenu()} />
 
-<button
-  bind:this={triggerEl}
-  type="button"
-  class="shrink-0 h-6 w-6 inline-flex items-center justify-center rounded-md text-muted hover:bg-hover hover:text-primary"
-  title="Switch project"
-  aria-haspopup="menu"
-  aria-expanded={open}
-  onclick={toggle}
->
-  <svg viewBox="0 0 12 12" width="10" height="10" aria-hidden="true">
-    <path d="M2 4 L6 8 L10 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-  </svg>
-</button>
+<h1 class="min-w-0">
+  <button
+    bind:this={triggerEl}
+    type="button"
+    class="max-w-full min-w-0 h-7 px-1.5 -ml-1.5 inline-flex items-center gap-1 rounded-md hover:bg-hover"
+    title="Switch project"
+    aria-haspopup="menu"
+    aria-expanded={open}
+    onclick={toggle}
+  >
+    <span class="text-base font-semibold text-primary truncate">{label}</span>
+    <svg viewBox="0 0 12 12" width="10" height="10" aria-hidden="true" class="shrink-0 text-muted">
+      <path d="M2 4 L6 8 L10 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  </button>
+</h1>
 
 {#if open}
   <div


### PR DESCRIPTION
## Summary
The sidebar header previously showed the project name as a static heading with a separate tiny chevron button to open the project switcher. This merges them into a single button: clicking the project name (or the chevron) opens the switcher menu, giving a larger hit target and a cleaner header.

## Changes
- `frontend/src/lib/ProjectSwitcher.svelte`: trigger now takes a `label` prop and renders the project name + chevron inside one button, wrapped in the `<h1>` for heading semantics; label truncates and the chevron stays visible.
- `frontend/src/App.svelte`: removed the standalone `<h1>` and passes `config.name ?? "Dashboard"` as the switcher label.

## Test plan
- [x] `bun run check` in `frontend` — 0 errors, 0 warnings
- [ ] Click the project name in the sidebar header — switcher menu opens, positioned under the button
- [ ] Long project names truncate without pushing the chevron out of view

---
Generated with [Claude Code](https://claude.com/claude-code)